### PR TITLE
feat: add recipe/provisioning system for VM and tenant deployment

### DIFF
--- a/examples/recipe_example.py
+++ b/examples/recipe_example.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Example: VM Recipe provisioning with pyvergeos.
+
+This example demonstrates VM recipe operations including:
+- Listing available recipes from the Marketplace
+- Viewing recipe configuration (sections and questions)
+- Deploying a VM from a recipe
+- Managing recipe instances
+- Working with recipe logs
+
+VM recipes are templates for deploying virtual machines with standardized
+configurations. They use a "golden image" base VM and allow customization
+via questions that collect user input during deployment.
+
+Key Concepts:
+    - Repository: Collection of catalogs (e.g., "Marketplace", "Local")
+    - Catalog: Container for recipes (e.g., "Operating Systems", "Applications")
+    - Recipe: Template with base VM and configurable questions
+    - Instance: A deployed VM linked to its source recipe
+"""
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+
+
+def list_recipes() -> None:
+    """List available VM recipes."""
+    print("=== List VM Recipes ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # List all downloaded recipes (ready to use)
+        recipes = client.vm_recipes.list(downloaded=True)
+        print(f"Found {len(recipes)} downloaded recipes:")
+
+        for recipe in recipes[:10]:
+            status = recipe.status_info or "Unknown"
+            instances = recipe.instance_count
+            print(f"  - {recipe.name}")
+            print(f"    Version: {recipe.version}")
+            print(f"    Status: {status}")
+            print(f"    Instances: {instances}")
+            print(f"    Key: {recipe.key[:16]}...")
+            print()
+
+
+def view_recipe_configuration() -> None:
+    """View the configuration options for a recipe."""
+    print("\n=== Recipe Configuration ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Get a specific recipe by name
+        try:
+            recipe = client.vm_recipes.get(name="Ubuntu Server 22.04")
+        except NotFoundError:
+            # Fallback to first available recipe
+            recipes = client.vm_recipes.list(downloaded=True, limit=1)
+            if not recipes:
+                print("No downloaded recipes available")
+                return
+            recipe = recipes[0]
+
+        print(f"Recipe: {recipe.name}")
+        print(f"Version: {recipe.version}")
+        print(f"Description: {recipe.get('description', 'No description')}")
+        print()
+
+        # Build the recipe reference for querying questions/sections
+        recipe_ref = f"vm_recipes/{recipe.key}"
+
+        # List sections (groups of questions)
+        sections = client.recipe_sections.list(recipe_ref=recipe_ref)
+        print(f"Sections ({len(sections)}):")
+        for section in sections:
+            print(f"  - {section.name}")
+
+        print()
+
+        # List questions (configuration options)
+        questions = client.recipe_questions.list(
+            recipe_ref=recipe_ref,
+            enabled=True,  # Only show enabled questions
+        )
+        print(f"Questions ({len(questions)}):")
+        for q in questions:
+            section_name = q.get("section_name", "Unknown")
+            q_type = q.question_type or "unknown"
+            display = q.get("display", q.name)
+            default = q.get("default", "")
+            required = "required" if q.is_required else "optional"
+
+            print(f"  [{section_name}] {q.name}")
+            print(f"    Type: {q_type}, {required}")
+            print(f"    Display: {display}")
+            if default:
+                print(f"    Default: {default}")
+            print()
+
+
+def deploy_recipe() -> None:
+    """Deploy a VM from a recipe.
+
+    This example shows how to provision a VM using a recipe template.
+    The recipe collects answers to questions and creates a customized VM.
+    """
+    print("\n=== Deploy VM from Recipe ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Get the recipe
+        try:
+            recipe = client.vm_recipes.get(name="Ubuntu Server 22.04")
+        except NotFoundError:
+            print("Recipe 'Ubuntu Server 22.04' not found")
+            return
+
+        # First, let's see what questions need answers
+        recipe_ref = f"vm_recipes/{recipe.key}"
+        questions = client.recipe_questions.list(
+            recipe_ref=recipe_ref,
+            enabled=True,
+        )
+
+        print(f"Deploying: {recipe.name}")
+        print("Required questions:")
+        for q in questions:
+            if q.is_required:
+                print(f"  - {q.name}: {q.get('display', q.name)}")
+
+        # Prepare answers based on common recipe question names
+        # These are typical YB_* variables used by VergeOS recipes
+        answers = {
+            "YB_CPU_CORES": 2,
+            "YB_RAM": 4096,  # 4GB in MB
+            "YB_HOSTNAME": "my-ubuntu-server",
+            "YB_IP_ADDR_TYPE": "dhcp",
+            "YB_USER": "ubuntu",
+            "YB_PASSWORD": "secure-password-here",
+        }
+
+        print(f"\nDeploying with answers: {list(answers.keys())}")
+
+        # Deploy the recipe (creates a VM instance)
+        # NOTE: Uncomment to actually deploy
+        # instance = recipe.deploy(
+        #     name="my-ubuntu-server",
+        #     answers=answers,
+        #     auto_update=False,  # Don't auto-update when recipe updates
+        # )
+        # print(f"Created instance: {instance.name}")
+        # print(f"VM Key: {instance.vm_key}")
+
+        print("\n(Deployment commented out - uncomment to run)")
+
+
+def list_recipe_instances() -> None:
+    """List VM instances created from recipes."""
+    print("\n=== Recipe Instances ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # List all recipe instances
+        instances = client.vm_recipe_instances.list()
+        print(f"Found {len(instances)} recipe instances:")
+
+        for inst in instances:
+            recipe_name = inst.get("recipe_name", "Unknown")
+            vm_name = inst.get("vm_name", inst.name)
+            version = inst.get("version", "?")
+            auto_update = "Yes" if inst.is_auto_update else "No"
+
+            print(f"  - {vm_name}")
+            print(f"    Recipe: {recipe_name} v{version}")
+            print(f"    Auto-update: {auto_update}")
+            print(f"    VM Key: {inst.vm_key}")
+            print()
+
+
+def recipe_scoped_operations() -> None:
+    """Demonstrate scoped operations on a specific recipe.
+
+    You can get instances and logs scoped to a specific recipe,
+    making it easy to manage deployments from that recipe.
+    """
+    print("\n=== Recipe-Scoped Operations ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Get a recipe
+        recipes = client.vm_recipes.list(downloaded=True, limit=1)
+        if not recipes:
+            print("No recipes available")
+            return
+
+        recipe = recipes[0]
+        print(f"Working with recipe: {recipe.name}")
+
+        # Get instances for this recipe (using the scoped manager)
+        instances = recipe.instances.list()
+        print(f"\nInstances deployed from this recipe: {len(instances)}")
+        for inst in instances:
+            print(f"  - {inst.name} (VM #{inst.vm_key})")
+
+        # Get logs for this recipe
+        logs = recipe.logs.list(limit=5)
+        print(f"\nRecent logs ({len(logs)}):")
+        for log in logs:
+            level = log.get("level", "info")
+            text = log.get("text", "")[:80]
+            print(f"  [{level}] {text}")
+
+        # Check for errors
+        errors = recipe.logs.list_errors(limit=3)
+        if errors:
+            print(f"\nRecent errors ({len(errors)}):")
+            for err in errors:
+                print(f"  - {err.get('text', '')[:80]}")
+
+
+def download_recipe() -> None:
+    """Download a recipe from the Marketplace.
+
+    Recipes from remote repositories (like the Marketplace) must be
+    downloaded before they can be used to deploy VMs.
+    """
+    print("\n=== Download Recipe ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Find a recipe that hasn't been downloaded yet
+        not_downloaded = client.vm_recipes.list(downloaded=False, limit=5)
+
+        if not not_downloaded:
+            print("All available recipes are already downloaded")
+            return
+
+        print(f"Found {len(not_downloaded)} recipes not yet downloaded:")
+        for recipe in not_downloaded:
+            print(f"  - {recipe.name}")
+
+        # Download the first one
+        recipe = not_downloaded[0]
+        print(f"\nDownloading: {recipe.name}...")
+
+        # NOTE: Uncomment to actually download
+        # result = recipe.download()
+        # print(f"Download initiated: {result}")
+        #
+        # # Wait for download to complete and refresh
+        # import time
+        # time.sleep(5)
+        # recipe = recipe.refresh()
+        # print(f"Downloaded: {recipe.is_downloaded}")
+
+        print("(Download commented out - uncomment to run)")
+
+
+if __name__ == "__main__":
+    print("pyvergeos VM Recipe Examples")
+    print("=" * 40)
+    print()
+    print("NOTE: Update host/credentials in this file before running.")
+    print()
+
+    # Uncomment the examples you want to run:
+    # list_recipes()
+    # view_recipe_configuration()
+    # deploy_recipe()
+    # list_recipe_instances()
+    # recipe_scoped_operations()
+    # download_recipe()
+
+    print("See the code for examples of:")
+    print("  - Listing available recipes")
+    print("  - Viewing recipe configuration (sections/questions)")
+    print("  - Deploying a VM from a recipe")
+    print("  - Managing recipe instances")
+    print("  - Working with recipe logs")
+    print("  - Downloading recipes from Marketplace")

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
     from pyvergeos.resources.networks import NetworkManager
     from pyvergeos.resources.nodes import NodeManager
     from pyvergeos.resources.permissions import PermissionManager
+    from pyvergeos.resources.recipe_common import (
+        RecipeQuestionManager,
+        RecipeSectionManager,
+    )
     from pyvergeos.resources.resource_groups import ResourceGroupManager
     from pyvergeos.resources.shared_objects import SharedObjectManager
     from pyvergeos.resources.site_syncs import (
@@ -54,8 +58,18 @@ if TYPE_CHECKING:
     from pyvergeos.resources.tags import TagCategoryManager, TagManager
     from pyvergeos.resources.tasks import TaskManager
     from pyvergeos.resources.tenant_manager import TenantManager
+    from pyvergeos.resources.tenant_recipes import (
+        TenantRecipeInstanceManager,
+        TenantRecipeLogManager,
+        TenantRecipeManager,
+    )
     from pyvergeos.resources.users import UserManager
     from pyvergeos.resources.vm_imports import VmImportLogManager, VmImportManager
+    from pyvergeos.resources.vm_recipes import (
+        VmRecipeInstanceManager,
+        VmRecipeLogManager,
+        VmRecipeManager,
+    )
     from pyvergeos.resources.vms import VMManager
     from pyvergeos.resources.volume_vm_exports import (
         VolumeVmExportManager,
@@ -163,6 +177,14 @@ class VergeClient:
         self._vm_import_logs: VmImportLogManager | None = None
         self._volume_vm_exports: VolumeVmExportManager | None = None
         self._volume_vm_export_stats: VolumeVmExportStatManager | None = None
+        self._vm_recipes: VmRecipeManager | None = None
+        self._vm_recipe_instances: VmRecipeInstanceManager | None = None
+        self._vm_recipe_logs: VmRecipeLogManager | None = None
+        self._tenant_recipes: TenantRecipeManager | None = None
+        self._tenant_recipe_instances: TenantRecipeInstanceManager | None = None
+        self._tenant_recipe_logs: TenantRecipeLogManager | None = None
+        self._recipe_questions: RecipeQuestionManager | None = None
+        self._recipe_sections: RecipeSectionManager | None = None
 
         if auto_connect:
             self.connect()
@@ -913,3 +935,174 @@ class VergeClient:
 
             self._volume_vm_export_stats = VolumeVmExportStatManager(self)
         return self._volume_vm_export_stats
+
+    @property
+    def vm_recipes(self) -> VmRecipeManager:
+        """Access VM recipe operations for automated VM provisioning.
+
+        VM recipes are templates that can be deployed to create new VMs
+        with pre-configured settings and software.
+
+        Example:
+            >>> # List all VM recipes
+            >>> for recipe in client.vm_recipes.list():
+            ...     print(f"{recipe.name}: {recipe.version}")
+
+            >>> # Get a specific recipe
+            >>> recipe = client.vm_recipes.get(name="Ubuntu Server")
+
+            >>> # Deploy a recipe
+            >>> instance = recipe.deploy("my-ubuntu", answers={"ram": 4096})
+        """
+        if self._vm_recipes is None:
+            from pyvergeos.resources.vm_recipes import VmRecipeManager
+
+            self._vm_recipes = VmRecipeManager(self)
+        return self._vm_recipes
+
+    @property
+    def vm_recipe_instances(self) -> VmRecipeInstanceManager:
+        """Access VM recipe instance operations.
+
+        VM recipe instances represent deployed VMs created from recipes.
+
+        Example:
+            >>> # List all VM recipe instances
+            >>> for inst in client.vm_recipe_instances.list():
+            ...     print(f"{inst.name}: {inst.version}")
+
+            >>> # List instances for a specific recipe
+            >>> insts = client.vm_recipe_instances.list(recipe="8f73f8bcc9...")
+        """
+        if self._vm_recipe_instances is None:
+            from pyvergeos.resources.vm_recipes import VmRecipeInstanceManager
+
+            self._vm_recipe_instances = VmRecipeInstanceManager(self)
+        return self._vm_recipe_instances
+
+    @property
+    def vm_recipe_logs(self) -> VmRecipeLogManager:
+        """Access VM recipe log operations.
+
+        VM recipe logs provide detailed progress and error information
+        for recipe operations.
+
+        Example:
+            >>> # List all recipe logs
+            >>> for log in client.vm_recipe_logs.list():
+            ...     print(f"{log.level}: {log.text}")
+
+            >>> # List errors only
+            >>> errors = client.vm_recipe_logs.list_errors()
+        """
+        if self._vm_recipe_logs is None:
+            from pyvergeos.resources.vm_recipes import VmRecipeLogManager
+
+            self._vm_recipe_logs = VmRecipeLogManager(self)
+        return self._vm_recipe_logs
+
+    @property
+    def tenant_recipes(self) -> TenantRecipeManager:
+        """Access tenant recipe operations for automated tenant provisioning.
+
+        Tenant recipes are templates that can be deployed to create new
+        tenants with pre-configured settings and resources.
+
+        Example:
+            >>> # List all tenant recipes
+            >>> for recipe in client.tenant_recipes.list():
+            ...     print(f"{recipe.name}: {recipe.version}")
+
+            >>> # Get a specific recipe
+            >>> recipe = client.tenant_recipes.get(name="Standard Tenant")
+
+            >>> # Deploy a recipe
+            >>> instance = recipe.deploy("my-tenant", answers={"storage_gb": 500})
+        """
+        if self._tenant_recipes is None:
+            from pyvergeos.resources.tenant_recipes import TenantRecipeManager
+
+            self._tenant_recipes = TenantRecipeManager(self)
+        return self._tenant_recipes
+
+    @property
+    def tenant_recipe_instances(self) -> TenantRecipeInstanceManager:
+        """Access tenant recipe instance operations.
+
+        Tenant recipe instances represent deployed tenants created from recipes.
+
+        Example:
+            >>> # List all tenant recipe instances
+            >>> for inst in client.tenant_recipe_instances.list():
+            ...     print(f"{inst.name}: {inst.version}")
+
+            >>> # List instances for a specific recipe
+            >>> insts = client.tenant_recipe_instances.list(recipe="8f73f8bcc9...")
+        """
+        if self._tenant_recipe_instances is None:
+            from pyvergeos.resources.tenant_recipes import TenantRecipeInstanceManager
+
+            self._tenant_recipe_instances = TenantRecipeInstanceManager(self)
+        return self._tenant_recipe_instances
+
+    @property
+    def tenant_recipe_logs(self) -> TenantRecipeLogManager:
+        """Access tenant recipe log operations.
+
+        Tenant recipe logs provide detailed progress and error information
+        for recipe operations.
+
+        Example:
+            >>> # List all recipe logs
+            >>> for log in client.tenant_recipe_logs.list():
+            ...     print(f"{log.level}: {log.text}")
+
+            >>> # List errors only
+            >>> errors = client.tenant_recipe_logs.list_errors()
+        """
+        if self._tenant_recipe_logs is None:
+            from pyvergeos.resources.tenant_recipes import TenantRecipeLogManager
+
+            self._tenant_recipe_logs = TenantRecipeLogManager(self)
+        return self._tenant_recipe_logs
+
+    @property
+    def recipe_questions(self) -> RecipeQuestionManager:
+        """Access recipe question operations.
+
+        Recipe questions define the configuration options available when
+        deploying a recipe. Questions are organized into sections.
+
+        Example:
+            >>> # List all questions for a VM recipe
+            >>> questions = client.recipe_questions.list(
+            ...     recipe_ref="vm_recipes/8f73f8bcc9..."
+            ... )
+            >>> for q in questions:
+            ...     print(f"{q.name}: {q.question_type}")
+        """
+        if self._recipe_questions is None:
+            from pyvergeos.resources.recipe_common import RecipeQuestionManager
+
+            self._recipe_questions = RecipeQuestionManager(self)
+        return self._recipe_questions
+
+    @property
+    def recipe_sections(self) -> RecipeSectionManager:
+        """Access recipe section operations.
+
+        Recipe sections organize questions into logical groups.
+
+        Example:
+            >>> # List all sections for a VM recipe
+            >>> sections = client.recipe_sections.list(
+            ...     recipe_ref="vm_recipes/8f73f8bcc9..."
+            ... )
+            >>> for s in sections:
+            ...     print(f"{s.name}: {s.description}")
+        """
+        if self._recipe_sections is None:
+            from pyvergeos.resources.recipe_common import RecipeSectionManager
+
+            self._recipe_sections = RecipeSectionManager(self)
+        return self._recipe_sections

--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -30,6 +30,12 @@ from pyvergeos.resources.nas_volumes import (
     NASVolumeSnapshotManager,
 )
 from pyvergeos.resources.permissions import Permission, PermissionManager
+from pyvergeos.resources.recipe_common import (
+    RecipeQuestion,
+    RecipeQuestionManager,
+    RecipeSection,
+    RecipeSectionManager,
+)
 from pyvergeos.resources.resource_groups import ResourceGroup, ResourceGroupManager
 from pyvergeos.resources.shared_objects import SharedObject, SharedObjectManager
 from pyvergeos.resources.site_syncs import (
@@ -65,8 +71,24 @@ from pyvergeos.resources.tenant_network_blocks import (
     TenantNetworkBlock,
     TenantNetworkBlockManager,
 )
+from pyvergeos.resources.tenant_recipes import (
+    TenantRecipe,
+    TenantRecipeInstance,
+    TenantRecipeInstanceManager,
+    TenantRecipeLog,
+    TenantRecipeLogManager,
+    TenantRecipeManager,
+)
 from pyvergeos.resources.tenant_snapshots import TenantSnapshot, TenantSnapshotManager
 from pyvergeos.resources.tenant_storage import TenantStorage, TenantStorageManager
+from pyvergeos.resources.vm_recipes import (
+    VmRecipe,
+    VmRecipeInstance,
+    VmRecipeInstanceManager,
+    VmRecipeLog,
+    VmRecipeLogManager,
+    VmRecipeManager,
+)
 from pyvergeos.resources.webhooks import Webhook, WebhookHistory, WebhookManager
 
 __all__ = [
@@ -142,4 +164,20 @@ __all__ = [
     "Webhook",
     "WebhookHistory",
     "WebhookManager",
+    "VmRecipe",
+    "VmRecipeInstance",
+    "VmRecipeInstanceManager",
+    "VmRecipeLog",
+    "VmRecipeLogManager",
+    "VmRecipeManager",
+    "TenantRecipe",
+    "TenantRecipeInstance",
+    "TenantRecipeInstanceManager",
+    "TenantRecipeLog",
+    "TenantRecipeLogManager",
+    "TenantRecipeManager",
+    "RecipeQuestion",
+    "RecipeQuestionManager",
+    "RecipeSection",
+    "RecipeSectionManager",
 ]

--- a/pyvergeos/resources/recipe_common.py
+++ b/pyvergeos/resources/recipe_common.py
@@ -1,0 +1,876 @@
+"""Recipe Questions and Sections shared between VM and Tenant recipes.
+
+Recipe questions define the configuration options presented to users when deploying
+a recipe. Questions are organized into sections that group related options together.
+
+Question Types:
+    User Input Types:
+        - string: Free-form text input
+        - number: Numeric value (supports min/max)
+        - boolean: Checkbox (true/false)
+        - password: Masked text with confirmation
+        - list: Dropdown selection from predefined options
+        - text_area: Multi-line text input
+        - hidden: Not shown on form (for internal values)
+
+    VergeOS-Specific Types:
+        - ram: RAM selector with unit conversion
+        - disk_size: Disk size selector
+        - cluster: Cluster selection dropdown
+        - network: Network selection dropdown
+        - row_selection: Database row picker
+
+    Database Automation Types:
+        - database_create: Create a database record
+        - database_edit: Modify a database record
+        - database_find: Look up database values
+
+Common Sections:
+    - "Virtual Machine": Core VM settings (CPU, RAM, hostname)
+    - "Network": Network and IP configuration
+    - "Drives": Storage/disk settings
+    - "Static IP Configuration": Manual IP settings
+    - "User Configuration": Guest OS user accounts
+    - "$database": Database automation (hidden from users)
+
+Variable Naming Convention:
+    Question names serve as variable names in recipe scripts. Common prefixes:
+    - YB_* : VergeOS built-in variables (YB_RAM, YB_CPU_CORES, etc.)
+    - SELECT_* : Selection/boolean options
+    - Custom names for recipe-specific variables
+
+Example:
+    >>> # List questions for a recipe
+    >>> recipe = client.vm_recipes.get(name="Ubuntu Server")
+    >>> questions = client.recipe_questions.list(
+    ...     recipe_ref=f"vm_recipes/{recipe.key}"
+    ... )
+    >>> for q in questions:
+    ...     print(f"{q.name}: {q.question_type} - {q.get('display')}")
+
+    >>> # Get sections for a recipe
+    >>> sections = client.recipe_sections.list(
+    ...     recipe_ref=f"vm_recipes/{recipe.key}"
+    ... )
+    >>> for s in sections:
+    ...     print(f"{s.name}: {s.get('description', 'No description')}")
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class RecipeQuestion(ResourceObject):
+    """Recipe question resource object.
+
+    Represents a configuration question for a recipe. Questions are used
+    to gather input during recipe deployment.
+
+    Attributes:
+        key: Question $key (integer row ID).
+        recipe: Recipe reference (e.g., "vm_recipes/{id}" or "tenant_recipes/{id}").
+        section: Section key this question belongs to.
+        name: Question variable name (used in recipe scripts).
+        display: Display label for the question.
+        hint: Placeholder text shown in input field.
+        help: Tooltip text shown on hover.
+        note: Note text displayed below the field.
+        type: Question type (string, bool, num, password, list, etc.).
+        default: Default value for the question.
+        required: Whether the question is required.
+        enabled: Whether the question is enabled.
+        readonly: Whether the question is read-only after creation.
+        orderid: Display order within the section.
+    """
+
+    @property
+    def recipe_ref(self) -> str | None:
+        """Get the recipe reference string."""
+        return self.get("recipe")
+
+    @property
+    def section_key(self) -> int | None:
+        """Get the section key this question belongs to."""
+        section = self.get("section")
+        return int(section) if section is not None else None
+
+    @property
+    def question_type(self) -> str | None:
+        """Get the question type."""
+        return self.get("type")
+
+    @property
+    def is_required(self) -> bool:
+        """Check if the question is required."""
+        return bool(self.get("required", False))
+
+    @property
+    def is_enabled(self) -> bool:
+        """Check if the question is enabled."""
+        return bool(self.get("enabled", True))
+
+    @property
+    def is_readonly(self) -> bool:
+        """Check if the question is read-only."""
+        return bool(self.get("readonly", False))
+
+    @property
+    def is_password(self) -> bool:
+        """Check if this is a password question."""
+        return self.get("type") == "password"
+
+    @property
+    def is_hidden(self) -> bool:
+        """Check if this is a hidden question."""
+        return self.get("type") == "hidden"
+
+    @property
+    def list_options(self) -> dict[str, Any] | None:
+        """Get list options if this is a list-type question."""
+        if self.get("type") != "list":
+            return None
+        return self.get("list")
+
+
+class RecipeSection(ResourceObject):
+    """Recipe section resource object.
+
+    Represents a section that groups related questions in a recipe form.
+
+    Attributes:
+        key: Section $key (integer row ID).
+        recipe: Recipe reference (e.g., "vm_recipes/{id}" or "tenant_recipes/{id}").
+        name: Section name.
+        description: Section description.
+        orderid: Display order.
+    """
+
+    @property
+    def recipe_ref(self) -> str | None:
+        """Get the recipe reference string."""
+        return self.get("recipe")
+
+
+class RecipeQuestionManager(ResourceManager["RecipeQuestion"]):
+    """Manager for recipe question operations.
+
+    Recipe questions define the configuration options available when deploying
+    a recipe. Questions are organized into sections.
+
+    Example:
+        >>> # List all questions for a VM recipe
+        >>> questions = client.recipe_questions.list(
+        ...     recipe_ref="vm_recipes/8f73f8bcc9c9..."
+        ... )
+        >>> for q in questions:
+        ...     print(f"{q.name}: {q.question_type} (required={q.is_required})")
+
+        >>> # List questions for a specific section
+        >>> questions = client.recipe_questions.list(section=123)
+    """
+
+    _endpoint = "recipe_questions"
+
+    _default_fields = [
+        "$key",
+        "recipe",
+        "section",
+        "section#name as section_name",
+        "name",
+        "display",
+        "hint",
+        "help",
+        "note",
+        "type",
+        "default",
+        "required",
+        "enabled",
+        "readonly",
+        "orderid",
+        "min",
+        "max",
+        "regex",
+        "list",
+        "table",
+        "fields",
+        "filter",
+        "database_context",
+        "hide_none",
+        "conditions",
+        "on_change",
+        "postprocess_string",
+        "dont_store",
+        "system",
+    ]
+
+    def __init__(
+        self,
+        client: VergeClient,
+        *,
+        recipe_ref: str | None = None,
+        section_key: int | None = None,
+    ) -> None:
+        super().__init__(client)
+        self._recipe_ref = recipe_ref
+        self._section_key = section_key
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        recipe_ref: str | None = None,
+        section: int | None = None,
+        enabled: bool | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[RecipeQuestion]:
+        """List recipe questions with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            recipe_ref: Filter by recipe reference (e.g., "vm_recipes/{id}").
+            section: Filter by section key.
+            enabled: Filter by enabled state.
+            **filter_kwargs: Shorthand filter arguments (name, type, etc.).
+
+        Returns:
+            List of RecipeQuestion objects.
+
+        Example:
+            >>> # List all questions for a VM recipe
+            >>> questions = client.recipe_questions.list(
+            ...     recipe_ref="vm_recipes/8f73f8bcc9c9..."
+            ... )
+
+            >>> # List enabled questions only
+            >>> enabled = client.recipe_questions.list(enabled=True)
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe = self._recipe_ref
+        if recipe is None and recipe_ref is not None:
+            recipe = recipe_ref
+
+        if recipe is not None:
+            filters.append(f"recipe eq '{recipe}'")
+
+        # Add section filter (from scope or parameter)
+        sect = self._section_key
+        if sect is None and section is not None:
+            sect = section
+
+        if sect is not None:
+            filters.append(f"section eq {sect}")
+
+        # Add enabled filter
+        if enabled is not None:
+            filters.append(f"enabled eq {1 if enabled else 0}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Sort by orderid
+        params["sort"] = "+orderid"
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> RecipeQuestion:
+        """Get a single recipe question by key or name.
+
+        Args:
+            key: Question $key (row ID).
+            name: Question name (variable name).
+            fields: List of fields to return.
+
+        Returns:
+            RecipeQuestion object.
+
+        Raises:
+            NotFoundError: If question not found.
+            ValueError: If no identifier provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Recipe question with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(
+                    f"Recipe question with key {key} returned invalid response"
+                )
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Recipe question with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        recipe_ref: str,
+        section: int,
+        question_type: str,
+        *,
+        display: str | None = None,
+        hint: str | None = None,
+        help_text: str | None = None,
+        note: str | None = None,
+        default: str | None = None,
+        required: bool = False,
+        enabled: bool = True,
+        readonly: bool = False,
+        min_value: int | None = None,
+        max_value: int | None = None,
+        regex: str | None = None,
+        list_options: dict[str, str] | None = None,
+        table: str | None = None,
+        fields: str | None = None,
+        db_filter: str | None = None,
+        database_context: str | None = None,
+        hide_none: bool = False,
+        conditions: dict[str, Any] | None = None,
+        on_change: dict[str, Any] | None = None,
+        postprocess_string: str | None = None,
+        dont_store: bool = False,
+    ) -> RecipeQuestion:
+        """Create a new recipe question.
+
+        Args:
+            name: Variable name for the question (alphanumeric with underscores).
+            recipe_ref: Recipe reference (e.g., "vm_recipes/{id}").
+            section: Section key to add the question to.
+            question_type: Question type (string, bool, num, password, list, etc.).
+            display: Display label.
+            hint: Placeholder text.
+            help_text: Tooltip text.
+            note: Note text below field.
+            default: Default value.
+            required: Whether the question is required.
+            enabled: Whether the question is enabled.
+            readonly: Whether the question is read-only after creation.
+            min_value: Minimum value (for numeric types).
+            max_value: Maximum value (for numeric types).
+            regex: Validation regex.
+            list_options: Options for list type (key: value dict).
+            table: Database table for row selection type.
+            fields: Database fields for row selection.
+            db_filter: Database filter for row selection.
+            database_context: Database context (local or tenant).
+            hide_none: Hide the "None" option in lists.
+            conditions: Conditional visibility rules.
+            on_change: On-change actions.
+            postprocess_string: Post-processing type.
+            dont_store: Don't store the answer in the database.
+
+        Returns:
+            Created RecipeQuestion object.
+
+        Example:
+            >>> question = client.recipe_questions.create(
+            ...     name="vm_ram",
+            ...     recipe_ref="vm_recipes/8f73f8bcc9c9...",
+            ...     section=123,
+            ...     question_type="ram",
+            ...     display="RAM",
+            ...     default="4096",
+            ...     required=True
+            ... )
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "recipe": recipe_ref,
+            "section": section,
+            "type": question_type,
+        }
+
+        if display is not None:
+            body["display"] = display
+
+        if hint is not None:
+            body["hint"] = hint
+
+        if help_text is not None:
+            body["help"] = help_text
+
+        if note is not None:
+            body["note"] = note
+
+        if default is not None:
+            body["default"] = default
+
+        body["required"] = required
+        body["enabled"] = enabled
+        body["readonly"] = readonly
+
+        if min_value is not None:
+            body["min"] = min_value
+
+        if max_value is not None:
+            body["max"] = max_value
+
+        if regex is not None:
+            body["regex"] = regex
+
+        if list_options is not None:
+            body["list"] = list_options
+
+        if table is not None:
+            body["table"] = table
+
+        if fields is not None:
+            body["fields"] = fields
+
+        if db_filter is not None:
+            body["filter"] = db_filter
+
+        if database_context is not None:
+            body["database_context"] = database_context
+
+        body["hide_none"] = hide_none
+
+        if conditions is not None:
+            body["conditions"] = conditions
+
+        if on_change is not None:
+            body["on_change"] = on_change
+
+        if postprocess_string is not None:
+            body["postprocess_string"] = postprocess_string
+
+        body["dont_store"] = dont_store
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created question
+        if response and isinstance(response, dict):
+            q_key = response.get("$key")
+            if q_key:
+                return self.get(key=q_key)
+
+        # Fallback: search by name in the recipe
+        results = self.list(
+            recipe_ref=recipe_ref, filter=f"name eq '{name}'", limit=1
+        )
+        if results:
+            return results[0]
+
+        raise NotFoundError(f"Failed to retrieve created question '{name}'")
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        display: str | None = None,
+        hint: str | None = None,
+        help_text: str | None = None,
+        note: str | None = None,
+        default: str | None = None,
+        required: bool | None = None,
+        enabled: bool | None = None,
+        readonly: bool | None = None,
+        min_value: int | None = None,
+        max_value: int | None = None,
+        orderid: int | None = None,
+    ) -> RecipeQuestion:
+        """Update a recipe question.
+
+        Args:
+            key: Question $key (row ID).
+            display: New display label.
+            hint: New placeholder text.
+            help_text: New tooltip text.
+            note: New note text.
+            default: New default value.
+            required: Set required state.
+            enabled: Set enabled state.
+            readonly: Set readonly state.
+            min_value: New minimum value.
+            max_value: New maximum value.
+            orderid: New display order.
+
+        Returns:
+            Updated RecipeQuestion object.
+        """
+        body: dict[str, Any] = {}
+
+        if display is not None:
+            body["display"] = display
+
+        if hint is not None:
+            body["hint"] = hint
+
+        if help_text is not None:
+            body["help"] = help_text
+
+        if note is not None:
+            body["note"] = note
+
+        if default is not None:
+            body["default"] = default
+
+        if required is not None:
+            body["required"] = required
+
+        if enabled is not None:
+            body["enabled"] = enabled
+
+        if readonly is not None:
+            body["readonly"] = readonly
+
+        if min_value is not None:
+            body["min"] = min_value
+
+        if max_value is not None:
+            body["max"] = max_value
+
+        if orderid is not None:
+            body["orderid"] = orderid
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a recipe question.
+
+        Args:
+            key: Question $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def _to_model(self, data: dict[str, Any]) -> RecipeQuestion:
+        """Convert API response to RecipeQuestion object."""
+        return RecipeQuestion(data, self)
+
+
+class RecipeSectionManager(ResourceManager["RecipeSection"]):
+    """Manager for recipe section operations.
+
+    Recipe sections organize questions into logical groups.
+
+    Example:
+        >>> # List all sections for a VM recipe
+        >>> sections = client.recipe_sections.list(
+        ...     recipe_ref="vm_recipes/8f73f8bcc9c9..."
+        ... )
+        >>> for s in sections:
+        ...     print(f"{s.name}: {s.description}")
+
+        >>> # Create a new section
+        >>> section = client.recipe_sections.create(
+        ...     name="Network Settings",
+        ...     recipe_ref="vm_recipes/8f73f8bcc9c9...",
+        ...     description="Network configuration options"
+        ... )
+    """
+
+    _endpoint = "recipe_sections"
+
+    _default_fields = [
+        "$key",
+        "recipe",
+        "name",
+        "description",
+        "orderid",
+    ]
+
+    def __init__(
+        self,
+        client: VergeClient,
+        *,
+        recipe_ref: str | None = None,
+    ) -> None:
+        super().__init__(client)
+        self._recipe_ref = recipe_ref
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        recipe_ref: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[RecipeSection]:
+        """List recipe sections with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            recipe_ref: Filter by recipe reference (e.g., "vm_recipes/{id}").
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of RecipeSection objects.
+
+        Example:
+            >>> # List all sections for a VM recipe
+            >>> sections = client.recipe_sections.list(
+            ...     recipe_ref="vm_recipes/8f73f8bcc9c9..."
+            ... )
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe = self._recipe_ref
+        if recipe is None and recipe_ref is not None:
+            recipe = recipe_ref
+
+        if recipe is not None:
+            filters.append(f"recipe eq '{recipe}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Sort by orderid
+        params["sort"] = "+orderid"
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> RecipeSection:
+        """Get a single recipe section by key or name.
+
+        Args:
+            key: Section $key (row ID).
+            name: Section name.
+            fields: List of fields to return.
+
+        Returns:
+            RecipeSection object.
+
+        Raises:
+            NotFoundError: If section not found.
+            ValueError: If no identifier provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Recipe section with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(
+                    f"Recipe section with key {key} returned invalid response"
+                )
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Recipe section with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        recipe_ref: str,
+        *,
+        description: str | None = None,
+    ) -> RecipeSection:
+        """Create a new recipe section.
+
+        Args:
+            name: Section name.
+            recipe_ref: Recipe reference (e.g., "vm_recipes/{id}").
+            description: Section description.
+
+        Returns:
+            Created RecipeSection object.
+
+        Example:
+            >>> section = client.recipe_sections.create(
+            ...     name="Network Settings",
+            ...     recipe_ref="vm_recipes/8f73f8bcc9c9...",
+            ...     description="Network configuration options"
+            ... )
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "recipe": recipe_ref,
+        }
+
+        if description is not None:
+            body["description"] = description
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created section
+        if response and isinstance(response, dict):
+            s_key = response.get("$key")
+            if s_key:
+                return self.get(key=s_key)
+
+        # Fallback: search by name in the recipe
+        results = self.list(
+            recipe_ref=recipe_ref, filter=f"name eq '{name}'", limit=1
+        )
+        if results:
+            return results[0]
+
+        raise NotFoundError(f"Failed to retrieve created section '{name}'")
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        orderid: int | None = None,
+    ) -> RecipeSection:
+        """Update a recipe section.
+
+        Args:
+            key: Section $key (row ID).
+            name: New name.
+            description: New description.
+            orderid: New display order.
+
+        Returns:
+            Updated RecipeSection object.
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+
+        if description is not None:
+            body["description"] = description
+
+        if orderid is not None:
+            body["orderid"] = orderid
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a recipe section.
+
+        Note: This will also delete all questions in the section.
+
+        Args:
+            key: Section $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def questions(self, key: int) -> RecipeQuestionManager:
+        """Get a question manager scoped to a specific section.
+
+        Args:
+            key: Section $key (row ID).
+
+        Returns:
+            RecipeQuestionManager for the section.
+        """
+        return RecipeQuestionManager(self._client, section_key=key)
+
+    def _to_model(self, data: dict[str, Any]) -> RecipeSection:
+        """Convert API response to RecipeSection object."""
+        return RecipeSection(data, self)

--- a/pyvergeos/resources/tenant_recipes.py
+++ b/pyvergeos/resources/tenant_recipes.py
@@ -1,0 +1,1003 @@
+"""Tenant Recipe resources for VergeOS provisioning system.
+
+Tenant recipes enable automated deployment of complete virtual data centers.
+A tenant recipe includes everything needed to spawn a functional tenant instance:
+tenant settings, networking configuration, VMs, and automation for tasks like
+creating passwords, establishing hostnames, registering DNS entries, etc.
+
+Key concepts:
+    - **Recipe**: A template based on a powered-off tenant, stored in a catalog
+    - **Instance**: A tenant created from a recipe (remains linked until detached)
+    - **Questions**: Configuration inputs for customizing each tenant deployment
+    - **Sections**: Logical groups organizing questions on the deployment form
+
+Benefits:
+    - Rapid deployment of entire tenants with consistent configurations
+    - Golden images for compliance and standardization
+    - Reduced manual setup time and human error
+    - Customizable via questions for tenant-specific settings
+
+Database Context:
+    Tenant recipe questions can interact with either the parent system database
+    or the newly-created tenant's database using the database_context field.
+    This enables powerful automation like creating users, registering DNS, etc.
+
+Example:
+    >>> # List available tenant recipes
+    >>> for recipe in client.tenant_recipes.list(downloaded=True):
+    ...     print(f"{recipe.name} (v{recipe.version})")
+
+    >>> # Deploy a tenant recipe
+    >>> recipe = client.tenant_recipes.get(name="30-Day Trial (POC)")
+    >>> instance = recipe.deploy("customer-tenant", answers={
+    ...     "TENANT_NAME": "Acme Corp",
+    ...     "ADMIN_USER": "admin",
+    ...     "ADMIN_PASSWORD": "secure-password",
+    ... })
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class TenantRecipe(ResourceObject):
+    """Tenant Recipe resource object.
+
+    Represents a tenant recipe template that can be deployed to create new tenants.
+
+    Note:
+        Recipe keys are 40-character hex strings, not integers like most
+        other VergeOS resources.
+
+    Attributes:
+        key: The recipe unique identifier ($key) - 40-char hex string.
+        id: The recipe ID (same as $key).
+        name: Recipe name.
+        description: Recipe description.
+        version: Recipe version string.
+        build: Recipe build number.
+        icon: Bootstrap icon name for UI display.
+        catalog: Parent catalog key.
+        status: Recipe status row key.
+        downloaded: Whether the recipe has been downloaded.
+        update_available: Whether an update is available.
+        needs_republish: Whether the recipe needs republishing.
+        tenant: Associated tenant key (for local recipes).
+        tenant_snapshot: Associated tenant snapshot key.
+        preserve_certs: Whether to preserve SSL certificates during deployment.
+        creator: Username who created the recipe.
+    """
+
+    @property
+    def key(self) -> str:  # type: ignore[override]
+        """Resource primary key ($key) - 40-character hex string.
+
+        Raises:
+            ValueError: If resource has no $key (not yet persisted).
+        """
+        k = self.get("$key")
+        if k is None:
+            raise ValueError("Resource has no $key - may not be persisted")
+        return str(k)
+
+    def refresh(self) -> TenantRecipe:
+        """Refresh resource data from API.
+
+        Returns:
+            Updated TenantRecipe object.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return manager.get(self.key)
+
+    def save(self, **kwargs: Any) -> TenantRecipe:
+        """Save changes to resource.
+
+        Args:
+            **kwargs: Fields to update.
+
+        Returns:
+            Updated TenantRecipe object.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return manager.update(self.key, **kwargs)
+
+    def delete(self) -> None:
+        """Delete this recipe."""
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        manager.delete(self.key)
+
+    @property
+    def is_downloaded(self) -> bool:
+        """Check if the recipe has been downloaded."""
+        return bool(self.get("downloaded", False))
+
+    @property
+    def has_update(self) -> bool:
+        """Check if an update is available."""
+        return bool(self.get("update_available", False))
+
+    @property
+    def status_info(self) -> str | None:
+        """Get the recipe status string."""
+        return self.get("status") or self.get("rstatus")
+
+    @property
+    def catalog_key(self) -> str | None:
+        """Get the parent catalog key."""
+        cat = self.get("catalog")
+        return str(cat) if cat is not None else None
+
+    @property
+    def tenant_key(self) -> int | None:
+        """Get the associated tenant key."""
+        tenant = self.get("tenant")
+        return int(tenant) if tenant is not None else None
+
+    @property
+    def instance_count(self) -> int:
+        """Get the number of deployed instances."""
+        return int(self.get("instances", 0))
+
+    @property
+    def instances(self) -> TenantRecipeInstanceManager:
+        """Get an instance manager scoped to this recipe.
+
+        Returns:
+            TenantRecipeInstanceManager for this recipe.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return TenantRecipeInstanceManager(manager._client, recipe_key=self.key)
+
+    @property
+    def logs(self) -> TenantRecipeLogManager:
+        """Get a log manager scoped to this recipe.
+
+        Returns:
+            TenantRecipeLogManager for this recipe.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return TenantRecipeLogManager(manager._client, recipe_key=self.key)
+
+    def download(self) -> dict[str, Any] | None:
+        """Download this recipe from the catalog repository.
+
+        Returns:
+            Task information dict or None.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return manager.download(self.key)
+
+    def deploy(
+        self,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+    ) -> TenantRecipeInstance:
+        """Deploy this recipe to create a new tenant.
+
+        Args:
+            name: Name for the new tenant.
+            answers: Recipe question answers.
+
+        Returns:
+            Created TenantRecipeInstance object.
+        """
+        from typing import cast
+
+        manager = cast("TenantRecipeManager", self._manager)
+        return manager.deploy(self.key, name=name, answers=answers)
+
+
+class TenantRecipeInstance(ResourceObject):
+    """Tenant Recipe instance resource object.
+
+    Represents a deployed instance of a tenant recipe.
+
+    Attributes:
+        key: Instance $key (integer row ID).
+        recipe: Recipe key that this instance was deployed from.
+        tenant: Tenant key that was created.
+        name: Instance/tenant name.
+        version: Recipe version when deployed.
+        build: Recipe build when deployed.
+        answers: Recipe question answers used.
+        created: Creation timestamp.
+        modified: Last modified timestamp.
+    """
+
+    @property
+    def recipe_key(self) -> str | None:
+        """Get the recipe key this instance was deployed from."""
+        recipe = self.get("recipe")
+        return str(recipe) if recipe is not None else None
+
+    @property
+    def tenant_key(self) -> int | None:
+        """Get the tenant key that was created."""
+        tenant = self.get("tenant")
+        return int(tenant) if tenant is not None else None
+
+
+class TenantRecipeLog(ResourceObject):
+    """Tenant Recipe log entry resource object.
+
+    Represents a log entry from recipe operations.
+
+    Attributes:
+        key: Log entry $key (integer row ID).
+        tenant_recipe: Recipe key.
+        level: Log level (message, warning, error, critical, etc.).
+        text: Log message text.
+        timestamp: Log timestamp (microseconds).
+        user: User who triggered the log.
+    """
+
+    @property
+    def recipe_key(self) -> str | None:
+        """Get the recipe key."""
+        recipe = self.get("tenant_recipe")
+        return str(recipe) if recipe is not None else None
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error log entry."""
+        level = self.get("level", "")
+        return level in ("error", "critical")
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning log entry."""
+        return self.get("level") == "warning"
+
+
+class TenantRecipeManager(ResourceManager["TenantRecipe"]):
+    """Manager for tenant recipe operations.
+
+    Tenant recipes are templates for automated tenant provisioning.
+
+    Example:
+        >>> # List all recipes
+        >>> for recipe in client.tenant_recipes.list():
+        ...     print(f"{recipe.name}: {recipe.version}")
+
+        >>> # Get a specific recipe
+        >>> recipe = client.tenant_recipes.get(name="Standard Tenant")
+
+        >>> # Deploy a recipe
+        >>> instance = recipe.deploy("my-tenant", answers={"storage_gb": 500})
+    """
+
+    _endpoint = "tenant_recipes"
+
+    _default_fields = [
+        "$key",
+        "id",
+        "name",
+        "description",
+        "icon",
+        "version",
+        "build",
+        "catalog",
+        "catalog#$display as catalog_display",
+        "catalog#repository as catalog_repository",
+        "catalog#repository#$display as repository_display",
+        "status#status as status",
+        "status#status as rstatus",
+        "downloaded",
+        "update_available",
+        "needs_republish",
+        "preserve_certs",
+        "tenant",
+        "tenant#$display as tenant_display",
+        "tenant_snapshot",
+        "tenant_snapshot#$display as snapshot_display",
+        "count(instances) as instances",
+        "creator",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        catalog: str | int | None = None,
+        downloaded: bool | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TenantRecipe]:
+        """List tenant recipes with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            catalog: Filter by catalog (key or name).
+            downloaded: Filter by downloaded state.
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of TenantRecipe objects.
+
+        Example:
+            >>> # List all recipes
+            >>> recipes = client.tenant_recipes.list()
+
+            >>> # List downloaded recipes only
+            >>> downloaded = client.tenant_recipes.list(downloaded=True)
+
+            >>> # Filter by name
+            >>> standard = client.tenant_recipes.list(name="Standard*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add catalog filter
+        if catalog is not None:
+            if isinstance(catalog, int):
+                filters.append(f"catalog eq {catalog}")
+            elif isinstance(catalog, str):
+                # Check if it looks like a catalog key (40-char hex) or a name
+                if len(catalog) == 40 and all(
+                    c in "0123456789abcdef" for c in catalog.lower()
+                ):
+                    filters.append(f"catalog eq '{catalog}'")
+                else:
+                    # Look up catalog by name
+                    cat_response = self._client._request(
+                        "GET",
+                        "catalogs",
+                        params={
+                            "filter": f"name eq '{catalog}'",
+                            "fields": "$key",
+                            "limit": "1",
+                        },
+                    )
+                    if cat_response:
+                        if isinstance(cat_response, list):
+                            cat_response = cat_response[0] if cat_response else None
+                        if cat_response:
+                            filters.append(f"catalog eq '{cat_response.get('$key')}'")
+
+        # Add downloaded filter
+        if downloaded is not None:
+            filters.append(f"downloaded eq {1 if downloaded else 0}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: str | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> TenantRecipe:
+        """Get a single tenant recipe by key or name.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: Recipe name.
+            fields: List of fields to return.
+
+        Returns:
+            TenantRecipe object.
+
+        Raises:
+            NotFoundError: If recipe not found.
+            ValueError: If no identifier provided.
+
+        Example:
+            >>> # Get by key
+            >>> recipe = client.tenant_recipes.get("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+            >>> # Get by name
+            >>> recipe = client.tenant_recipes.get(name="Standard Tenant")
+        """
+        if key is not None:
+            # Fetch by key using id filter
+            params: dict[str, Any] = {
+                "filter": f"id eq '{key}'",
+            }
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request("GET", self._endpoint, params=params)
+
+            if response is None:
+                raise NotFoundError(f"Tenant recipe with key {key} not found")
+            if isinstance(response, list):
+                if not response:
+                    raise NotFoundError(f"Tenant recipe with key {key} not found")
+                response = response[0]
+            if not isinstance(response, dict):
+                raise NotFoundError(
+                    f"Tenant recipe with key {key} returned invalid response"
+                )
+            return self._to_model(response)
+
+        if name is not None:
+            # Search by name
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Tenant recipe with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def update(  # type: ignore[override]
+        self,
+        key: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        icon: str | None = None,
+        version: str | None = None,
+        preserve_certs: bool | None = None,
+    ) -> TenantRecipe:
+        """Update a tenant recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: New name.
+            description: New description.
+            icon: New icon name.
+            version: New version string.
+            preserve_certs: Whether to preserve SSL certs during deployment.
+
+        Returns:
+            Updated TenantRecipe object.
+
+        Example:
+            >>> client.tenant_recipes.update(recipe.key, description="Updated description")
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+
+        if description is not None:
+            body["description"] = description
+
+        if icon is not None:
+            body["icon"] = icon
+
+        if version is not None:
+            body["version"] = version
+
+        if preserve_certs is not None:
+            body["preserve_certs"] = preserve_certs
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: str) -> None:  # type: ignore[override]
+        """Delete a tenant recipe.
+
+        This operation is destructive and cannot be undone.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Raises:
+            NotFoundError: If recipe not found.
+
+        Example:
+            >>> client.tenant_recipes.delete(recipe.key)
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def download(self, key: str) -> dict[str, Any] | None:
+        """Download a recipe from the catalog repository.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            Task information dict or None.
+
+        Example:
+            >>> client.tenant_recipes.download(recipe.key)
+        """
+        result = self._client._request(
+            "PUT", f"{self._endpoint}/{key}?action=download", json_data={}
+        )
+        if isinstance(result, dict):
+            return result
+        return None
+
+    def deploy(
+        self,
+        key: str,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+    ) -> TenantRecipeInstance:
+        """Deploy a recipe to create a new tenant.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: Name for the new tenant.
+            answers: Recipe question answers.
+
+        Returns:
+            Created TenantRecipeInstance object.
+
+        Example:
+            >>> instance = client.tenant_recipes.deploy(
+            ...     recipe.key,
+            ...     "my-tenant",
+            ...     answers={"storage_gb": 500, "cpu_cores": 4}
+            ... )
+        """
+        instance_mgr = TenantRecipeInstanceManager(self._client)
+        return instance_mgr.create(recipe=key, name=name, answers=answers)
+
+    def instances(self, key: str) -> TenantRecipeInstanceManager:
+        """Get an instance manager scoped to a specific recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            TenantRecipeInstanceManager for the recipe.
+        """
+        return TenantRecipeInstanceManager(self._client, recipe_key=key)
+
+    def logs(self, key: str) -> TenantRecipeLogManager:
+        """Get a log manager scoped to a specific recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            TenantRecipeLogManager for the recipe.
+        """
+        return TenantRecipeLogManager(self._client, recipe_key=key)
+
+    def _to_model(self, data: dict[str, Any]) -> TenantRecipe:
+        """Convert API response to TenantRecipe object."""
+        return TenantRecipe(data, self)
+
+
+class TenantRecipeInstanceManager(ResourceManager["TenantRecipeInstance"]):
+    """Manager for tenant recipe instance operations.
+
+    Recipe instances represent deployed tenants created from recipes.
+
+    Example:
+        >>> # List all instances
+        >>> for inst in client.tenant_recipe_instances.list():
+        ...     print(f"{inst.name}: {inst.version}")
+
+        >>> # List instances for a specific recipe
+        >>> for inst in client.tenant_recipes.get(name="Standard").instances.list():
+        ...     print(inst.name)
+    """
+
+    _endpoint = "tenant_recipe_instances"
+
+    _default_fields = [
+        "$key",
+        "recipe",
+        "recipe#$display as recipe_display",
+        "recipe#name as recipe_name",
+        "tenant",
+        "tenant#$display as tenant_display",
+        "tenant#name as tenant_name",
+        "name",
+        "version",
+        "build",
+        "created",
+        "modified",
+    ]
+
+    def __init__(
+        self, client: VergeClient, *, recipe_key: str | None = None
+    ) -> None:
+        super().__init__(client)
+        self._recipe_key = recipe_key
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        recipe: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TenantRecipeInstance]:
+        """List recipe instances with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            recipe: Filter by recipe key. Ignored if manager is scoped.
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of TenantRecipeInstance objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe_key = self._recipe_key
+        if recipe_key is None and recipe is not None:
+            recipe_key = recipe
+
+        if recipe_key is not None:
+            filters.append(f"recipe eq '{recipe_key}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> TenantRecipeInstance:
+        """Get a single recipe instance by key or name.
+
+        Args:
+            key: Instance $key (row ID).
+            name: Instance/tenant name.
+            fields: List of fields to return.
+
+        Returns:
+            TenantRecipeInstance object.
+
+        Raises:
+            NotFoundError: If instance not found.
+            ValueError: If no identifier provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Recipe instance with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(
+                    f"Recipe instance with key {key} returned invalid response"
+                )
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Recipe instance with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        recipe: str,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+    ) -> TenantRecipeInstance:
+        """Create a new recipe instance (deploy a recipe).
+
+        Args:
+            recipe: Recipe $key (40-character hex string).
+            name: Name for the new tenant.
+            answers: Recipe question answers.
+
+        Returns:
+            Created TenantRecipeInstance object.
+
+        Example:
+            >>> instance = client.tenant_recipe_instances.create(
+            ...     recipe="8f73f8bcc9c9...",
+            ...     name="my-tenant",
+            ...     answers={"storage_gb": 500}
+            ... )
+        """
+        body: dict[str, Any] = {
+            "recipe": recipe,
+            "name": name,
+        }
+
+        if answers is not None:
+            body["answers"] = answers
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created instance
+        if response and isinstance(response, dict):
+            inst_key = response.get("$key")
+            if inst_key:
+                return self.get(key=inst_key)
+
+        # Fallback: search by name
+        return self.get(name=name)
+
+    def delete(self, key: int) -> None:
+        """Delete a recipe instance.
+
+        Note: This typically does NOT delete the created tenant.
+
+        Args:
+            key: Instance $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def _to_model(self, data: dict[str, Any]) -> TenantRecipeInstance:
+        """Convert API response to TenantRecipeInstance object."""
+        return TenantRecipeInstance(data, self)
+
+
+class TenantRecipeLogManager(ResourceManager["TenantRecipeLog"]):
+    """Manager for tenant recipe log operations.
+
+    Example:
+        >>> # List all recipe logs
+        >>> for log in client.tenant_recipe_logs.list():
+        ...     print(f"{log.level}: {log.text}")
+
+        >>> # List logs for a specific recipe
+        >>> for log in client.tenant_recipes.get(name="Standard").logs.list():
+        ...     print(f"{log.level}: {log.text}")
+    """
+
+    _endpoint = "tenant_recipe_logs"
+
+    _default_fields = [
+        "$key",
+        "tenant_recipe",
+        "tenant_recipe#name as tenant_recipe_display",
+        "level",
+        "text",
+        "timestamp",
+        "user",
+    ]
+
+    def __init__(
+        self, client: VergeClient, *, recipe_key: str | None = None
+    ) -> None:
+        super().__init__(client)
+        self._recipe_key = recipe_key
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        tenant_recipe: str | None = None,
+        level: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TenantRecipeLog]:
+        """List recipe logs with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            tenant_recipe: Filter by recipe key. Ignored if manager is scoped.
+            level: Filter by log level.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of TenantRecipeLog objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe_key = self._recipe_key
+        if recipe_key is None and tenant_recipe is not None:
+            recipe_key = tenant_recipe
+
+        if recipe_key is not None:
+            filters.append(f"tenant_recipe eq '{recipe_key}'")
+
+        # Add level filter
+        if level is not None:
+            filters.append(f"level eq '{level}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        # Default sort by timestamp descending
+        params["sort"] = "-timestamp"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> TenantRecipeLog:
+        """Get a single log entry by key.
+
+        Args:
+            key: Log entry $key (row ID).
+            fields: List of fields to return.
+
+        Returns:
+            TenantRecipeLog object.
+
+        Raises:
+            NotFoundError: If log entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+        if response is None:
+            raise NotFoundError(f"Recipe log with key {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Recipe log with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def list_errors(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[TenantRecipeLog]:
+        """List error and critical log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of error/critical log entries.
+        """
+        return self.list(
+            filter="(level eq 'error') or (level eq 'critical')",
+            limit=limit,
+        )
+
+    def list_warnings(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[TenantRecipeLog]:
+        """List warning log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of warning log entries.
+        """
+        return self.list(level="warning", limit=limit)
+
+    def _to_model(self, data: dict[str, Any]) -> TenantRecipeLog:
+        """Convert API response to TenantRecipeLog object."""
+        return TenantRecipeLog(data, self)

--- a/pyvergeos/resources/vm_recipes.py
+++ b/pyvergeos/resources/vm_recipes.py
@@ -1,0 +1,1050 @@
+"""VM Recipe resources for VergeOS provisioning system.
+
+VM recipes are customizable templates for deploying virtual machines. They consist
+of a golden image (base VM) and configurable options via questions that allow
+users to customize each deployment.
+
+Key concepts:
+    - **Recipe**: A template based on a golden image VM, stored in a catalog
+    - **Instance**: A VM created from a recipe (remains linked until detached)
+    - **Questions**: Configuration inputs grouped into sections
+    - **Sections**: Logical groups like "Virtual Machine", "Network", "Drives"
+
+Common question variable names:
+    - YB_CPU_CORES: Number of CPU cores
+    - YB_RAM: RAM amount in MB
+    - YB_HOSTNAME: VM hostname
+    - YB_IP_ADDR_TYPE: IP type (dhcp/static)
+    - YB_NIC_ETH0: Network selection for eth0
+    - YB_DRIVE_OS_SIZE: OS disk size in bytes
+    - YB_USER: Username for guest OS
+    - YB_PASSWORD: Password for guest OS
+    - OS_DL_URL: Cloud image download URL (for cloud-init images)
+
+Question types:
+    - string, number, boolean, password, list, hidden
+    - ram, cluster, network, disk_size, row_selection, text_area
+    - database_create, database_edit, database_find (for API automation)
+
+Example:
+    >>> # List available recipes
+    >>> for recipe in client.vm_recipes.list(downloaded=True):
+    ...     print(f"{recipe.name} (v{recipe.version})")
+
+    >>> # Deploy a recipe
+    >>> recipe = client.vm_recipes.get(name="Ubuntu Server 22.04")
+    >>> instance = recipe.deploy("my-ubuntu", answers={
+    ...     "YB_CPU_CORES": 4,
+    ...     "YB_RAM": 8192,
+    ...     "YB_HOSTNAME": "my-ubuntu-server",
+    ...     "YB_IP_ADDR_TYPE": "dhcp",
+    ... })
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class VmRecipe(ResourceObject):
+    """VM Recipe resource object.
+
+    Represents a VM recipe template that can be deployed to create new VMs.
+
+    Note:
+        Recipe keys are 40-character hex strings, not integers like most
+        other VergeOS resources.
+
+    Attributes:
+        key: The recipe unique identifier ($key) - 40-char hex string.
+        id: The recipe ID (same as $key).
+        name: Recipe name.
+        description: Recipe description.
+        version: Recipe version string.
+        build: Recipe build number.
+        icon: Bootstrap icon name for UI display.
+        catalog: Parent catalog key.
+        status: Recipe status row key.
+        downloaded: Whether the recipe has been downloaded.
+        update_available: Whether an update is available.
+        needs_republish: Whether the recipe needs republishing.
+        vm: Associated VM key (for local recipes).
+        vm_snapshot: Associated VM snapshot key.
+        creator: Username who created the recipe.
+    """
+
+    @property
+    def key(self) -> str:  # type: ignore[override]
+        """Resource primary key ($key) - 40-character hex string.
+
+        Raises:
+            ValueError: If resource has no $key (not yet persisted).
+        """
+        k = self.get("$key")
+        if k is None:
+            raise ValueError("Resource has no $key - may not be persisted")
+        return str(k)
+
+    def refresh(self) -> VmRecipe:
+        """Refresh resource data from API.
+
+        Returns:
+            Updated VmRecipe object.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return manager.get(self.key)
+
+    def save(self, **kwargs: Any) -> VmRecipe:
+        """Save changes to resource.
+
+        Args:
+            **kwargs: Fields to update.
+
+        Returns:
+            Updated VmRecipe object.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return manager.update(self.key, **kwargs)
+
+    def delete(self) -> None:
+        """Delete this recipe."""
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        manager.delete(self.key)
+
+    @property
+    def is_downloaded(self) -> bool:
+        """Check if the recipe has been downloaded."""
+        return bool(self.get("downloaded", False))
+
+    @property
+    def has_update(self) -> bool:
+        """Check if an update is available."""
+        return bool(self.get("update_available", False))
+
+    @property
+    def status_info(self) -> str | None:
+        """Get the recipe status string."""
+        return self.get("status") or self.get("rstatus")
+
+    @property
+    def catalog_key(self) -> str | None:
+        """Get the parent catalog key."""
+        cat = self.get("catalog")
+        return str(cat) if cat is not None else None
+
+    @property
+    def vm_key(self) -> int | None:
+        """Get the associated VM key."""
+        vm = self.get("vm")
+        return int(vm) if vm is not None else None
+
+    @property
+    def instance_count(self) -> int:
+        """Get the number of deployed instances."""
+        return int(self.get("instances", 0))
+
+    @property
+    def instances(self) -> VmRecipeInstanceManager:
+        """Get an instance manager scoped to this recipe.
+
+        Returns:
+            VmRecipeInstanceManager for this recipe.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return VmRecipeInstanceManager(manager._client, recipe_key=self.key)
+
+    @property
+    def logs(self) -> VmRecipeLogManager:
+        """Get a log manager scoped to this recipe.
+
+        Returns:
+            VmRecipeLogManager for this recipe.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return VmRecipeLogManager(manager._client, recipe_key=self.key)
+
+    def download(self) -> dict[str, Any] | None:
+        """Download this recipe from the catalog repository.
+
+        Returns:
+            Task information dict or None.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return manager.download(self.key)
+
+    def deploy(
+        self,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+        auto_update: bool = False,
+    ) -> VmRecipeInstance:
+        """Deploy this recipe to create a new VM.
+
+        Args:
+            name: Name for the new VM.
+            answers: Recipe question answers.
+            auto_update: Auto-update when recipe updates are available.
+
+        Returns:
+            Created VmRecipeInstance object.
+        """
+        from typing import cast
+
+        manager = cast("VmRecipeManager", self._manager)
+        return manager.deploy(
+            self.key, name=name, answers=answers, auto_update=auto_update
+        )
+
+
+class VmRecipeInstance(ResourceObject):
+    """VM Recipe instance resource object.
+
+    Represents a deployed instance of a VM recipe.
+
+    Attributes:
+        key: Instance $key (integer row ID).
+        recipe: Recipe key that this instance was deployed from.
+        vm: VM key that was created.
+        name: Instance/VM name.
+        version: Recipe version when deployed.
+        build: Recipe build when deployed.
+        answers: Recipe question answers used.
+        auto_update: Whether auto-update is enabled.
+        created: Creation timestamp.
+        modified: Last modified timestamp.
+    """
+
+    @property
+    def recipe_key(self) -> str | None:
+        """Get the recipe key this instance was deployed from."""
+        recipe = self.get("recipe")
+        return str(recipe) if recipe is not None else None
+
+    @property
+    def vm_key(self) -> int | None:
+        """Get the VM key that was created."""
+        vm = self.get("vm")
+        return int(vm) if vm is not None else None
+
+    @property
+    def is_auto_update(self) -> bool:
+        """Check if auto-update is enabled."""
+        return bool(self.get("auto_update", False))
+
+
+class VmRecipeLog(ResourceObject):
+    """VM Recipe log entry resource object.
+
+    Represents a log entry from recipe operations.
+
+    Attributes:
+        key: Log entry $key (integer row ID).
+        vm_recipe: Recipe key.
+        level: Log level (message, warning, error, critical, etc.).
+        text: Log message text.
+        timestamp: Log timestamp (microseconds).
+        user: User who triggered the log.
+    """
+
+    @property
+    def recipe_key(self) -> str | None:
+        """Get the recipe key."""
+        recipe = self.get("vm_recipe")
+        return str(recipe) if recipe is not None else None
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error log entry."""
+        level = self.get("level", "")
+        return level in ("error", "critical")
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning log entry."""
+        return self.get("level") == "warning"
+
+
+class VmRecipeManager(ResourceManager["VmRecipe"]):
+    """Manager for VM recipe operations.
+
+    VM recipes are templates for automated VM provisioning.
+
+    Example:
+        >>> # List all recipes
+        >>> for recipe in client.vm_recipes.list():
+        ...     print(f"{recipe.name}: {recipe.version}")
+
+        >>> # Get a specific recipe
+        >>> recipe = client.vm_recipes.get(name="Ubuntu Server")
+
+        >>> # Deploy a recipe
+        >>> instance = recipe.deploy("my-ubuntu", answers={"ram": 4096})
+    """
+
+    _endpoint = "vm_recipes"
+
+    _default_fields = [
+        "$key",
+        "id",
+        "name",
+        "description",
+        "icon",
+        "version",
+        "build",
+        "catalog",
+        "catalog#$display as catalog_display",
+        "catalog#repository as catalog_repository",
+        "catalog#repository#$display as repository_display",
+        "status#status as status",
+        "status#status as rstatus",
+        "downloaded",
+        "update_available",
+        "needs_republish",
+        "vm",
+        "vm#$display as vm_display",
+        "vm_snapshot",
+        "vm_snapshot#$display as snapshot_display",
+        "count(instances) as instances",
+        "creator",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        catalog: str | int | None = None,
+        downloaded: bool | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[VmRecipe]:
+        """List VM recipes with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            catalog: Filter by catalog (key or name).
+            downloaded: Filter by downloaded state.
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of VmRecipe objects.
+
+        Example:
+            >>> # List all recipes
+            >>> recipes = client.vm_recipes.list()
+
+            >>> # List downloaded recipes only
+            >>> downloaded = client.vm_recipes.list(downloaded=True)
+
+            >>> # Filter by name
+            >>> ubuntu = client.vm_recipes.list(name="Ubuntu*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add catalog filter
+        if catalog is not None:
+            if isinstance(catalog, int):
+                filters.append(f"catalog eq {catalog}")
+            elif isinstance(catalog, str):
+                # Check if it looks like a catalog key (40-char hex) or a name
+                if len(catalog) == 40 and all(
+                    c in "0123456789abcdef" for c in catalog.lower()
+                ):
+                    filters.append(f"catalog eq '{catalog}'")
+                else:
+                    # Look up catalog by name
+                    cat_response = self._client._request(
+                        "GET",
+                        "catalogs",
+                        params={
+                            "filter": f"name eq '{catalog}'",
+                            "fields": "$key",
+                            "limit": "1",
+                        },
+                    )
+                    if cat_response:
+                        if isinstance(cat_response, list):
+                            cat_response = cat_response[0] if cat_response else None
+                        if cat_response:
+                            filters.append(f"catalog eq '{cat_response.get('$key')}'")
+
+        # Add downloaded filter
+        if downloaded is not None:
+            filters.append(f"downloaded eq {1 if downloaded else 0}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: str | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> VmRecipe:
+        """Get a single VM recipe by key or name.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: Recipe name.
+            fields: List of fields to return.
+
+        Returns:
+            VmRecipe object.
+
+        Raises:
+            NotFoundError: If recipe not found.
+            ValueError: If no identifier provided.
+
+        Example:
+            >>> # Get by key
+            >>> recipe = client.vm_recipes.get("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+            >>> # Get by name
+            >>> recipe = client.vm_recipes.get(name="Ubuntu Server")
+        """
+        if key is not None:
+            # Fetch by key using id filter
+            params: dict[str, Any] = {
+                "filter": f"id eq '{key}'",
+            }
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request("GET", self._endpoint, params=params)
+
+            if response is None:
+                raise NotFoundError(f"VM recipe with key {key} not found")
+            if isinstance(response, list):
+                if not response:
+                    raise NotFoundError(f"VM recipe with key {key} not found")
+                response = response[0]
+            if not isinstance(response, dict):
+                raise NotFoundError(f"VM recipe with key {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            # Search by name
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"VM recipe with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def update(  # type: ignore[override]
+        self,
+        key: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        icon: str | None = None,
+        version: str | None = None,
+    ) -> VmRecipe:
+        """Update a VM recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: New name.
+            description: New description.
+            icon: New icon name.
+            version: New version string.
+
+        Returns:
+            Updated VmRecipe object.
+
+        Example:
+            >>> client.vm_recipes.update(recipe.key, description="Updated description")
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+
+        if description is not None:
+            body["description"] = description
+
+        if icon is not None:
+            body["icon"] = icon
+
+        if version is not None:
+            body["version"] = version
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: str) -> None:  # type: ignore[override]
+        """Delete a VM recipe.
+
+        This operation is destructive and cannot be undone.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Raises:
+            NotFoundError: If recipe not found.
+
+        Example:
+            >>> client.vm_recipes.delete(recipe.key)
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def download(self, key: str) -> dict[str, Any] | None:
+        """Download a recipe from the catalog repository.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            Task information dict or None.
+
+        Example:
+            >>> client.vm_recipes.download(recipe.key)
+        """
+        result = self._client._request(
+            "PUT", f"{self._endpoint}/{key}?action=download", json_data={}
+        )
+        if isinstance(result, dict):
+            return result
+        return None
+
+    def deploy(
+        self,
+        key: str,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+        auto_update: bool = False,
+    ) -> VmRecipeInstance:
+        """Deploy a recipe to create a new VM.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+            name: Name for the new VM.
+            answers: Recipe question answers.
+            auto_update: Auto-update when recipe updates are available.
+
+        Returns:
+            Created VmRecipeInstance object.
+
+        Example:
+            >>> instance = client.vm_recipes.deploy(
+            ...     recipe.key,
+            ...     "my-vm",
+            ...     answers={"ram": 4096, "cpu_cores": 2}
+            ... )
+        """
+        instance_mgr = VmRecipeInstanceManager(self._client)
+        return instance_mgr.create(
+            recipe=key, name=name, answers=answers, auto_update=auto_update
+        )
+
+    def instances(self, key: str) -> VmRecipeInstanceManager:
+        """Get an instance manager scoped to a specific recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            VmRecipeInstanceManager for the recipe.
+        """
+        return VmRecipeInstanceManager(self._client, recipe_key=key)
+
+    def logs(self, key: str) -> VmRecipeLogManager:
+        """Get a log manager scoped to a specific recipe.
+
+        Args:
+            key: Recipe $key (40-character hex string).
+
+        Returns:
+            VmRecipeLogManager for the recipe.
+        """
+        return VmRecipeLogManager(self._client, recipe_key=key)
+
+    def _to_model(self, data: dict[str, Any]) -> VmRecipe:
+        """Convert API response to VmRecipe object."""
+        return VmRecipe(data, self)
+
+
+class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
+    """Manager for VM recipe instance operations.
+
+    Recipe instances represent deployed VMs created from recipes.
+
+    Example:
+        >>> # List all instances
+        >>> for inst in client.vm_recipe_instances.list():
+        ...     print(f"{inst.name}: {inst.version}")
+
+        >>> # List instances for a specific recipe
+        >>> for inst in client.vm_recipes.get(name="Ubuntu").instances.list():
+        ...     print(inst.name)
+    """
+
+    _endpoint = "vm_recipe_instances"
+
+    _default_fields = [
+        "$key",
+        "recipe",
+        "recipe#$display as recipe_display",
+        "recipe#name as recipe_name",
+        "vm",
+        "vm#$display as vm_display",
+        "vm#name as vm_name",
+        "name",
+        "version",
+        "build",
+        "auto_update",
+        "created",
+        "modified",
+    ]
+
+    def __init__(
+        self, client: VergeClient, *, recipe_key: str | None = None
+    ) -> None:
+        super().__init__(client)
+        self._recipe_key = recipe_key
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        recipe: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[VmRecipeInstance]:
+        """List recipe instances with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            recipe: Filter by recipe key. Ignored if manager is scoped.
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of VmRecipeInstance objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe_key = self._recipe_key
+        if recipe_key is None and recipe is not None:
+            recipe_key = recipe
+
+        if recipe_key is not None:
+            filters.append(f"recipe eq '{recipe_key}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> VmRecipeInstance:
+        """Get a single recipe instance by key or name.
+
+        Args:
+            key: Instance $key (row ID).
+            name: Instance/VM name.
+            fields: List of fields to return.
+
+        Returns:
+            VmRecipeInstance object.
+
+        Raises:
+            NotFoundError: If instance not found.
+            ValueError: If no identifier provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Recipe instance with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(
+                    f"Recipe instance with key {key} returned invalid response"
+                )
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Recipe instance with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        recipe: str,
+        name: str,
+        *,
+        answers: dict[str, Any] | None = None,
+        auto_update: bool = False,
+    ) -> VmRecipeInstance:
+        """Create a new recipe instance (deploy a recipe).
+
+        Args:
+            recipe: Recipe $key (40-character hex string).
+            name: Name for the new VM.
+            answers: Recipe question answers.
+            auto_update: Auto-update when recipe updates are available.
+
+        Returns:
+            Created VmRecipeInstance object.
+
+        Example:
+            >>> instance = client.vm_recipe_instances.create(
+            ...     recipe="8f73f8bcc9c9...",
+            ...     name="my-vm",
+            ...     answers={"ram": 4096}
+            ... )
+        """
+        body: dict[str, Any] = {
+            "recipe": recipe,
+            "name": name,
+        }
+
+        if answers is not None:
+            body["answers"] = answers
+
+        if auto_update:
+            body["auto_update"] = True
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created instance
+        if response and isinstance(response, dict):
+            inst_key = response.get("$key")
+            if inst_key:
+                return self.get(key=inst_key)
+
+        # Fallback: search by name
+        return self.get(name=name)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        auto_update: bool | None = None,
+        answers: dict[str, Any] | None = None,
+    ) -> VmRecipeInstance:
+        """Update a recipe instance.
+
+        Args:
+            key: Instance $key (row ID).
+            auto_update: Enable or disable auto-update.
+            answers: Update recipe answers.
+
+        Returns:
+            Updated VmRecipeInstance object.
+        """
+        body: dict[str, Any] = {}
+
+        if auto_update is not None:
+            body["auto_update"] = auto_update
+
+        if answers is not None:
+            body["answers"] = answers
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a recipe instance.
+
+        Note: This typically does NOT delete the created VM.
+
+        Args:
+            key: Instance $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def _to_model(self, data: dict[str, Any]) -> VmRecipeInstance:
+        """Convert API response to VmRecipeInstance object."""
+        return VmRecipeInstance(data, self)
+
+
+class VmRecipeLogManager(ResourceManager["VmRecipeLog"]):
+    """Manager for VM recipe log operations.
+
+    Example:
+        >>> # List all recipe logs
+        >>> for log in client.vm_recipe_logs.list():
+        ...     print(f"{log.level}: {log.text}")
+
+        >>> # List logs for a specific recipe
+        >>> for log in client.vm_recipes.get(name="Ubuntu").logs.list():
+        ...     print(f"{log.level}: {log.text}")
+    """
+
+    _endpoint = "vm_recipe_logs"
+
+    _default_fields = [
+        "$key",
+        "vm_recipe",
+        "vm_recipe#name as vm_recipe_display",
+        "level",
+        "text",
+        "timestamp",
+        "user",
+    ]
+
+    def __init__(
+        self, client: VergeClient, *, recipe_key: str | None = None
+    ) -> None:
+        super().__init__(client)
+        self._recipe_key = recipe_key
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        vm_recipe: str | None = None,
+        level: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[VmRecipeLog]:
+        """List recipe logs with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            vm_recipe: Filter by recipe key. Ignored if manager is scoped.
+            level: Filter by log level.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of VmRecipeLog objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add recipe filter (from scope or parameter)
+        recipe_key = self._recipe_key
+        if recipe_key is None and vm_recipe is not None:
+            recipe_key = vm_recipe
+
+        if recipe_key is not None:
+            filters.append(f"vm_recipe eq '{recipe_key}'")
+
+        # Add level filter
+        if level is not None:
+            filters.append(f"level eq '{level}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        # Default sort by timestamp descending
+        params["sort"] = "-timestamp"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> VmRecipeLog:
+        """Get a single log entry by key.
+
+        Args:
+            key: Log entry $key (row ID).
+            fields: List of fields to return.
+
+        Returns:
+            VmRecipeLog object.
+
+        Raises:
+            NotFoundError: If log entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+        if response is None:
+            raise NotFoundError(f"Recipe log with key {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Recipe log with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def list_errors(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[VmRecipeLog]:
+        """List error and critical log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of error/critical log entries.
+        """
+        return self.list(
+            filter="(level eq 'error') or (level eq 'critical')",
+            limit=limit,
+        )
+
+    def list_warnings(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[VmRecipeLog]:
+        """List warning log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of warning log entries.
+        """
+        return self.list(level="warning", limit=limit)
+
+    def _to_model(self, data: dict[str, Any]) -> VmRecipeLog:
+        """Convert API response to VmRecipeLog object."""
+        return VmRecipeLog(data, self)

--- a/tests/unit/test_recipe_common.py
+++ b/tests/unit/test_recipe_common.py
@@ -1,0 +1,578 @@
+"""Unit tests for recipe questions and sections."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.recipe_common import (
+    RecipeQuestion,
+    RecipeQuestionManager,
+    RecipeSection,
+    RecipeSectionManager,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def recipe_question_manager(mock_client):
+    """Create a RecipeQuestionManager with mock client."""
+    return RecipeQuestionManager(mock_client)
+
+
+@pytest.fixture
+def scoped_question_manager(mock_client):
+    """Create a RecipeQuestionManager scoped to a recipe."""
+    return RecipeQuestionManager(
+        mock_client, recipe_ref="vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def section_scoped_question_manager(mock_client):
+    """Create a RecipeQuestionManager scoped to a section."""
+    return RecipeQuestionManager(mock_client, section_key=123)
+
+
+@pytest.fixture
+def recipe_section_manager(mock_client):
+    """Create a RecipeSectionManager with mock client."""
+    return RecipeSectionManager(mock_client)
+
+
+@pytest.fixture
+def scoped_section_manager(mock_client):
+    """Create a RecipeSectionManager scoped to a recipe."""
+    return RecipeSectionManager(
+        mock_client, recipe_ref="vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def sample_recipe_question():
+    """Sample recipe question data from API."""
+    return {
+        "$key": 1,
+        "recipe": "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "section": 10,
+        "section_name": "Virtual Machine",
+        "name": "YB_CPU_CORES",
+        "display": "CPU Cores",
+        "hint": "Number of CPU cores",
+        "help": "Select the number of CPU cores for this VM",
+        "note": "More cores = better performance",
+        "type": "num",
+        "default": "2",
+        "required": True,
+        "enabled": True,
+        "readonly": False,
+        "orderid": 1,
+        "min": 1,
+        "max": 64,
+    }
+
+
+@pytest.fixture
+def sample_password_question():
+    """Sample password question data from API."""
+    return {
+        "$key": 2,
+        "recipe": "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "section": 10,
+        "name": "PASSWORD",
+        "display": "Password",
+        "type": "password",
+        "required": True,
+        "enabled": True,
+        "readonly": True,
+    }
+
+
+@pytest.fixture
+def sample_list_question():
+    """Sample list question data from API."""
+    return {
+        "$key": 3,
+        "recipe": "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "section": 10,
+        "name": "DISK_TYPE",
+        "display": "Disk Type",
+        "type": "list",
+        "required": False,
+        "enabled": True,
+        "list": {"ssd": "SSD", "hdd": "HDD", "nvme": "NVMe"},
+    }
+
+
+@pytest.fixture
+def sample_hidden_question():
+    """Sample hidden question data from API."""
+    return {
+        "$key": 4,
+        "recipe": "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "section": 10,
+        "name": "YB_INTERNAL",
+        "display": "Internal",
+        "type": "hidden",
+        "default": "true",
+        "enabled": True,
+    }
+
+
+@pytest.fixture
+def sample_recipe_section():
+    """Sample recipe section data from API."""
+    return {
+        "$key": 10,
+        "recipe": "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "name": "Virtual Machine",
+        "description": "Basic VM configuration settings",
+        "orderid": 1,
+    }
+
+
+class TestRecipeQuestion:
+    """Tests for RecipeQuestion model."""
+
+    def test_recipe_ref(self, recipe_question_manager, sample_recipe_question):
+        """Test recipe_ref property."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.recipe_ref == "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_section_key(self, recipe_question_manager, sample_recipe_question):
+        """Test section_key property."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.section_key == 10
+
+    def test_question_type(self, recipe_question_manager, sample_recipe_question):
+        """Test question_type property."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.question_type == "num"
+
+    def test_is_required_true(self, recipe_question_manager, sample_recipe_question):
+        """Test is_required returns True when required."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_required is True
+
+    def test_is_required_false(self, recipe_question_manager, sample_list_question):
+        """Test is_required returns False when not required."""
+        question = RecipeQuestion(sample_list_question, recipe_question_manager)
+        assert question.is_required is False
+
+    def test_is_enabled_true(self, recipe_question_manager, sample_recipe_question):
+        """Test is_enabled returns True when enabled."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_enabled is True
+
+    def test_is_enabled_false(self, recipe_question_manager, sample_recipe_question):
+        """Test is_enabled returns False when disabled."""
+        sample_recipe_question["enabled"] = False
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_enabled is False
+
+    def test_is_readonly_true(self, recipe_question_manager, sample_password_question):
+        """Test is_readonly returns True when readonly."""
+        question = RecipeQuestion(sample_password_question, recipe_question_manager)
+        assert question.is_readonly is True
+
+    def test_is_readonly_false(self, recipe_question_manager, sample_recipe_question):
+        """Test is_readonly returns False when not readonly."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_readonly is False
+
+    def test_is_password_true(self, recipe_question_manager, sample_password_question):
+        """Test is_password returns True for password type."""
+        question = RecipeQuestion(sample_password_question, recipe_question_manager)
+        assert question.is_password is True
+
+    def test_is_password_false(self, recipe_question_manager, sample_recipe_question):
+        """Test is_password returns False for non-password type."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_password is False
+
+    def test_is_hidden_true(self, recipe_question_manager, sample_hidden_question):
+        """Test is_hidden returns True for hidden type."""
+        question = RecipeQuestion(sample_hidden_question, recipe_question_manager)
+        assert question.is_hidden is True
+
+    def test_is_hidden_false(self, recipe_question_manager, sample_recipe_question):
+        """Test is_hidden returns False for non-hidden type."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.is_hidden is False
+
+    def test_list_options(self, recipe_question_manager, sample_list_question):
+        """Test list_options returns options for list type."""
+        question = RecipeQuestion(sample_list_question, recipe_question_manager)
+        assert question.list_options == {"ssd": "SSD", "hdd": "HDD", "nvme": "NVMe"}
+
+    def test_list_options_none_for_non_list(
+        self, recipe_question_manager, sample_recipe_question
+    ):
+        """Test list_options returns None for non-list type."""
+        question = RecipeQuestion(sample_recipe_question, recipe_question_manager)
+        assert question.list_options is None
+
+
+class TestRecipeQuestionManagerList:
+    """Tests for RecipeQuestionManager.list()."""
+
+    def test_list_all(self, recipe_question_manager, mock_client, sample_recipe_question):
+        """Test listing all questions."""
+        mock_client._request.return_value = [sample_recipe_question]
+
+        result = recipe_question_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "YB_CPU_CORES"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "recipe_questions"
+        # Should sort by orderid
+        assert args[1]["params"]["sort"] == "+orderid"
+
+    def test_list_empty(self, recipe_question_manager, mock_client):
+        """Test listing when no questions exist."""
+        mock_client._request.return_value = None
+
+        result = recipe_question_manager.list()
+
+        assert result == []
+
+    def test_list_scoped_to_recipe(
+        self, scoped_question_manager, mock_client, sample_recipe_question
+    ):
+        """Test listing questions scoped to a recipe."""
+        mock_client._request.return_value = [sample_recipe_question]
+
+        result = scoped_question_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert (
+            "recipe eq 'vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554'"
+            in args[1]["params"]["filter"]
+        )
+
+    def test_list_scoped_to_section(
+        self, section_scoped_question_manager, mock_client, sample_recipe_question
+    ):
+        """Test listing questions scoped to a section."""
+        mock_client._request.return_value = [sample_recipe_question]
+
+        result = section_scoped_question_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "section eq 123" in args[1]["params"]["filter"]
+
+    def test_list_with_enabled_filter(
+        self, recipe_question_manager, mock_client, sample_recipe_question
+    ):
+        """Test listing with enabled filter."""
+        mock_client._request.return_value = [sample_recipe_question]
+
+        result = recipe_question_manager.list(enabled=True)
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "enabled eq 1" in args[1]["params"]["filter"]
+
+
+class TestRecipeQuestionManagerGet:
+    """Tests for RecipeQuestionManager.get()."""
+
+    def test_get_by_key(
+        self, recipe_question_manager, mock_client, sample_recipe_question
+    ):
+        """Test getting question by key."""
+        mock_client._request.return_value = sample_recipe_question
+
+        result = recipe_question_manager.get(key=1)
+
+        assert result.name == "YB_CPU_CORES"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "recipe_questions/1"
+
+    def test_get_by_name(
+        self, recipe_question_manager, mock_client, sample_recipe_question
+    ):
+        """Test getting question by name."""
+        mock_client._request.return_value = [sample_recipe_question]
+
+        result = recipe_question_manager.get(name="YB_CPU_CORES")
+
+        assert result.name == "YB_CPU_CORES"
+        args = mock_client._request.call_args
+        assert "name eq 'YB_CPU_CORES'" in args[1]["params"]["filter"]
+
+    def test_get_not_found(self, recipe_question_manager, mock_client):
+        """Test getting non-existent question."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError, match="not found"):
+            recipe_question_manager.get(key=999)
+
+    def test_get_no_key_or_name(self, recipe_question_manager):
+        """Test get without key or name raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            recipe_question_manager.get()
+
+
+class TestRecipeQuestionManagerCreate:
+    """Tests for RecipeQuestionManager.create()."""
+
+    def test_create(self, recipe_question_manager, mock_client, sample_recipe_question):
+        """Test creating a question."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # Create
+            sample_recipe_question,  # Get created
+        ]
+
+        result = recipe_question_manager.create(
+            name="YB_CPU_CORES",
+            recipe_ref="vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            section=10,
+            question_type="num",
+            display="CPU Cores",
+            default="2",
+            required=True,
+            min_value=1,
+            max_value=64,
+        )
+
+        assert result.name == "YB_CPU_CORES"
+        create_call = mock_client._request.call_args_list[0]
+        assert create_call[0][0] == "POST"
+        assert create_call[0][1] == "recipe_questions"
+        body = create_call[1]["json_data"]
+        assert body["name"] == "YB_CPU_CORES"
+        assert body["recipe"] == "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        assert body["section"] == 10
+        assert body["type"] == "num"
+        assert body["display"] == "CPU Cores"
+        assert body["default"] == "2"
+        assert body["required"] is True
+        assert body["min"] == 1
+        assert body["max"] == 64
+
+
+class TestRecipeQuestionManagerUpdate:
+    """Tests for RecipeQuestionManager.update()."""
+
+    def test_update(self, recipe_question_manager, mock_client, sample_recipe_question):
+        """Test updating a question."""
+        mock_client._request.side_effect = [
+            None,  # Update
+            sample_recipe_question,  # Get updated
+        ]
+
+        result = recipe_question_manager.update(
+            key=1,
+            display="Number of CPU Cores",
+            default="4",
+            required=False,
+        )
+
+        assert result is not None
+        update_call = mock_client._request.call_args_list[0]
+        assert update_call[0][0] == "PUT"
+        assert update_call[0][1] == "recipe_questions/1"
+        body = update_call[1]["json_data"]
+        assert body["display"] == "Number of CPU Cores"
+        assert body["default"] == "4"
+        assert body["required"] is False
+
+
+class TestRecipeQuestionManagerDelete:
+    """Tests for RecipeQuestionManager.delete()."""
+
+    def test_delete(self, recipe_question_manager, mock_client):
+        """Test deleting a question."""
+        mock_client._request.return_value = None
+
+        recipe_question_manager.delete(1)
+
+        delete_call = mock_client._request.call_args
+        assert delete_call[0][0] == "DELETE"
+        assert delete_call[0][1] == "recipe_questions/1"
+
+
+# =============================================================================
+# Recipe Section Tests
+# =============================================================================
+
+
+class TestRecipeSection:
+    """Tests for RecipeSection model."""
+
+    def test_recipe_ref(self, recipe_section_manager, sample_recipe_section):
+        """Test recipe_ref property."""
+        section = RecipeSection(sample_recipe_section, recipe_section_manager)
+        assert section.recipe_ref == "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+
+class TestRecipeSectionManagerList:
+    """Tests for RecipeSectionManager.list()."""
+
+    def test_list_all(self, recipe_section_manager, mock_client, sample_recipe_section):
+        """Test listing all sections."""
+        mock_client._request.return_value = [sample_recipe_section]
+
+        result = recipe_section_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "Virtual Machine"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "recipe_sections"
+        # Should sort by orderid
+        assert args[1]["params"]["sort"] == "+orderid"
+
+    def test_list_empty(self, recipe_section_manager, mock_client):
+        """Test listing when no sections exist."""
+        mock_client._request.return_value = None
+
+        result = recipe_section_manager.list()
+
+        assert result == []
+
+    def test_list_scoped_to_recipe(
+        self, scoped_section_manager, mock_client, sample_recipe_section
+    ):
+        """Test listing sections scoped to a recipe."""
+        mock_client._request.return_value = [sample_recipe_section]
+
+        result = scoped_section_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert (
+            "recipe eq 'vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554'"
+            in args[1]["params"]["filter"]
+        )
+
+
+class TestRecipeSectionManagerGet:
+    """Tests for RecipeSectionManager.get()."""
+
+    def test_get_by_key(self, recipe_section_manager, mock_client, sample_recipe_section):
+        """Test getting section by key."""
+        mock_client._request.return_value = sample_recipe_section
+
+        result = recipe_section_manager.get(key=10)
+
+        assert result.name == "Virtual Machine"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "recipe_sections/10"
+
+    def test_get_by_name(
+        self, recipe_section_manager, mock_client, sample_recipe_section
+    ):
+        """Test getting section by name."""
+        mock_client._request.return_value = [sample_recipe_section]
+
+        result = recipe_section_manager.get(name="Virtual Machine")
+
+        assert result.name == "Virtual Machine"
+        args = mock_client._request.call_args
+        assert "name eq 'Virtual Machine'" in args[1]["params"]["filter"]
+
+    def test_get_not_found(self, recipe_section_manager, mock_client):
+        """Test getting non-existent section."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError, match="not found"):
+            recipe_section_manager.get(key=999)
+
+    def test_get_no_key_or_name(self, recipe_section_manager):
+        """Test get without key or name raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            recipe_section_manager.get()
+
+
+class TestRecipeSectionManagerCreate:
+    """Tests for RecipeSectionManager.create()."""
+
+    def test_create(self, recipe_section_manager, mock_client, sample_recipe_section):
+        """Test creating a section."""
+        mock_client._request.side_effect = [
+            {"$key": 10},  # Create
+            sample_recipe_section,  # Get created
+        ]
+
+        result = recipe_section_manager.create(
+            name="Virtual Machine",
+            recipe_ref="vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            description="Basic VM configuration settings",
+        )
+
+        assert result.name == "Virtual Machine"
+        create_call = mock_client._request.call_args_list[0]
+        assert create_call[0][0] == "POST"
+        assert create_call[0][1] == "recipe_sections"
+        body = create_call[1]["json_data"]
+        assert body["name"] == "Virtual Machine"
+        assert body["recipe"] == "vm_recipes/8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        assert body["description"] == "Basic VM configuration settings"
+
+
+class TestRecipeSectionManagerUpdate:
+    """Tests for RecipeSectionManager.update()."""
+
+    def test_update(self, recipe_section_manager, mock_client, sample_recipe_section):
+        """Test updating a section."""
+        mock_client._request.side_effect = [
+            None,  # Update
+            sample_recipe_section,  # Get updated
+        ]
+
+        result = recipe_section_manager.update(
+            key=10,
+            name="VM Settings",
+            description="Updated description",
+        )
+
+        assert result is not None
+        update_call = mock_client._request.call_args_list[0]
+        assert update_call[0][0] == "PUT"
+        assert update_call[0][1] == "recipe_sections/10"
+        body = update_call[1]["json_data"]
+        assert body["name"] == "VM Settings"
+        assert body["description"] == "Updated description"
+
+
+class TestRecipeSectionManagerDelete:
+    """Tests for RecipeSectionManager.delete()."""
+
+    def test_delete(self, recipe_section_manager, mock_client):
+        """Test deleting a section."""
+        mock_client._request.return_value = None
+
+        recipe_section_manager.delete(10)
+
+        delete_call = mock_client._request.call_args
+        assert delete_call[0][0] == "DELETE"
+        assert delete_call[0][1] == "recipe_sections/10"
+
+
+class TestRecipeSectionManagerQuestions:
+    """Tests for RecipeSectionManager.questions()."""
+
+    def test_get_questions_manager(self, recipe_section_manager, mock_client):
+        """Test getting a scoped questions manager."""
+        q_mgr = recipe_section_manager.questions(10)
+
+        assert isinstance(q_mgr, RecipeQuestionManager)
+        assert q_mgr._section_key == 10

--- a/tests/unit/test_tenant_recipes.py
+++ b/tests/unit/test_tenant_recipes.py
@@ -1,0 +1,567 @@
+"""Unit tests for tenant recipe management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.tenant_recipes import (
+    TenantRecipe,
+    TenantRecipeInstance,
+    TenantRecipeInstanceManager,
+    TenantRecipeLog,
+    TenantRecipeLogManager,
+    TenantRecipeManager,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def tenant_recipe_manager(mock_client):
+    """Create a TenantRecipeManager with mock client."""
+    return TenantRecipeManager(mock_client)
+
+
+@pytest.fixture
+def tenant_recipe_instance_manager(mock_client):
+    """Create a TenantRecipeInstanceManager with mock client."""
+    return TenantRecipeInstanceManager(mock_client)
+
+
+@pytest.fixture
+def scoped_instance_manager(mock_client):
+    """Create a scoped TenantRecipeInstanceManager with mock client."""
+    return TenantRecipeInstanceManager(
+        mock_client, recipe_key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def tenant_recipe_log_manager(mock_client):
+    """Create a TenantRecipeLogManager with mock client."""
+    return TenantRecipeLogManager(mock_client)
+
+
+@pytest.fixture
+def scoped_log_manager(mock_client):
+    """Create a scoped TenantRecipeLogManager with mock client."""
+    return TenantRecipeLogManager(
+        mock_client, recipe_key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def sample_tenant_recipe():
+    """Sample tenant recipe data from API."""
+    return {
+        "$key": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "id": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "name": "Standard Tenant",
+        "description": "Standard tenant template",
+        "icon": "building",
+        "version": "1.0.0",
+        "build": 3,
+        "catalog": "abc123def456...",
+        "catalog_display": "Local Catalog",
+        "status": "online",
+        "rstatus": "online",
+        "downloaded": True,
+        "update_available": False,
+        "needs_republish": False,
+        "preserve_certs": True,
+        "tenant": 5,
+        "tenant_display": "tenant-template",
+        "tenant_snapshot": 1,
+        "snapshot_display": "initial",
+        "instances": 2,
+        "creator": "admin",
+    }
+
+
+@pytest.fixture
+def sample_tenant_recipe_not_downloaded():
+    """Sample tenant recipe that is not downloaded."""
+    return {
+        "$key": "9a84a8bdd0d0e2bcbb43e844cec3a6bdbe659665",
+        "id": "9a84a8bdd0d0e2bcbb43e844cec3a6bdbe659665",
+        "name": "Enterprise Tenant",
+        "description": "Enterprise tenant template",
+        "version": "2.0.0",
+        "downloaded": False,
+        "update_available": True,
+    }
+
+
+@pytest.fixture
+def sample_tenant_recipe_instance():
+    """Sample tenant recipe instance data from API."""
+    return {
+        "$key": 1,
+        "recipe": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "recipe_display": "Standard Tenant",
+        "recipe_name": "Standard Tenant",
+        "tenant": 10,
+        "tenant_display": "my-tenant",
+        "tenant_name": "my-tenant",
+        "name": "my-tenant",
+        "version": "1.0.0",
+        "build": 3,
+        "created": 1700000000,
+        "modified": 1700001000,
+    }
+
+
+@pytest.fixture
+def sample_tenant_recipe_log():
+    """Sample tenant recipe log data from API."""
+    return {
+        "$key": 1,
+        "tenant_recipe": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "tenant_recipe_display": "Standard Tenant",
+        "level": "message",
+        "text": "Recipe deployed successfully",
+        "timestamp": 1700000000,
+        "user": "admin",
+    }
+
+
+class TestTenantRecipe:
+    """Tests for TenantRecipe model."""
+
+    def test_key_is_string(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test that recipe key is a string (40-char hex)."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert isinstance(recipe.key, str)
+        assert len(recipe.key) == 40
+
+    def test_key_missing(self, tenant_recipe_manager):
+        """Test key property raises ValueError when missing."""
+        recipe = TenantRecipe({}, tenant_recipe_manager)
+        with pytest.raises(ValueError, match="has no \\$key"):
+            _ = recipe.key
+
+    def test_is_downloaded_true(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test is_downloaded returns True when downloaded."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.is_downloaded is True
+
+    def test_is_downloaded_false(
+        self, tenant_recipe_manager, sample_tenant_recipe_not_downloaded
+    ):
+        """Test is_downloaded returns False when not downloaded."""
+        recipe = TenantRecipe(sample_tenant_recipe_not_downloaded, tenant_recipe_manager)
+        assert recipe.is_downloaded is False
+
+    def test_has_update_true(
+        self, tenant_recipe_manager, sample_tenant_recipe_not_downloaded
+    ):
+        """Test has_update returns True when update available."""
+        recipe = TenantRecipe(sample_tenant_recipe_not_downloaded, tenant_recipe_manager)
+        assert recipe.has_update is True
+
+    def test_has_update_false(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test has_update returns False when no update available."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.has_update is False
+
+    def test_status_info(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test status_info property."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.status_info == "online"
+
+    def test_catalog_key(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test catalog_key property."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.catalog_key == "abc123def456..."
+
+    def test_tenant_key(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test tenant_key property."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.tenant_key == 5
+
+    def test_tenant_key_none(
+        self, tenant_recipe_manager, sample_tenant_recipe_not_downloaded
+    ):
+        """Test tenant_key returns None when not set."""
+        recipe = TenantRecipe(sample_tenant_recipe_not_downloaded, tenant_recipe_manager)
+        assert recipe.tenant_key is None
+
+    def test_instance_count(self, tenant_recipe_manager, sample_tenant_recipe):
+        """Test instance_count property."""
+        recipe = TenantRecipe(sample_tenant_recipe, tenant_recipe_manager)
+        assert recipe.instance_count == 2
+
+
+class TestTenantRecipeManagerList:
+    """Tests for TenantRecipeManager.list()."""
+
+    def test_list_all(self, tenant_recipe_manager, mock_client, sample_tenant_recipe):
+        """Test listing all recipes."""
+        mock_client._request.return_value = [sample_tenant_recipe]
+
+        result = tenant_recipe_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "Standard Tenant"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "tenant_recipes"
+
+    def test_list_empty(self, tenant_recipe_manager, mock_client):
+        """Test listing when no recipes exist."""
+        mock_client._request.return_value = None
+
+        result = tenant_recipe_manager.list()
+
+        assert result == []
+
+    def test_list_with_filter(
+        self, tenant_recipe_manager, mock_client, sample_tenant_recipe
+    ):
+        """Test listing with filter."""
+        mock_client._request.return_value = [sample_tenant_recipe]
+
+        result = tenant_recipe_manager.list(filter="name eq 'Standard Tenant'")
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "filter" in args[1]["params"]
+        assert args[1]["params"]["filter"] == "name eq 'Standard Tenant'"
+
+    def test_list_with_downloaded_filter(
+        self, tenant_recipe_manager, mock_client, sample_tenant_recipe
+    ):
+        """Test listing with downloaded filter."""
+        mock_client._request.return_value = [sample_tenant_recipe]
+
+        result = tenant_recipe_manager.list(downloaded=True)
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "downloaded eq 1" in args[1]["params"]["filter"]
+
+
+class TestTenantRecipeManagerGet:
+    """Tests for TenantRecipeManager.get()."""
+
+    def test_get_by_key(self, tenant_recipe_manager, mock_client, sample_tenant_recipe):
+        """Test getting recipe by key."""
+        mock_client._request.return_value = [sample_tenant_recipe]
+
+        result = tenant_recipe_manager.get(
+            key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        )
+
+        assert result.name == "Standard Tenant"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert (
+            "id eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'"
+            in args[1]["params"]["filter"]
+        )
+
+    def test_get_by_name(self, tenant_recipe_manager, mock_client, sample_tenant_recipe):
+        """Test getting recipe by name."""
+        mock_client._request.return_value = [sample_tenant_recipe]
+
+        result = tenant_recipe_manager.get(name="Standard Tenant")
+
+        assert result.name == "Standard Tenant"
+        args = mock_client._request.call_args
+        assert "name eq 'Standard Tenant'" in args[1]["params"]["filter"]
+
+    def test_get_not_found_by_key(self, tenant_recipe_manager, mock_client):
+        """Test getting non-existent recipe by key."""
+        mock_client._request.return_value = []
+
+        with pytest.raises(NotFoundError, match="not found"):
+            tenant_recipe_manager.get(key="nonexistent")
+
+    def test_get_no_key_or_name(self, tenant_recipe_manager):
+        """Test get without key or name raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            tenant_recipe_manager.get()
+
+
+class TestTenantRecipeManagerUpdate:
+    """Tests for TenantRecipeManager.update()."""
+
+    def test_update_description(
+        self, tenant_recipe_manager, mock_client, sample_tenant_recipe
+    ):
+        """Test updating recipe description."""
+        mock_client._request.side_effect = [
+            None,  # Update
+            [sample_tenant_recipe],  # Get updated recipe
+        ]
+
+        result = tenant_recipe_manager.update(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            description="New description",
+        )
+
+        assert result is not None
+        update_call = mock_client._request.call_args_list[0]
+        assert update_call[0][0] == "PUT"
+        assert "8f73f8bcc9c9f1aaba32f733bfc295acaf548554" in update_call[0][1]
+        assert update_call[1]["json_data"]["description"] == "New description"
+
+    def test_update_preserve_certs(
+        self, tenant_recipe_manager, mock_client, sample_tenant_recipe
+    ):
+        """Test updating preserve_certs setting."""
+        mock_client._request.side_effect = [
+            None,  # Update
+            [sample_tenant_recipe],  # Get updated recipe
+        ]
+
+        tenant_recipe_manager.update(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            preserve_certs=False,
+        )
+
+        update_call = mock_client._request.call_args_list[0]
+        assert update_call[1]["json_data"]["preserve_certs"] is False
+
+
+class TestTenantRecipeManagerDelete:
+    """Tests for TenantRecipeManager.delete()."""
+
+    def test_delete(self, tenant_recipe_manager, mock_client):
+        """Test deleting a recipe."""
+        mock_client._request.return_value = None
+
+        tenant_recipe_manager.delete("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        delete_call = mock_client._request.call_args
+        assert delete_call[0][0] == "DELETE"
+        assert "8f73f8bcc9c9f1aaba32f733bfc295acaf548554" in delete_call[0][1]
+
+
+class TestTenantRecipeManagerActions:
+    """Tests for tenant recipe actions."""
+
+    def test_download(self, tenant_recipe_manager, mock_client):
+        """Test downloading a recipe."""
+        mock_client._request.return_value = {"task": 123}
+
+        result = tenant_recipe_manager.download(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        )
+
+        assert result == {"task": 123}
+        action_call = mock_client._request.call_args
+        assert action_call[0][0] == "PUT"
+        assert "action=download" in action_call[0][1]
+
+    def test_get_instances_manager(self, tenant_recipe_manager, mock_client):
+        """Test getting a scoped instances manager."""
+        inst_mgr = tenant_recipe_manager.instances(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        )
+
+        assert isinstance(inst_mgr, TenantRecipeInstanceManager)
+        assert inst_mgr._recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_get_logs_manager(self, tenant_recipe_manager, mock_client):
+        """Test getting a scoped logs manager."""
+        log_mgr = tenant_recipe_manager.logs(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        )
+
+        assert isinstance(log_mgr, TenantRecipeLogManager)
+        assert log_mgr._recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+
+# =============================================================================
+# Tenant Recipe Instance Tests
+# =============================================================================
+
+
+class TestTenantRecipeInstance:
+    """Tests for TenantRecipeInstance model."""
+
+    def test_recipe_key(
+        self, tenant_recipe_instance_manager, sample_tenant_recipe_instance
+    ):
+        """Test recipe_key property."""
+        inst = TenantRecipeInstance(
+            sample_tenant_recipe_instance, tenant_recipe_instance_manager
+        )
+        assert inst.recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_tenant_key(
+        self, tenant_recipe_instance_manager, sample_tenant_recipe_instance
+    ):
+        """Test tenant_key property."""
+        inst = TenantRecipeInstance(
+            sample_tenant_recipe_instance, tenant_recipe_instance_manager
+        )
+        assert inst.tenant_key == 10
+
+
+class TestTenantRecipeInstanceManagerList:
+    """Tests for TenantRecipeInstanceManager.list()."""
+
+    def test_list_all(
+        self, tenant_recipe_instance_manager, mock_client, sample_tenant_recipe_instance
+    ):
+        """Test listing all instances."""
+        mock_client._request.return_value = [sample_tenant_recipe_instance]
+
+        result = tenant_recipe_instance_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "my-tenant"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "tenant_recipe_instances"
+
+    def test_list_scoped_to_recipe(
+        self, scoped_instance_manager, mock_client, sample_tenant_recipe_instance
+    ):
+        """Test listing instances scoped to a recipe."""
+        mock_client._request.return_value = [sample_tenant_recipe_instance]
+
+        result = scoped_instance_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert (
+            "recipe eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'"
+            in args[1]["params"]["filter"]
+        )
+
+
+class TestTenantRecipeInstanceManagerCreate:
+    """Tests for TenantRecipeInstanceManager.create()."""
+
+    def test_create(
+        self, tenant_recipe_instance_manager, mock_client, sample_tenant_recipe_instance
+    ):
+        """Test creating a recipe instance."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # Create
+            sample_tenant_recipe_instance,  # Get created
+        ]
+
+        result = tenant_recipe_instance_manager.create(
+            recipe="8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            name="my-tenant",
+            answers={"storage_gb": 500},
+        )
+
+        assert result.name == "my-tenant"
+        create_call = mock_client._request.call_args_list[0]
+        assert create_call[0][0] == "POST"
+        assert create_call[0][1] == "tenant_recipe_instances"
+        body = create_call[1]["json_data"]
+        assert body["recipe"] == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        assert body["name"] == "my-tenant"
+        assert body["answers"] == {"storage_gb": 500}
+
+
+# =============================================================================
+# Tenant Recipe Log Tests
+# =============================================================================
+
+
+class TestTenantRecipeLog:
+    """Tests for TenantRecipeLog model."""
+
+    def test_recipe_key(self, tenant_recipe_log_manager, sample_tenant_recipe_log):
+        """Test recipe_key property."""
+        log = TenantRecipeLog(sample_tenant_recipe_log, tenant_recipe_log_manager)
+        assert log.recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_is_error_true(self, tenant_recipe_log_manager, sample_tenant_recipe_log):
+        """Test is_error returns True for error level."""
+        sample_tenant_recipe_log["level"] = "error"
+        log = TenantRecipeLog(sample_tenant_recipe_log, tenant_recipe_log_manager)
+        assert log.is_error is True
+
+    def test_is_error_false(self, tenant_recipe_log_manager, sample_tenant_recipe_log):
+        """Test is_error returns False for message level."""
+        log = TenantRecipeLog(sample_tenant_recipe_log, tenant_recipe_log_manager)
+        assert log.is_error is False
+
+    def test_is_warning_true(self, tenant_recipe_log_manager, sample_tenant_recipe_log):
+        """Test is_warning returns True for warning level."""
+        sample_tenant_recipe_log["level"] = "warning"
+        log = TenantRecipeLog(sample_tenant_recipe_log, tenant_recipe_log_manager)
+        assert log.is_warning is True
+
+
+class TestTenantRecipeLogManagerList:
+    """Tests for TenantRecipeLogManager.list()."""
+
+    def test_list_all(
+        self, tenant_recipe_log_manager, mock_client, sample_tenant_recipe_log
+    ):
+        """Test listing all logs."""
+        mock_client._request.return_value = [sample_tenant_recipe_log]
+
+        result = tenant_recipe_log_manager.list()
+
+        assert len(result) == 1
+        assert result[0].text == "Recipe deployed successfully"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "tenant_recipe_logs"
+
+    def test_list_scoped_to_recipe(
+        self, scoped_log_manager, mock_client, sample_tenant_recipe_log
+    ):
+        """Test listing logs scoped to a recipe."""
+        mock_client._request.return_value = [sample_tenant_recipe_log]
+
+        result = scoped_log_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert (
+            "tenant_recipe eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'"
+            in args[1]["params"]["filter"]
+        )
+
+
+class TestTenantRecipeLogManagerHelpers:
+    """Tests for TenantRecipeLogManager helper methods."""
+
+    def test_list_errors(self, scoped_log_manager, mock_client, sample_tenant_recipe_log):
+        """Test list_errors helper."""
+        sample_tenant_recipe_log["level"] = "error"
+        mock_client._request.return_value = [sample_tenant_recipe_log]
+
+        result = scoped_log_manager.list_errors()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert (
+            "(level eq 'error') or (level eq 'critical')"
+            in args[1]["params"]["filter"]
+        )
+
+    def test_list_warnings(
+        self, scoped_log_manager, mock_client, sample_tenant_recipe_log
+    ):
+        """Test list_warnings helper."""
+        sample_tenant_recipe_log["level"] = "warning"
+        mock_client._request.return_value = [sample_tenant_recipe_log]
+
+        result = scoped_log_manager.list_warnings()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "level eq 'warning'" in args[1]["params"]["filter"]

--- a/tests/unit/test_vm_recipes.py
+++ b/tests/unit/test_vm_recipes.py
@@ -1,0 +1,683 @@
+"""Unit tests for VM recipe management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.vm_recipes import (
+    VmRecipe,
+    VmRecipeInstance,
+    VmRecipeInstanceManager,
+    VmRecipeLog,
+    VmRecipeLogManager,
+    VmRecipeManager,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def vm_recipe_manager(mock_client):
+    """Create a VmRecipeManager with mock client."""
+    return VmRecipeManager(mock_client)
+
+
+@pytest.fixture
+def vm_recipe_instance_manager(mock_client):
+    """Create a VmRecipeInstanceManager with mock client."""
+    return VmRecipeInstanceManager(mock_client)
+
+
+@pytest.fixture
+def scoped_instance_manager(mock_client):
+    """Create a scoped VmRecipeInstanceManager with mock client."""
+    return VmRecipeInstanceManager(
+        mock_client, recipe_key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def vm_recipe_log_manager(mock_client):
+    """Create a VmRecipeLogManager with mock client."""
+    return VmRecipeLogManager(mock_client)
+
+
+@pytest.fixture
+def scoped_log_manager(mock_client):
+    """Create a scoped VmRecipeLogManager with mock client."""
+    return VmRecipeLogManager(
+        mock_client, recipe_key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+    )
+
+
+@pytest.fixture
+def sample_vm_recipe():
+    """Sample VM recipe data from API."""
+    return {
+        "$key": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "id": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "name": "Ubuntu Server",
+        "description": "Ubuntu Server LTS",
+        "icon": "server",
+        "version": "1.0.0",
+        "build": 5,
+        "catalog": "abc123def456...",
+        "catalog_display": "Local Catalog",
+        "status": "online",
+        "rstatus": "online",
+        "downloaded": True,
+        "update_available": False,
+        "needs_republish": False,
+        "vm": 10,
+        "vm_display": "ubuntu-template",
+        "vm_snapshot": 1,
+        "snapshot_display": "initial",
+        "instances": 3,
+        "creator": "admin",
+    }
+
+
+@pytest.fixture
+def sample_vm_recipe_not_downloaded():
+    """Sample VM recipe that is not downloaded."""
+    return {
+        "$key": "9a84a8bdd0d0e2bcbb43e844cec3a6bdbe659665",
+        "id": "9a84a8bdd0d0e2bcbb43e844cec3a6bdbe659665",
+        "name": "CentOS 7",
+        "description": "CentOS 7 Latest",
+        "version": "1.0.0",
+        "downloaded": False,
+        "update_available": True,
+    }
+
+
+@pytest.fixture
+def sample_vm_recipe_instance():
+    """Sample VM recipe instance data from API."""
+    return {
+        "$key": 1,
+        "recipe": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "recipe_display": "Ubuntu Server",
+        "recipe_name": "Ubuntu Server",
+        "vm": 10,
+        "vm_display": "my-ubuntu",
+        "vm_name": "my-ubuntu",
+        "name": "my-ubuntu",
+        "version": "1.0.0",
+        "build": 5,
+        "auto_update": True,
+        "created": 1700000000,
+        "modified": 1700001000,
+    }
+
+
+@pytest.fixture
+def sample_vm_recipe_log():
+    """Sample VM recipe log data from API."""
+    return {
+        "$key": 1,
+        "vm_recipe": "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+        "vm_recipe_display": "Ubuntu Server",
+        "level": "message",
+        "text": "Recipe deployed successfully",
+        "timestamp": 1700000000,
+        "user": "admin",
+    }
+
+
+class TestVmRecipe:
+    """Tests for VmRecipe model."""
+
+    def test_key_is_string(self, vm_recipe_manager, sample_vm_recipe):
+        """Test that recipe key is a string (40-char hex)."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert isinstance(recipe.key, str)
+        assert len(recipe.key) == 40
+
+    def test_key_missing(self, vm_recipe_manager):
+        """Test key property raises ValueError when missing."""
+        recipe = VmRecipe({}, vm_recipe_manager)
+        with pytest.raises(ValueError, match="has no \\$key"):
+            _ = recipe.key
+
+    def test_is_downloaded_true(self, vm_recipe_manager, sample_vm_recipe):
+        """Test is_downloaded returns True when downloaded."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.is_downloaded is True
+
+    def test_is_downloaded_false(self, vm_recipe_manager, sample_vm_recipe_not_downloaded):
+        """Test is_downloaded returns False when not downloaded."""
+        recipe = VmRecipe(sample_vm_recipe_not_downloaded, vm_recipe_manager)
+        assert recipe.is_downloaded is False
+
+    def test_has_update_true(self, vm_recipe_manager, sample_vm_recipe_not_downloaded):
+        """Test has_update returns True when update available."""
+        recipe = VmRecipe(sample_vm_recipe_not_downloaded, vm_recipe_manager)
+        assert recipe.has_update is True
+
+    def test_has_update_false(self, vm_recipe_manager, sample_vm_recipe):
+        """Test has_update returns False when no update available."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.has_update is False
+
+    def test_status_info(self, vm_recipe_manager, sample_vm_recipe):
+        """Test status_info property."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.status_info == "online"
+
+    def test_catalog_key(self, vm_recipe_manager, sample_vm_recipe):
+        """Test catalog_key property."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.catalog_key == "abc123def456..."
+
+    def test_vm_key(self, vm_recipe_manager, sample_vm_recipe):
+        """Test vm_key property."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.vm_key == 10
+
+    def test_vm_key_none(self, vm_recipe_manager, sample_vm_recipe_not_downloaded):
+        """Test vm_key returns None when not set."""
+        recipe = VmRecipe(sample_vm_recipe_not_downloaded, vm_recipe_manager)
+        assert recipe.vm_key is None
+
+    def test_instance_count(self, vm_recipe_manager, sample_vm_recipe):
+        """Test instance_count property."""
+        recipe = VmRecipe(sample_vm_recipe, vm_recipe_manager)
+        assert recipe.instance_count == 3
+
+
+class TestVmRecipeManagerList:
+    """Tests for VmRecipeManager.list()."""
+
+    def test_list_all(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test listing all recipes."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "Ubuntu Server"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "vm_recipes"
+
+    def test_list_empty(self, vm_recipe_manager, mock_client):
+        """Test listing when no recipes exist."""
+        mock_client._request.return_value = None
+
+        result = vm_recipe_manager.list()
+
+        assert result == []
+
+    def test_list_with_filter(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test listing with filter."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.list(filter="name eq 'Ubuntu Server'")
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "filter" in args[1]["params"]
+        assert args[1]["params"]["filter"] == "name eq 'Ubuntu Server'"
+
+    def test_list_with_downloaded_filter(
+        self, vm_recipe_manager, mock_client, sample_vm_recipe
+    ):
+        """Test listing with downloaded filter."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.list(downloaded=True)
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "downloaded eq 1" in args[1]["params"]["filter"]
+
+    def test_list_with_pagination(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test listing with pagination."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.list(limit=10, offset=5)
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert args[1]["params"]["limit"] == 10
+        assert args[1]["params"]["offset"] == 5
+
+
+class TestVmRecipeManagerGet:
+    """Tests for VmRecipeManager.get()."""
+
+    def test_get_by_key(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test getting recipe by key."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.get(key="8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        assert result.name == "Ubuntu Server"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert "id eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'" in args[1]["params"]["filter"]
+
+    def test_get_by_name(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test getting recipe by name."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        result = vm_recipe_manager.get(name="Ubuntu Server")
+
+        assert result.name == "Ubuntu Server"
+        args = mock_client._request.call_args
+        assert "name eq 'Ubuntu Server'" in args[1]["params"]["filter"]
+
+    def test_get_not_found_by_key(self, vm_recipe_manager, mock_client):
+        """Test getting non-existent recipe by key."""
+        mock_client._request.return_value = []
+
+        with pytest.raises(NotFoundError, match="not found"):
+            vm_recipe_manager.get(key="nonexistent")
+
+    def test_get_not_found_by_name(self, vm_recipe_manager, mock_client):
+        """Test getting non-existent recipe by name."""
+        mock_client._request.return_value = []
+
+        with pytest.raises(NotFoundError, match="not found"):
+            vm_recipe_manager.get(name="nonexistent")
+
+    def test_get_no_key_or_name(self, vm_recipe_manager):
+        """Test get without key or name raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            vm_recipe_manager.get()
+
+
+class TestVmRecipeManagerUpdate:
+    """Tests for VmRecipeManager.update()."""
+
+    def test_update_description(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test updating recipe description."""
+        mock_client._request.side_effect = [
+            None,  # Update
+            [sample_vm_recipe],  # Get updated recipe
+        ]
+
+        result = vm_recipe_manager.update(
+            "8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            description="New description",
+        )
+
+        assert result is not None
+        update_call = mock_client._request.call_args_list[0]
+        assert update_call[0][0] == "PUT"
+        assert "8f73f8bcc9c9f1aaba32f733bfc295acaf548554" in update_call[0][1]
+        assert update_call[1]["json_data"]["description"] == "New description"
+
+    def test_update_no_changes(self, vm_recipe_manager, mock_client, sample_vm_recipe):
+        """Test update with no changes."""
+        mock_client._request.return_value = [sample_vm_recipe]
+
+        vm_recipe_manager.update("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        # Should only call get, not update
+        assert mock_client._request.call_count == 1
+
+
+class TestVmRecipeManagerDelete:
+    """Tests for VmRecipeManager.delete()."""
+
+    def test_delete(self, vm_recipe_manager, mock_client):
+        """Test deleting a recipe."""
+        mock_client._request.return_value = None
+
+        vm_recipe_manager.delete("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        delete_call = mock_client._request.call_args
+        assert delete_call[0][0] == "DELETE"
+        assert "8f73f8bcc9c9f1aaba32f733bfc295acaf548554" in delete_call[0][1]
+
+
+class TestVmRecipeManagerActions:
+    """Tests for VM recipe actions."""
+
+    def test_download(self, vm_recipe_manager, mock_client):
+        """Test downloading a recipe."""
+        mock_client._request.return_value = {"task": 123}
+
+        result = vm_recipe_manager.download("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        assert result == {"task": 123}
+        action_call = mock_client._request.call_args
+        assert action_call[0][0] == "PUT"
+        assert "action=download" in action_call[0][1]
+
+    def test_get_instances_manager(self, vm_recipe_manager, mock_client):
+        """Test getting a scoped instances manager."""
+        inst_mgr = vm_recipe_manager.instances("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        assert isinstance(inst_mgr, VmRecipeInstanceManager)
+        assert inst_mgr._recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_get_logs_manager(self, vm_recipe_manager, mock_client):
+        """Test getting a scoped logs manager."""
+        log_mgr = vm_recipe_manager.logs("8f73f8bcc9c9f1aaba32f733bfc295acaf548554")
+
+        assert isinstance(log_mgr, VmRecipeLogManager)
+        assert log_mgr._recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+
+# =============================================================================
+# VM Recipe Instance Tests
+# =============================================================================
+
+
+class TestVmRecipeInstance:
+    """Tests for VmRecipeInstance model."""
+
+    def test_recipe_key(self, vm_recipe_instance_manager, sample_vm_recipe_instance):
+        """Test recipe_key property."""
+        inst = VmRecipeInstance(sample_vm_recipe_instance, vm_recipe_instance_manager)
+        assert inst.recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_vm_key(self, vm_recipe_instance_manager, sample_vm_recipe_instance):
+        """Test vm_key property."""
+        inst = VmRecipeInstance(sample_vm_recipe_instance, vm_recipe_instance_manager)
+        assert inst.vm_key == 10
+
+    def test_is_auto_update_true(self, vm_recipe_instance_manager, sample_vm_recipe_instance):
+        """Test is_auto_update returns True when enabled."""
+        inst = VmRecipeInstance(sample_vm_recipe_instance, vm_recipe_instance_manager)
+        assert inst.is_auto_update is True
+
+    def test_is_auto_update_false(self, vm_recipe_instance_manager, sample_vm_recipe_instance):
+        """Test is_auto_update returns False when disabled."""
+        sample_vm_recipe_instance["auto_update"] = False
+        inst = VmRecipeInstance(sample_vm_recipe_instance, vm_recipe_instance_manager)
+        assert inst.is_auto_update is False
+
+
+class TestVmRecipeInstanceManagerList:
+    """Tests for VmRecipeInstanceManager.list()."""
+
+    def test_list_all(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test listing all instances."""
+        mock_client._request.return_value = [sample_vm_recipe_instance]
+
+        result = vm_recipe_instance_manager.list()
+
+        assert len(result) == 1
+        assert result[0].name == "my-ubuntu"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "vm_recipe_instances"
+
+    def test_list_empty(self, vm_recipe_instance_manager, mock_client):
+        """Test listing when no instances exist."""
+        mock_client._request.return_value = None
+
+        result = vm_recipe_instance_manager.list()
+
+        assert result == []
+
+    def test_list_scoped_to_recipe(
+        self, scoped_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test listing instances scoped to a recipe."""
+        mock_client._request.return_value = [sample_vm_recipe_instance]
+
+        result = scoped_instance_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "recipe eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'" in args[1]["params"]["filter"]
+
+
+class TestVmRecipeInstanceManagerGet:
+    """Tests for VmRecipeInstanceManager.get()."""
+
+    def test_get_by_key(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test getting instance by key."""
+        mock_client._request.return_value = sample_vm_recipe_instance
+
+        result = vm_recipe_instance_manager.get(key=1)
+
+        assert result.name == "my-ubuntu"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "vm_recipe_instances/1"
+
+    def test_get_by_name(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test getting instance by name."""
+        mock_client._request.return_value = [sample_vm_recipe_instance]
+
+        result = vm_recipe_instance_manager.get(name="my-ubuntu")
+
+        assert result.name == "my-ubuntu"
+        args = mock_client._request.call_args
+        assert "name eq 'my-ubuntu'" in args[1]["params"]["filter"]
+
+    def test_get_not_found(self, vm_recipe_instance_manager, mock_client):
+        """Test getting non-existent instance."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError, match="not found"):
+            vm_recipe_instance_manager.get(key=999)
+
+    def test_get_no_key_or_name(self, vm_recipe_instance_manager):
+        """Test get without key or name raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            vm_recipe_instance_manager.get()
+
+
+class TestVmRecipeInstanceManagerCreate:
+    """Tests for VmRecipeInstanceManager.create()."""
+
+    def test_create(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test creating a recipe instance."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # Create
+            sample_vm_recipe_instance,  # Get created
+        ]
+
+        result = vm_recipe_instance_manager.create(
+            recipe="8f73f8bcc9c9f1aaba32f733bfc295acaf548554",
+            name="my-ubuntu",
+            answers={"ram": 4096},
+            auto_update=True,
+        )
+
+        assert result.name == "my-ubuntu"
+        create_call = mock_client._request.call_args_list[0]
+        assert create_call[0][0] == "POST"
+        assert create_call[0][1] == "vm_recipe_instances"
+        body = create_call[1]["json_data"]
+        assert body["recipe"] == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+        assert body["name"] == "my-ubuntu"
+        assert body["answers"] == {"ram": 4096}
+        assert body["auto_update"] is True
+
+
+class TestVmRecipeInstanceManagerDelete:
+    """Tests for VmRecipeInstanceManager.delete()."""
+
+    def test_delete(self, vm_recipe_instance_manager, mock_client):
+        """Test deleting an instance."""
+        mock_client._request.return_value = None
+
+        vm_recipe_instance_manager.delete(1)
+
+        delete_call = mock_client._request.call_args
+        assert delete_call[0][0] == "DELETE"
+        assert delete_call[0][1] == "vm_recipe_instances/1"
+
+
+# =============================================================================
+# VM Recipe Log Tests
+# =============================================================================
+
+
+class TestVmRecipeLog:
+    """Tests for VmRecipeLog model."""
+
+    def test_recipe_key(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test recipe_key property."""
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.recipe_key == "8f73f8bcc9c9f1aaba32f733bfc295acaf548554"
+
+    def test_is_error_true(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test is_error returns True for error level."""
+        sample_vm_recipe_log["level"] = "error"
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.is_error is True
+
+    def test_is_error_critical(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test is_error returns True for critical level."""
+        sample_vm_recipe_log["level"] = "critical"
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.is_error is True
+
+    def test_is_error_false(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test is_error returns False for message level."""
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.is_error is False
+
+    def test_is_warning_true(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test is_warning returns True for warning level."""
+        sample_vm_recipe_log["level"] = "warning"
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.is_warning is True
+
+    def test_is_warning_false(self, vm_recipe_log_manager, sample_vm_recipe_log):
+        """Test is_warning returns False for message level."""
+        log = VmRecipeLog(sample_vm_recipe_log, vm_recipe_log_manager)
+        assert log.is_warning is False
+
+
+class TestVmRecipeLogManagerList:
+    """Tests for VmRecipeLogManager.list()."""
+
+    def test_list_all(self, vm_recipe_log_manager, mock_client, sample_vm_recipe_log):
+        """Test listing all logs."""
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = vm_recipe_log_manager.list()
+
+        assert len(result) == 1
+        assert result[0].text == "Recipe deployed successfully"
+        mock_client._request.assert_called_once()
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "vm_recipe_logs"
+
+    def test_list_empty(self, vm_recipe_log_manager, mock_client):
+        """Test listing when no logs exist."""
+        mock_client._request.return_value = None
+
+        result = vm_recipe_log_manager.list()
+
+        assert result == []
+
+    def test_list_scoped_to_recipe(
+        self, scoped_log_manager, mock_client, sample_vm_recipe_log
+    ):
+        """Test listing logs scoped to a recipe."""
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = scoped_log_manager.list()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "vm_recipe eq '8f73f8bcc9c9f1aaba32f733bfc295acaf548554'" in args[1]["params"]["filter"]
+
+    def test_list_with_level_filter(
+        self, vm_recipe_log_manager, mock_client, sample_vm_recipe_log
+    ):
+        """Test listing with level filter."""
+        sample_vm_recipe_log["level"] = "error"
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = vm_recipe_log_manager.list(level="error")
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "level eq 'error'" in args[1]["params"]["filter"]
+
+    def test_list_with_pagination(
+        self, vm_recipe_log_manager, mock_client, sample_vm_recipe_log
+    ):
+        """Test listing with pagination."""
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = vm_recipe_log_manager.list(limit=10, offset=5)
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert args[1]["params"]["limit"] == 10
+        assert args[1]["params"]["offset"] == 5
+
+
+class TestVmRecipeLogManagerGet:
+    """Tests for VmRecipeLogManager.get()."""
+
+    def test_get_by_key(self, vm_recipe_log_manager, mock_client, sample_vm_recipe_log):
+        """Test getting log by key."""
+        mock_client._request.return_value = sample_vm_recipe_log
+
+        result = vm_recipe_log_manager.get(key=1)
+
+        assert result.text == "Recipe deployed successfully"
+        args = mock_client._request.call_args
+        assert args[0][0] == "GET"
+        assert args[0][1] == "vm_recipe_logs/1"
+
+    def test_get_not_found(self, vm_recipe_log_manager, mock_client):
+        """Test getting non-existent log."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError, match="not found"):
+            vm_recipe_log_manager.get(key=999)
+
+    def test_get_no_key(self, vm_recipe_log_manager):
+        """Test get without key raises ValueError."""
+        with pytest.raises(ValueError, match="Key must be provided"):
+            vm_recipe_log_manager.get()
+
+
+class TestVmRecipeLogManagerHelpers:
+    """Tests for VmRecipeLogManager helper methods."""
+
+    def test_list_errors(self, scoped_log_manager, mock_client, sample_vm_recipe_log):
+        """Test list_errors helper."""
+        sample_vm_recipe_log["level"] = "error"
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = scoped_log_manager.list_errors()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "(level eq 'error') or (level eq 'critical')" in args[1]["params"]["filter"]
+
+    def test_list_warnings(self, scoped_log_manager, mock_client, sample_vm_recipe_log):
+        """Test list_warnings helper."""
+        sample_vm_recipe_log["level"] = "warning"
+        mock_client._request.return_value = [sample_vm_recipe_log]
+
+        result = scoped_log_manager.list_warnings()
+
+        assert len(result) == 1
+        args = mock_client._request.call_args
+        assert "level eq 'warning'" in args[1]["params"]["filter"]


### PR DESCRIPTION
## Summary

Adds comprehensive support for VM and tenant recipe management, enabling automated provisioning via templates with customizable configuration options. This completes section 1.2 of the v1.0 release plan.

- Add VM recipe managers (recipes, instances, logs)
- Add tenant recipe managers (recipes, instances, logs)
- Add shared recipe questions and sections managers
- Add example script demonstrating recipe usage
- Add 133 unit tests with complete coverage

## New Resource Managers

| Manager | Endpoint | Description |
|---------|----------|-------------|
| `vm_recipes` | `vm_recipes` | VM recipe template management |
| `vm_recipe_instances` | `vm_recipe_instances` | Track VMs created from recipes |
| `vm_recipe_logs` | `vm_recipe_logs` | Recipe operation logging |
| `tenant_recipes` | `tenant_recipes` | Tenant recipe template management |
| `tenant_recipe_instances` | `tenant_recipe_instances` | Track tenants created from recipes |
| `tenant_recipe_logs` | `tenant_recipe_logs` | Tenant recipe operation logging |
| `recipe_questions` | `recipe_questions` | Configuration questions for recipes |
| `recipe_sections` | `recipe_sections` | Question grouping/organization |

## Key Features

- 40-character hex string keys (following `nas_volumes.py` pattern)
- Scoped managers for recipe-specific instances/logs
- Full CRUD operations with filtering and pagination
- Cloud-init/Cloudbase-init integration support
- Comprehensive module docstrings with question types and common variables

## Files Changed

**New Files:**
- `pyvergeos/resources/vm_recipes.py`
- `pyvergeos/resources/tenant_recipes.py`
- `pyvergeos/resources/recipe_common.py`
- `tests/unit/test_vm_recipes.py` (56 tests)
- `tests/unit/test_tenant_recipes.py` (40 tests)
- `tests/unit/test_recipe_common.py` (37 tests)
- `examples/recipe_example.py`

**Modified Files:**
- `pyvergeos/client.py` - Added 8 new recipe manager properties
- `pyvergeos/resources/__init__.py` - Exported new classes

## Test plan

- [x] All 133 new unit tests pass
- [x] Full test suite passes (2592 tests)
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Tested against live VergeOS system (192.168.10.75)
- [x] Verified recipe sections and questions match product documentation