### PR TITLE
feat: add task scheduling system for event-driven and scheduled automation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,151 @@
+# pyvergeos Examples
+
+This directory contains example scripts demonstrating how to use pyvergeos to interact with VergeOS systems. Each example is self-contained and includes detailed comments explaining the operations.
+
+## Prerequisites
+
+Before running any example:
+
+1. Install pyvergeos:
+   ```bash
+   pip install pyvergeos
+   ```
+
+2. Set environment variables (or modify credentials in the script):
+   ```bash
+   export VERGE_HOST="your-vergeos-host"
+   export VERGE_USERNAME="admin"
+   export VERGE_PASSWORD="your-password"
+   export VERGE_VERIFY_SSL="false"  # Optional, for self-signed certs
+   ```
+
+## Examples by Category
+
+### Getting Started
+
+| Example | Description |
+|---------|-------------|
+| [connection_example.py](connection_example.py) | Various ways to connect to VergeOS (basic auth, environment variables, context managers) |
+
+### Virtual Machines
+
+| Example | Description |
+|---------|-------------|
+| [vm_example.py](vm_example.py) | Basic VM operations: listing, filtering, power management, console access |
+| [vm_lifecycle.py](vm_lifecycle.py) | Complete VM lifecycle: create, clone, snapshot, bulk operations, maintenance workflows |
+| [vm_snapshots_example.py](vm_snapshots_example.py) | VM snapshot operations: create, restore to new VM, restore over existing VM |
+| [CreateVM.py](CreateVM.py) | Create a fully configured VM with drives, NICs, ISO, and optional cloud-init |
+
+### Networking
+
+| Example | Description |
+|---------|-------------|
+| [network_example.py](network_example.py) | Network management, DHCP, firewall rules, IP aliases, DNS, diagnostics |
+| [dns_example.py](dns_example.py) | DNS zone and record management for networks with BIND DNS |
+| [wireguard_example.py](wireguard_example.py) | WireGuard VPN: interfaces, peers, site-to-site and remote user configs |
+
+### Storage & NAS
+
+| Example | Description |
+|---------|-------------|
+| [storage_example.py](storage_example.py) | Storage operations: media catalog, file listing, tier info, vSAN status |
+| [nas_simple.py](nas_simple.py) | Simple NAS setup: deploy service, create volumes |
+| [nas_advanced.py](nas_advanced.py) | Advanced NAS: users, CIFS/SMB shares, NFS shares with restrictions |
+| [nas_volume_sync.py](nas_volume_sync.py) | NAS volume synchronization between two NAS services |
+
+### Backup & DR
+
+| Example | Description |
+|---------|-------------|
+| [cloud_snapshots_example.py](cloud_snapshots_example.py) | Cloud (system) snapshots: create, list, query VMs/tenants, restore |
+| [snapshot_profiles_example.py](snapshot_profiles_example.py) | Snapshot profiles: schedules, retention policies, periods |
+| [site_syncs_example.py](site_syncs_example.py) | Site sync operations: outgoing/incoming syncs, queues, throttling |
+
+### Multi-Tenancy
+
+| Example | Description |
+|---------|-------------|
+| [tenant_management.py](tenant_management.py) | Complete tenant workflow: create, allocate resources, networking, file sharing |
+| [recipe_example.py](recipe_example.py) | VM recipe provisioning from Marketplace catalogs |
+
+### Automation & Tasks
+
+| Example | Description |
+|---------|-------------|
+| [task_automation_example.py](task_automation_example.py) | Task Engine: schedules, events, triggers for automated operations |
+
+### System Administration
+
+| Example | Description |
+|---------|-------------|
+| [system_example.py](system_example.py) | System settings, license info, dashboard stats, inventory reports |
+| [user_management_example.py](user_management_example.py) | User onboarding: create users, groups, API keys, permissions |
+| [tag_management_example.py](tag_management_example.py) | Tag workflow: categories, tags, resource tagging, queries |
+| [certificate_example.py](certificate_example.py) | SSL/TLS certificates: self-signed, manual upload, renewal, monitoring |
+
+## Running Examples
+
+Most examples are designed to be read and modified before running. They contain placeholder credentials and resource names that should be updated for your environment.
+
+```bash
+# View an example
+cat vm_example.py
+
+# Run an example (after updating credentials)
+python vm_example.py
+```
+
+## Example Structure
+
+Each example follows a consistent structure:
+
+```python
+#!/usr/bin/env python3
+"""Example: Brief description.
+
+Detailed explanation of what this example demonstrates.
+"""
+
+from pyvergeos import VergeClient
+
+def example_function() -> None:
+    """Demonstrate a specific operation."""
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Example operations here
+        pass
+
+if __name__ == "__main__":
+    # Uncomment to run:
+    # example_function()
+    pass
+```
+
+## Safety Notes
+
+- Examples that modify resources (create, delete, power operations) are commented out by default
+- Always review and understand an example before running it
+- Test in a non-production environment first
+- Some examples include cleanup functions to remove created resources
+
+## Contributing
+
+When adding new examples:
+
+1. Follow the existing naming convention: `feature_example.py`
+2. Include a comprehensive docstring at the top
+3. Use type hints for function signatures
+4. Keep credentials as placeholders (not real values)
+5. Comment out destructive operations by default
+6. Include cleanup functions where appropriate
+7. Update this README with the new example
+
+## Related Documentation
+
+- [pyvergeos Documentation](https://github.com/verge-io/pyvergeos)
+- [VergeOS Documentation](https://docs.verge.io)
+- [VergeOS API Reference](https://docs.verge.io/api)

--- a/examples/task_automation_example.py
+++ b/examples/task_automation_example.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Example: Task Engine automation with pyvergeos.
+
+This example demonstrates the VergeOS Task Engine, which enables automated
+operations triggered by specific events or scheduled times.
+
+Task Engine Components:
+    - Tasks: Define the action to perform (e.g., power off a VM)
+    - Schedules: Specify when and how often a task runs
+    - Events: Define conditions that trigger a task (e.g., user login)
+    - Schedule Triggers: Link tasks to schedules
+    - Event Triggers: Link tasks to events
+
+Use Cases Demonstrated:
+    1. Power on VMs when a user logs in
+    2. Power off VMs when the user logs out
+    3. Power off VMs on a schedule (e.g., Friday at 6 PM)
+    4. Send notifications on sync errors
+
+Based on VergeOS documentation:
+    - product-guide/automation/task-engine.md
+    - product-guide/automation/create-tasks.md
+"""
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+
+
+def list_tasks() -> None:
+    """List all tasks and their status."""
+    print("=== List All Tasks ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        tasks = client.tasks.list(limit=10)
+        print(f"Found {len(tasks)} tasks")
+
+        for task in tasks:
+            print(f"\n  Task: {task.name}")
+            print(f"    Key: {task.key}")
+            print(f"    Status: {task.get('status')}")
+            print(f"    Enabled: {task.is_enabled}")
+            print(f"    Action: {task.action_display_name}")
+            print(f"    Schedule Triggers: {task.trigger_count}")
+            print(f"    Event Triggers: {task.event_count}")
+
+
+def list_schedules() -> None:
+    """List all task schedules."""
+    print("\n=== List All Schedules ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        schedules = client.task_schedules.list(limit=10)
+        print(f"Found {len(schedules)} schedules")
+
+        for schedule in schedules:
+            print(f"\n  Schedule: {schedule.name}")
+            print(f"    Key: {schedule.key}")
+            print(f"    Enabled: {schedule.is_enabled}")
+            print(f"    Repeat: {schedule.repeat_every_display}")
+            print(f"    Active Days: {', '.join(schedule.active_days)}")
+
+
+def create_vm_power_on_task() -> None:
+    """Create a task to power on VMs.
+
+    This demonstrates creating a task that can be triggered by events
+    (e.g., user login) or schedules.
+    """
+    print("\n=== Create VM Power On Task ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # First, find a VM to use as the target
+        vms = client.vms.list(limit=1)
+        if not vms:
+            print("No VMs found. Please create a VM first.")
+            return
+
+        vm = vms[0]
+        print(f"Using VM: {vm.name} (key={vm.key})")
+
+        # Create the power on task
+        task = client.tasks.create(
+            name="Power On Dev VMs",
+            owner=vm.key,
+            action="poweron",
+            description="Power on development VMs when user logs in",
+            enabled=True,
+        )
+
+        print(f"Created task: {task.name} (key={task.key})")
+        print(f"  Action: {task.action_type}")
+        print(f"  Enabled: {task.is_enabled}")
+
+
+def create_vm_power_off_task() -> None:
+    """Create a task to power off VMs.
+
+    This task can be linked to:
+    - User logout events
+    - A schedule (e.g., Friday at 6 PM)
+    """
+    print("\n=== Create VM Power Off Task ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Find a VM to use as the target
+        vms = client.vms.list(limit=1)
+        if not vms:
+            print("No VMs found.")
+            return
+
+        vm = vms[0]
+
+        # Create the power off task
+        task = client.tasks.create(
+            name="Power Off Dev VMs",
+            owner=vm.key,
+            action="poweroff",
+            description="Power off development VMs on logout or end of day",
+            enabled=True,
+        )
+
+        print(f"Created task: {task.name} (key={task.key})")
+
+
+def create_weekly_schedule() -> None:
+    """Create a schedule for Fridays at 6:00 PM.
+
+    This schedule can be applied to multiple tasks for consistent
+    end-of-week automation.
+    """
+    print("\n=== Create Friday 6 PM Schedule ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Create a schedule for Fridays at 6:00 PM
+        # Time is in seconds from midnight: 18:00 = 18 * 3600 = 64800
+        schedule = client.task_schedules.create(
+            name="Friday End of Business",
+            description="Runs every Friday at 6:00 PM",
+            repeat_every="week",
+            repeat_iteration=1,
+            start_time_of_day=64800,  # 6:00 PM (18 * 3600 seconds)
+            monday=False,
+            tuesday=False,
+            wednesday=False,
+            thursday=False,
+            friday=True,
+            saturday=False,
+            sunday=False,
+            enabled=True,
+        )
+
+        print(f"Created schedule: {schedule.name} (key={schedule.key})")
+        print(f"  Repeat: {schedule.repeat_every_display}")
+        print(f"  Active Days: {', '.join(schedule.active_days)}")
+
+
+def link_task_to_schedule() -> None:
+    """Link a power off task to the Friday schedule.
+
+    Schedule triggers link tasks to schedules, enabling time-based automation.
+    """
+    print("\n=== Link Task to Schedule ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Find the task and schedule
+        try:
+            task = client.tasks.get(name="Power Off Dev VMs")
+            schedule = client.task_schedules.get(name="Friday End of Business")
+        except NotFoundError as e:
+            print(f"Not found: {e}")
+            print("Run create_vm_power_off_task() and create_weekly_schedule() first.")
+            return
+
+        # Create the schedule trigger
+        trigger = client.task_schedule_triggers.create(
+            task=task.key,
+            schedule=schedule.key,
+        )
+
+        print(f"Created schedule trigger (key={trigger.key})")
+        print(f"  Task: {trigger.task_display}")
+        print(f"  Schedule: {trigger.schedule_display}")
+
+        # Verify the trigger shows up on the task
+        print(f"\n  Task now has {task.trigger_count + 1} schedule trigger(s)")
+
+
+def view_task_triggers() -> None:
+    """View all triggers (schedule and event) for a task."""
+    print("\n=== View Task Triggers ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        tasks = client.tasks.list(limit=5)
+
+        for task in tasks:
+            print(f"\nTask: {task.name}")
+
+            # List schedule triggers
+            triggers = task.triggers.list()
+            if triggers:
+                print(f"  Schedule Triggers ({len(triggers)}):")
+                for t in triggers:
+                    print(f"    - Schedule: {t.schedule_display}")
+            else:
+                print("  Schedule Triggers: None")
+
+            # List event triggers
+            events = task.events.list()
+            if events:
+                print(f"  Event Triggers ({len(events)}):")
+                for e in events:
+                    print(f"    - Event: {e.event_name_display}")
+            else:
+                print("  Event Triggers: None")
+
+
+def execute_task_manually() -> None:
+    """Execute a task immediately, bypassing its triggers.
+
+    This is useful for testing tasks or running them on-demand.
+    """
+    print("\n=== Execute Task Manually ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        try:
+            task = client.tasks.get(name="Power On Dev VMs")
+        except NotFoundError:
+            print("Task 'Power On Dev VMs' not found.")
+            return
+
+        print(f"Executing task: {task.name}")
+
+        # Execute the task
+        task = task.execute()
+        print(f"  Status: {task.get('status')}")
+
+        # Optionally wait for completion
+        print("  Waiting for completion...")
+        task = task.wait(timeout=60, poll_interval=2)
+        print(f"  Final Status: {task.get('status')}")
+
+
+def enable_disable_task() -> None:
+    """Enable or disable a task.
+
+    Disabled tasks won't run according to their triggers but can still
+    be executed manually.
+    """
+    print("\n=== Enable/Disable Task ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        try:
+            task = client.tasks.get(name="Power On Dev VMs")
+        except NotFoundError:
+            print("Task not found.")
+            return
+
+        print(f"Task: {task.name}")
+        print(f"  Currently enabled: {task.is_enabled}")
+
+        # Toggle the enabled state
+        if task.is_enabled:
+            task = task.disable()
+            print("  Task disabled")
+        else:
+            task = task.enable()
+            print("  Task enabled")
+
+        print(f"  Now enabled: {task.is_enabled}")
+
+
+def list_task_scripts() -> None:
+    """List available task scripts.
+
+    Task scripts are GCS (VergeOS scripting) code that can be executed
+    as tasks. Scripts can define questions (settings) for configurability.
+    """
+    print("\n=== List Task Scripts ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        scripts = client.task_scripts.list(limit=10)
+        print(f"Found {len(scripts)} scripts")
+
+        for script in scripts:
+            print(f"\n  Script: {script.name}")
+            print(f"    Key: {script.key}")
+            print(f"    Description: {script.get('description', 'N/A')}")
+            print(f"    Tasks using this script: {script.task_count}")
+
+
+def cleanup_example_resources() -> None:
+    """Clean up tasks and schedules created by this example.
+
+    WARNING: This deletes resources. Only run if you want to remove
+    the example tasks and schedules.
+    """
+    print("\n=== Cleanup Example Resources ===")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # Delete tasks
+        for task_name in ["Power On Dev VMs", "Power Off Dev VMs"]:
+            try:
+                task = client.tasks.get(name=task_name)
+
+                # Delete associated triggers first
+                for trigger in task.triggers.list():
+                    client.task_schedule_triggers.delete(trigger.key)
+                    print(f"  Deleted trigger {trigger.key}")
+
+                # Delete associated events
+                for event in task.events.list():
+                    client.task_events.delete(event.key)
+                    print(f"  Deleted event {event.key}")
+
+                # Delete the task
+                client.tasks.delete(task.key)
+                print(f"Deleted task: {task_name}")
+            except NotFoundError:
+                print(f"Task not found: {task_name}")
+
+        # Delete schedule
+        try:
+            schedule = client.task_schedules.get(name="Friday End of Business")
+            client.task_schedules.delete(schedule.key)
+            print("Deleted schedule: Friday End of Business")
+        except NotFoundError:
+            print("Schedule not found: Friday End of Business")
+
+
+def full_automation_workflow() -> None:
+    """Complete workflow: Create task, schedule, and link them.
+
+    This demonstrates the full workflow for setting up automated
+    VM power management similar to the documentation example.
+    """
+    print("\n=== Full Automation Workflow ===")
+    print("Setting up automated VM power management...")
+
+    with VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        verify_ssl=False,
+    ) as client:
+        # 1. Find a VM to manage
+        vms = client.vms.list(limit=1)
+        if not vms:
+            print("No VMs found. Please create a VM first.")
+            return
+        vm = vms[0]
+        print(f"\n1. Target VM: {vm.name}")
+
+        # 2. Create power off task
+        power_off_task = client.tasks.create(
+            name="Auto Power Off VM",
+            owner=vm.key,
+            action="poweroff",
+            description="Automatically power off VM on schedule",
+            enabled=True,
+        )
+        print(f"2. Created task: {power_off_task.name}")
+
+        # 3. Create weekly schedule (Fridays at 6 PM)
+        friday_schedule = client.task_schedules.create(
+            name="Weekly Friday 6PM",
+            description="Every Friday at 6:00 PM",
+            repeat_every="week",
+            start_time_of_day=64800,  # 6 PM
+            friday=True,
+            monday=False,
+            tuesday=False,
+            wednesday=False,
+            thursday=False,
+            saturday=False,
+            sunday=False,
+        )
+        print(f"3. Created schedule: {friday_schedule.name}")
+
+        # 4. Link task to schedule
+        client.task_schedule_triggers.create(
+            task=power_off_task.key,
+            schedule=friday_schedule.key,
+        )
+        print("4. Created trigger linking task to schedule")
+
+        # 5. Verify setup
+        task = client.tasks.get(power_off_task.key)
+        print("\n5. Verification:")
+        print(f"   Task '{task.name}' now has {task.trigger_count} schedule trigger(s)")
+        print(f"   VM '{vm.name}' will power off every Friday at 6 PM")
+
+        print("\nAutomation setup complete!")
+        print("The VM will automatically power off every Friday at 6:00 PM.")
+
+
+if __name__ == "__main__":
+    print("pyvergeos Task Engine Examples")
+    print("=" * 50)
+    print()
+    print("NOTE: Update host/credentials in this file before running.")
+    print()
+    print("Task Engine Components:")
+    print("  - Tasks: Define actions to perform")
+    print("  - Schedules: Define when tasks run")
+    print("  - Events: Define conditions that trigger tasks")
+    print("  - Triggers: Link tasks to schedules or events")
+    print()
+
+    # Uncomment the examples you want to run:
+    # list_tasks()
+    # list_schedules()
+    # create_vm_power_on_task()
+    # create_vm_power_off_task()
+    # create_weekly_schedule()
+    # link_task_to_schedule()
+    # view_task_triggers()
+    # execute_task_manually()
+    # enable_disable_task()
+    # list_task_scripts()
+    # full_automation_workflow()
+    # cleanup_example_resources()
+
+    print("\nSee the code for examples of:")
+    print("  - Creating tasks for VM power management")
+    print("  - Creating schedules (hourly, daily, weekly)")
+    print("  - Linking tasks to schedules via triggers")
+    print("  - Viewing task triggers and events")
+    print("  - Executing tasks manually")
+    print("  - Enabling/disabling tasks")
+    print("  - Listing task scripts")
+    print("  - Full automation workflow setup")

--- a/pyvergeos/resources/task_events.py
+++ b/pyvergeos/resources/task_events.py
@@ -1,0 +1,515 @@
+"""Task event resource manager for VergeOS event-driven automation.
+
+Task events (event triggers) link tasks to system events, enabling event-driven
+automation. When a specific event occurs on a resource, tasks linked via task
+events are automatically executed.
+
+Event triggers allow tasks to run in response to specific system occurrences.
+A single task can be triggered by multiple distinct events, enabling you to
+consolidate logic and reuse task definitions across scenarios.
+
+Event-Based Task Examples:
+    - Power on a VM when a designated user logs into VergeOS
+    - Power off VMs when the user logs out
+    - Send an email notification when a system update completes
+    - Use a webhook to notify Slack when a sync error is detected
+
+Event Configuration:
+    - **Type**: The object class (e.g., users, virtual machines, tenants, alarms)
+    - **Event**: The event type (e.g., login, logout, poweron, error)
+    - **Object Instance**: A specific resource, or use tags to match multiple
+    - **Filter Settings**: For logs/alarms, filter by severity or log type
+
+Example:
+    >>> # List all task events
+    >>> for event in client.task_events.list():
+    ...     print(f"{event.event_name_display} -> {event.task_display}")
+
+    >>> # Get events linked to a specific task
+    >>> task = client.tasks.get(name="Power On Dev VMs")
+    >>> for event in task.events.list():
+    ...     print(f"Triggered by: {event.event_name_display}")
+
+    >>> # Create event trigger for user login
+    >>> event = client.task_events.create(
+    ...     task=task.key,
+    ...     owner=user.key,
+    ...     event="login",
+    ...     table="users",
+    ... )
+
+    >>> # Manually trigger an event for testing
+    >>> event.trigger_now(context={"custom": "data"})
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class TaskEvent(ResourceObject):
+    """Task event resource object.
+
+    Represents a link between a task and a system event.
+
+    Properties:
+        owner_key: The owner resource $key.
+        owner_table: The owner resource table name.
+        event: Event identifier.
+        event_name: Human-readable event name.
+        task_key: Linked task $key.
+        task_display: Linked task display name.
+        filters: Event filter conditions (JSON).
+        context: Event context data (JSON).
+        trigger: Timer value for the event trigger.
+    """
+
+    @property
+    def owner_key(self) -> int | None:
+        """Get the owner resource key.
+
+        Note: Some events have non-integer owner values (e.g., 'update_settings/1').
+        In those cases, this property returns None.
+        """
+        owner = self.get("owner")
+        if owner is None or owner == "":
+            return None
+        # Owner can be an integer or a path like 'update_settings/1'
+        try:
+            return int(owner)
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def owner_table(self) -> str | None:
+        """Get the owner resource table name."""
+        return self.get("table")
+
+    @property
+    def event_type(self) -> str | None:
+        """Get the event identifier."""
+        return self.get("event")
+
+    @property
+    def event_name_display(self) -> str | None:
+        """Get the human-readable event name."""
+        return self.get("event_name")
+
+    @property
+    def task_key(self) -> int | None:
+        """Get the linked task key."""
+        task = self.get("task")
+        return int(task) if task is not None else None
+
+    @property
+    def task_display(self) -> str:
+        """Get the linked task display name."""
+        return str(self.get("task_display", ""))
+
+    @property
+    def event_filters(self) -> dict[str, Any] | None:
+        """Get the event filter conditions."""
+        filters = self.get("table_event_filters")
+        if isinstance(filters, dict):
+            return filters
+        return None
+
+    @property
+    def event_context(self) -> dict[str, Any] | None:
+        """Get the event context data."""
+        context = self.get("context")
+        if isinstance(context, dict):
+            return context
+        return None
+
+    def trigger_now(self, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        """Manually trigger this event.
+
+        Args:
+            context: Optional context data to pass to the task.
+
+        Returns:
+            Action response dict or None.
+        """
+        from typing import cast
+
+        manager = cast("TaskEventManager", self._manager)
+        return manager.trigger(self.key, context=context)
+
+
+class TaskEventManager(ResourceManager[TaskEvent]):
+    """Manager for task event operations.
+
+    Task events enable event-driven automation by linking tasks to system events.
+
+    Example:
+        >>> # List all task events
+        >>> for event in client.task_events.list():
+        ...     print(f"{event.event_name_display}: {event.task_display}")
+
+        >>> # List events for a specific task
+        >>> events = client.task_events.list(task=task_key)
+
+        >>> # List events for a specific owner
+        >>> events = client.task_events.list(owner=vm_key)
+
+        >>> # Manually trigger an event
+        >>> client.task_events.trigger(event_key, context={"key": "value"})
+    """
+
+    _endpoint = "task_events"
+
+    _default_fields = [
+        "$key",
+        "owner",
+        "owner#$display as owner_display",
+        "table",
+        "event",
+        "event_name",
+        "task",
+        "task#$display as task_display",
+        "task#name as task_name",
+        "table_event_filters",
+        "trigger",
+        "context",
+    ]
+
+    def __init__(
+        self,
+        client: VergeClient,
+        *,
+        task_key: int | None = None,
+        owner_key: int | None = None,
+    ) -> None:
+        """Initialize the event manager.
+
+        Args:
+            client: VergeClient instance.
+            task_key: Optional task key to scope the manager.
+            owner_key: Optional owner resource key to scope the manager.
+        """
+        super().__init__(client)
+        self._task_key = task_key
+        self._owner_key = owner_key
+
+    def _to_model(self, data: dict[str, Any]) -> TaskEvent:
+        return TaskEvent(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        task: int | None = None,
+        owner: int | None = None,
+        table: str | None = None,
+        event: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TaskEvent]:
+        """List task events with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            task: Filter by task key. Ignored if manager is scoped to a task.
+            owner: Filter by owner resource key. Ignored if manager is scoped.
+            table: Filter by owner table name.
+            event: Filter by event identifier.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of TaskEvent objects.
+
+        Example:
+            >>> # All events
+            >>> events = client.task_events.list()
+
+            >>> # Events for a specific task
+            >>> events = client.task_events.list(task=task_key)
+
+            >>> # Events for VMs only
+            >>> events = client.task_events.list(table="vms")
+
+            >>> # Events for a specific event type
+            >>> events = client.task_events.list(event="poweron")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter conditions
+        filters: builtins.list[str] = []
+
+        if filter:
+            filters.append(f"({filter})")
+
+        # Use scoped key or parameter
+        task_filter = self._task_key if self._task_key is not None else task
+        if task_filter is not None:
+            filters.append(f"task eq {task_filter}")
+
+        owner_filter = self._owner_key if self._owner_key is not None else owner
+        if owner_filter is not None:
+            filters.append(f"owner eq {owner_filter}")
+
+        if table is not None:
+            filters.append(f"table eq '{table}'")
+
+        if event is not None:
+            filters.append(f"event eq '{event}'")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> TaskEvent:
+        """Get a task event by key.
+
+        Args:
+            key: Event $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            TaskEvent object.
+
+        Raises:
+            NotFoundError: If event not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+        if response is None:
+            raise NotFoundError(f"Task event {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Task event {key} returned invalid response")
+        return self._to_model(response)
+
+    def create(  # type: ignore[override]
+        self,
+        task: int,
+        owner: int,
+        event: str,
+        *,
+        table: str | None = None,
+        event_name: str | None = None,
+        table_event_filters: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> TaskEvent:
+        """Create a task event.
+
+        Links a task to a system event for event-driven execution.
+
+        Args:
+            task: Task $key to link.
+            owner: Owner resource $key.
+            event: Event identifier.
+            table: Owner table name (usually auto-detected).
+            event_name: Human-readable event name.
+            table_event_filters: JSON filter conditions for the event.
+            context: JSON context data to pass to the task.
+
+        Returns:
+            Created TaskEvent object.
+
+        Example:
+            >>> # Trigger task when a VM powers on
+            >>> event = client.task_events.create(
+            ...     task=notification_task.key,
+            ...     owner=vm.key,
+            ...     event="poweron",
+            ... )
+        """
+        body: dict[str, Any] = {
+            "task": task,
+            "owner": owner,
+            "event": event,
+        }
+
+        if table is not None:
+            body["table"] = table
+        if event_name is not None:
+            body["event_name"] = event_name
+        if table_event_filters is not None:
+            body["table_event_filters"] = table_event_filters
+        if context is not None:
+            body["context"] = context
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        # Get the full object
+        key = response.get("$key")
+        if key is not None:
+            return self.get(int(key))
+
+        return self._to_model(response)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        table_event_filters: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> TaskEvent:
+        """Update a task event.
+
+        Args:
+            key: Event $key (ID).
+            table_event_filters: New filter conditions.
+            context: New context data.
+
+        Returns:
+            Updated TaskEvent object.
+        """
+        body: dict[str, Any] = {}
+
+        if table_event_filters is not None:
+            body["table_event_filters"] = table_event_filters
+        if context is not None:
+            body["context"] = context
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a task event.
+
+        Removes the link between a task and event.
+
+        Args:
+            key: Event $key (ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def trigger(
+        self,
+        key: int,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Manually trigger a task event.
+
+        Fires the event, causing the linked task to execute.
+
+        Args:
+            key: Event $key (ID).
+            context: Optional context data to pass to the task.
+
+        Returns:
+            Action response dict or None.
+
+        Example:
+            >>> # Trigger an event
+            >>> client.task_events.trigger(event_key)
+
+            >>> # Trigger with context
+            >>> client.task_events.trigger(event_key, context={"key": "value"})
+        """
+        params: dict[str, Any] = {}
+        if context is not None:
+            params["context"] = context
+
+        return self.action(key, "trigger", **params)
+
+    def list_for_task(
+        self,
+        task_key: int,
+        limit: int | None = None,
+    ) -> builtins.list[TaskEvent]:
+        """List all events for a specific task.
+
+        Args:
+            task_key: Task $key.
+            limit: Maximum number of results.
+
+        Returns:
+            List of TaskEvent objects.
+        """
+        return self.list(task=task_key, limit=limit)
+
+    def list_for_owner(
+        self,
+        owner_key: int,
+        limit: int | None = None,
+    ) -> builtins.list[TaskEvent]:
+        """List all events for a specific owner resource.
+
+        Args:
+            owner_key: Owner resource $key.
+            limit: Maximum number of results.
+
+        Returns:
+            List of TaskEvent objects.
+        """
+        return self.list(owner=owner_key, limit=limit)
+
+    def list_by_table(
+        self,
+        table: str,
+        limit: int | None = None,
+    ) -> builtins.list[TaskEvent]:
+        """List all events for a specific table/resource type.
+
+        Args:
+            table: Table name (e.g., "vms", "vnets", "tenants").
+            limit: Maximum number of results.
+
+        Returns:
+            List of TaskEvent objects.
+        """
+        return self.list(table=table, limit=limit)

--- a/pyvergeos/resources/task_schedule_triggers.py
+++ b/pyvergeos/resources/task_schedule_triggers.py
@@ -1,0 +1,369 @@
+"""Task schedule trigger resource manager for VergeOS scheduling system.
+
+Task schedule triggers link tasks to schedules. When a schedule's trigger time
+arrives, all tasks linked via triggers are executed.
+
+Example:
+    >>> # Get a task and schedule
+    >>> task = client.tasks.get(name="Backup Task")
+    >>> schedule = client.task_schedules.get(name="Nightly")
+
+    >>> # Create a trigger to link them
+    >>> trigger = client.task_schedule_triggers.create(
+    ...     task=task.key,
+    ...     schedule=schedule.key,
+    ... )
+
+    >>> # List all triggers for a schedule
+    >>> for trigger in schedule.triggers.list():
+    ...     print(f"Task: {trigger.task_display}")
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class TaskScheduleTrigger(ResourceObject):
+    """Task schedule trigger resource object.
+
+    Represents a link between a task and a schedule.
+
+    Properties:
+        task_key: The linked task's $key.
+        task_display: Display name of the linked task.
+        schedule_key: The linked schedule's $key.
+        schedule_display: Display name of the linked schedule.
+        schedule_enabled: Whether the linked schedule is enabled.
+        trigger: Timer value for the trigger.
+    """
+
+    @property
+    def task_key(self) -> int | None:
+        """Get the linked task key."""
+        task = self.get("task")
+        return int(task) if task is not None else None
+
+    @property
+    def task_display(self) -> str:
+        """Get the linked task display name."""
+        return str(self.get("task_display", ""))
+
+    @property
+    def schedule_key(self) -> int | None:
+        """Get the linked schedule key."""
+        schedule = self.get("schedule")
+        return int(schedule) if schedule is not None else None
+
+    @property
+    def schedule_display(self) -> str:
+        """Get the linked schedule display name."""
+        return str(self.get("schedule_display", ""))
+
+    @property
+    def is_schedule_enabled(self) -> bool:
+        """Check if the linked schedule is enabled."""
+        return bool(self.get("sch_enabled", False))
+
+    @property
+    def schedule_repeat_every(self) -> str | None:
+        """Get the schedule's repeat interval."""
+        return self.get("sch_repeat_every")
+
+    @property
+    def schedule_start_time(self) -> int | None:
+        """Get the schedule's start time of day in seconds."""
+        start = self.get("sch_start_time_of_day")
+        return int(start) if start is not None else None
+
+    def trigger_now(self) -> dict[str, Any] | None:
+        """Trigger the task immediately.
+
+        Returns:
+            Action response dict or None.
+        """
+        from typing import cast
+
+        manager = cast("TaskScheduleTriggerManager", self._manager)
+        return manager.trigger(self.key)
+
+
+class TaskScheduleTriggerManager(ResourceManager[TaskScheduleTrigger]):
+    """Manager for task schedule trigger operations.
+
+    Task schedule triggers link tasks to schedules for execution.
+
+    Example:
+        >>> # List all triggers
+        >>> for trigger in client.task_schedule_triggers.list():
+        ...     print(f"{trigger.task_display} -> {trigger.schedule_display}")
+
+        >>> # Create a trigger
+        >>> trigger = client.task_schedule_triggers.create(
+        ...     task=task_key,
+        ...     schedule=schedule_key,
+        ... )
+
+        >>> # List triggers for a specific task
+        >>> triggers = client.task_schedule_triggers.list(task=task_key)
+
+        >>> # List triggers for a specific schedule
+        >>> triggers = client.task_schedule_triggers.list(schedule=schedule_key)
+    """
+
+    _endpoint = "task_schedule_triggers"
+
+    _default_fields = [
+        "$key",
+        "task",
+        "display(task) as task_display",
+        "schedule",
+        "display(schedule) as schedule_display",
+        "trigger",
+        "flatten(schedule[$key as sch_$key,enabled as sch_enabled,"
+        "start_time_of_day as sch_start_time_of_day,repeat_iteration as sch_repeat_iteration,"
+        "end_date as sch_end_date,display(day_of_month) as sch_day_of_month,"
+        "display(repeat_every) as sch_repeat_every])",
+    ]
+
+    def __init__(
+        self,
+        client: VergeClient,
+        *,
+        task_key: int | None = None,
+        schedule_key: int | None = None,
+    ) -> None:
+        """Initialize the trigger manager.
+
+        Args:
+            client: VergeClient instance.
+            task_key: Optional task key to scope the manager.
+            schedule_key: Optional schedule key to scope the manager.
+        """
+        super().__init__(client)
+        self._task_key = task_key
+        self._schedule_key = schedule_key
+
+    def _to_model(self, data: dict[str, Any]) -> TaskScheduleTrigger:
+        return TaskScheduleTrigger(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        task: int | None = None,
+        schedule: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TaskScheduleTrigger]:
+        """List task schedule triggers with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            task: Filter by task key. Ignored if manager is scoped to a task.
+            schedule: Filter by schedule key. Ignored if manager is scoped to a schedule.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of TaskScheduleTrigger objects.
+
+        Example:
+            >>> # All triggers
+            >>> triggers = client.task_schedule_triggers.list()
+
+            >>> # Triggers for a specific task
+            >>> triggers = client.task_schedule_triggers.list(task=task_key)
+
+            >>> # Triggers for a specific schedule
+            >>> triggers = client.task_schedule_triggers.list(schedule=schedule_key)
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter conditions
+        filters: builtins.list[str] = []
+
+        if filter:
+            filters.append(f"({filter})")
+
+        # Use scoped key or parameter
+        task_filter = self._task_key if self._task_key is not None else task
+        if task_filter is not None:
+            filters.append(f"task eq {task_filter}")
+
+        schedule_filter = self._schedule_key if self._schedule_key is not None else schedule
+        if schedule_filter is not None:
+            filters.append(f"schedule eq {schedule_filter}")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> TaskScheduleTrigger:
+        """Get a task schedule trigger by key.
+
+        Args:
+            key: Trigger $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            TaskScheduleTrigger object.
+
+        Raises:
+            NotFoundError: If trigger not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+        if response is None:
+            raise NotFoundError(f"Task schedule trigger {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Task schedule trigger {key} returned invalid response")
+        return self._to_model(response)
+
+    def create(  # type: ignore[override]
+        self,
+        task: int,
+        schedule: int,
+    ) -> TaskScheduleTrigger:
+        """Create a task schedule trigger.
+
+        Links a task to a schedule so it runs when the schedule fires.
+
+        Args:
+            task: Task $key to link.
+            schedule: Schedule $key to link.
+
+        Returns:
+            Created TaskScheduleTrigger object.
+
+        Example:
+            >>> trigger = client.task_schedule_triggers.create(
+            ...     task=backup_task.key,
+            ...     schedule=nightly_schedule.key,
+            ... )
+        """
+        body: dict[str, Any] = {
+            "task": task,
+            "schedule": schedule,
+        }
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        # Get the full object
+        key = response.get("$key")
+        if key is not None:
+            return self.get(int(key))
+
+        return self._to_model(response)
+
+    def delete(self, key: int) -> None:
+        """Delete a task schedule trigger.
+
+        Removes the link between a task and schedule.
+
+        Args:
+            key: Trigger $key (ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def trigger(self, key: int) -> dict[str, Any] | None:
+        """Trigger execution immediately.
+
+        Fires the trigger, causing the linked task to execute.
+
+        Args:
+            key: Trigger $key (ID).
+
+        Returns:
+            Action response dict or None.
+        """
+        return self.action(key, "trigger")
+
+    def list_for_task(
+        self,
+        task_key: int,
+        limit: int | None = None,
+    ) -> builtins.list[TaskScheduleTrigger]:
+        """List all triggers for a specific task.
+
+        Args:
+            task_key: Task $key.
+            limit: Maximum number of results.
+
+        Returns:
+            List of TaskScheduleTrigger objects.
+        """
+        return self.list(task=task_key, limit=limit)
+
+    def list_for_schedule(
+        self,
+        schedule_key: int,
+        limit: int | None = None,
+    ) -> builtins.list[TaskScheduleTrigger]:
+        """List all triggers for a specific schedule.
+
+        Args:
+            schedule_key: Schedule $key.
+            limit: Maximum number of results.
+
+        Returns:
+            List of TaskScheduleTrigger objects.
+        """
+        return self.list(schedule=schedule_key, limit=limit)

--- a/pyvergeos/resources/task_schedules.py
+++ b/pyvergeos/resources/task_schedules.py
@@ -1,0 +1,774 @@
+"""Task schedule resource manager for VergeOS scheduling system.
+
+Task schedules specify when and how often tasks should run (e.g., daily,
+weekly, monthly). Schedules are reusable - you can create a schedule once
+and apply it to multiple tasks for consistent configuration management.
+
+Supported repeat intervals:
+    - minute: Run every N minutes
+    - hour: Run every N hours
+    - day: Run every N days
+    - week: Run every N weeks (with day-of-week options)
+    - month: Run every N months (with day-of-month options)
+    - year: Run every N years
+    - never: Does not repeat (run once)
+
+Schedule-Based Task Examples:
+    - Check for and download system updates every Saturday at 5:00 PM
+    - Power off a tenant on a specific date
+    - Disable a user account 30 days after creation
+
+Example:
+    >>> # Create a schedule that runs every hour
+    >>> schedule = client.task_schedules.create(
+    ...     name="Hourly Backup",
+    ...     repeat_every="hour",
+    ...     repeat_iteration=1,
+    ... )
+
+    >>> # Create a schedule for Fridays at 6:00 PM (64800 seconds from midnight)
+    >>> schedule = client.task_schedules.create(
+    ...     name="Friday EOB",
+    ...     repeat_every="week",
+    ...     start_time_of_day=64800,  # 18:00 (6 PM)
+    ...     monday=False,
+    ...     tuesday=False,
+    ...     wednesday=False,
+    ...     thursday=False,
+    ...     friday=True,
+    ...     saturday=False,
+    ...     sunday=False,
+    ... )
+
+    >>> # Create a weekday-only schedule
+    >>> schedule = client.task_schedules.create(
+    ...     name="Weekday Reports",
+    ...     repeat_every="day",
+    ...     saturday=False,
+    ...     sunday=False,
+    ... )
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+# Repeat interval options
+REPEAT_INTERVALS = {
+    "minute": "Minute(s)",
+    "hour": "Hour(s)",
+    "day": "Day(s)",
+    "week": "Week(s)",
+    "month": "Month(s)",
+    "year": "Year(s)",
+    "never": "Does Not Repeat",
+}
+
+# Day of month options
+DAY_OF_MONTH_OPTIONS = {
+    "first": "First",
+    "last": "Last",
+    "15th": "15th",
+    "start_date": "Start Date",
+}
+
+
+class TaskSchedule(ResourceObject):
+    """Task schedule resource object.
+
+    Represents a schedule definition for task automation.
+
+    Properties:
+        name: Schedule name.
+        description: Schedule description.
+        is_enabled: Whether the schedule is enabled.
+        repeat_every: Repeat interval (minute, hour, day, week, month, year, never).
+        repeat_iteration: Number of intervals between executions.
+        start_date: Start date in YYYY-MM-DD format.
+        end_date: Expiration date in YYYY-MM-DD HH:MM:SS format.
+        start_time_of_day: Start time in seconds from midnight.
+        end_time_of_day: End time in seconds from midnight.
+        day_of_month: Day of month setting for monthly schedules.
+        monday-sunday: Boolean flags for weekly schedules.
+        task_key: Bound task key (if schedule is task-specific).
+        is_system_created: Whether created by system.
+        creator_key: Key of the user who created the schedule.
+    """
+
+    @property
+    def is_enabled(self) -> bool:
+        """Check if the schedule is enabled."""
+        return bool(self.get("enabled", True))
+
+    @property
+    def repeat_every_display(self) -> str:
+        """Get human-readable repeat interval."""
+        repeat = self.get("repeat_every", "hour")
+        return str(REPEAT_INTERVALS.get(repeat, repeat))
+
+    @property
+    def repeat_count(self) -> int:
+        """Get the repeat iteration count."""
+        return int(self.get("repeat_iteration", 1))
+
+    @property
+    def task_key(self) -> int | None:
+        """Get the bound task key if any."""
+        task = self.get("task")
+        return int(task) if task is not None else None
+
+    @property
+    def is_system_created(self) -> bool:
+        """Check if created by system."""
+        return bool(self.get("system_created", False))
+
+    @property
+    def creator_key(self) -> int | None:
+        """Get creator user key."""
+        creator = self.get("creator")
+        return int(creator) if creator is not None else None
+
+    @property
+    def runs_on_monday(self) -> bool:
+        """Check if schedule runs on Monday."""
+        return bool(self.get("monday", True))
+
+    @property
+    def runs_on_tuesday(self) -> bool:
+        """Check if schedule runs on Tuesday."""
+        return bool(self.get("tuesday", True))
+
+    @property
+    def runs_on_wednesday(self) -> bool:
+        """Check if schedule runs on Wednesday."""
+        return bool(self.get("wednesday", True))
+
+    @property
+    def runs_on_thursday(self) -> bool:
+        """Check if schedule runs on Thursday."""
+        return bool(self.get("thursday", True))
+
+    @property
+    def runs_on_friday(self) -> bool:
+        """Check if schedule runs on Friday."""
+        return bool(self.get("friday", True))
+
+    @property
+    def runs_on_saturday(self) -> bool:
+        """Check if schedule runs on Saturday."""
+        return bool(self.get("saturday", True))
+
+    @property
+    def runs_on_sunday(self) -> bool:
+        """Check if schedule runs on Sunday."""
+        return bool(self.get("sunday", True))
+
+    @property
+    def active_days(self) -> builtins.list[str]:
+        """Get list of days when schedule is active."""
+        days = []
+        if self.runs_on_monday:
+            days.append("Monday")
+        if self.runs_on_tuesday:
+            days.append("Tuesday")
+        if self.runs_on_wednesday:
+            days.append("Wednesday")
+        if self.runs_on_thursday:
+            days.append("Thursday")
+        if self.runs_on_friday:
+            days.append("Friday")
+        if self.runs_on_saturday:
+            days.append("Saturday")
+        if self.runs_on_sunday:
+            days.append("Sunday")
+        return days
+
+    @property
+    def triggers(self) -> TaskScheduleTriggerManager:
+        """Get trigger manager scoped to this schedule.
+
+        Returns:
+            TaskScheduleTriggerManager for this schedule.
+        """
+        from typing import cast
+
+        from pyvergeos.resources.task_schedule_triggers import TaskScheduleTriggerManager
+
+        manager = cast("TaskScheduleManager", self._manager)
+        return TaskScheduleTriggerManager(manager._client, schedule_key=self.key)
+
+    def enable(self) -> TaskSchedule:
+        """Enable this schedule.
+
+        Returns:
+            Updated TaskSchedule object.
+        """
+        from typing import cast
+
+        manager = cast("TaskScheduleManager", self._manager)
+        return manager.update(self.key, enabled=True)
+
+    def disable(self) -> TaskSchedule:
+        """Disable this schedule.
+
+        Returns:
+            Updated TaskSchedule object.
+        """
+        from typing import cast
+
+        manager = cast("TaskScheduleManager", self._manager)
+        return manager.update(self.key, enabled=False)
+
+    def get_schedule(
+        self,
+        max_results: int = 100,
+        start_time: int | None = None,
+        end_time: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Get upcoming scheduled execution times.
+
+        Args:
+            max_results: Maximum number of results (1-1440).
+            start_time: Start timestamp for range.
+            end_time: End timestamp for range.
+
+        Returns:
+            List of scheduled execution time dicts.
+        """
+        from typing import cast
+
+        manager = cast("TaskScheduleManager", self._manager)
+        return manager.get_schedule(
+            self.key,
+            max_results=max_results,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+
+class TaskScheduleManager(ResourceManager[TaskSchedule]):
+    """Manager for task schedule operations.
+
+    Task schedules define when and how often tasks should run.
+
+    Example:
+        >>> # List all schedules
+        >>> for schedule in client.task_schedules.list():
+        ...     print(f"{schedule.name}: {schedule.repeat_every_display}")
+
+        >>> # Create a daily schedule
+        >>> schedule = client.task_schedules.create(
+        ...     name="Daily Backup",
+        ...     repeat_every="day",
+        ...     start_time_of_day=7200,  # 2 AM
+        ... )
+
+        >>> # Enable/disable
+        >>> schedule.disable()
+        >>> schedule.enable()
+
+        >>> # Get upcoming execution times
+        >>> times = schedule.get_schedule(max_results=10)
+    """
+
+    _endpoint = "task_schedules"
+
+    _default_fields = [
+        "$key",
+        "name",
+        "description",
+        "enabled",
+        "task",
+        "task#$display as task_display",
+        "repeat_every",
+        "repeat_iteration",
+        "start_date",
+        "start_date_epoch",
+        "end_date",
+        "start_time_of_day",
+        "end_time_of_day",
+        "all_day",
+        "day_of_month",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+        "system_created",
+        "creator",
+        "creator#$display as creator_display",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def _to_model(self, data: dict[str, Any]) -> TaskSchedule:
+        return TaskSchedule(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        enabled: bool | None = None,
+        repeat_every: str | None = None,
+        name: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TaskSchedule]:
+        """List task schedules with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            enabled: Filter by enabled state.
+            repeat_every: Filter by repeat interval.
+            name: Filter by name.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of TaskSchedule objects.
+
+        Example:
+            >>> # All schedules
+            >>> schedules = client.task_schedules.list()
+
+            >>> # Enabled daily schedules
+            >>> daily = client.task_schedules.list(enabled=True, repeat_every="day")
+
+            >>> # Schedules by name pattern
+            >>> backups = client.task_schedules.list(name="Backup*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter conditions
+        filters: builtins.list[str] = []
+
+        if filter:
+            filters.append(f"({filter})")
+
+        if enabled is not None:
+            filters.append(f"enabled eq {str(enabled).lower()}")
+
+        if repeat_every is not None:
+            filters.append(f"repeat_every eq '{repeat_every}'")
+
+        if name is not None:
+            if "*" in name or "?" in name:
+                search_term = name.replace("*", "").replace("?", "")
+                if search_term:
+                    filters.append(f"name ct '{search_term}'")
+            else:
+                escaped_name = name.replace("'", "''")
+                filters.append(f"name eq '{escaped_name}'")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> TaskSchedule:
+        """Get a task schedule by key or name.
+
+        Args:
+            key: Schedule $key (ID).
+            name: Schedule name.
+            fields: List of fields to return.
+
+        Returns:
+            TaskSchedule object.
+
+        Raises:
+            NotFoundError: If schedule not found.
+            ValueError: If neither key nor name provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Task schedule {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Task schedule {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Task schedule with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        *,
+        description: str | None = None,
+        enabled: bool = True,
+        repeat_every: str = "hour",
+        repeat_iteration: int = 1,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        start_time_of_day: int = 0,
+        end_time_of_day: int = 86400,
+        day_of_month: str = "start_date",
+        monday: bool = True,
+        tuesday: bool = True,
+        wednesday: bool = True,
+        thursday: bool = True,
+        friday: bool = True,
+        saturday: bool = True,
+        sunday: bool = True,
+        task: int | None = None,
+    ) -> TaskSchedule:
+        """Create a new task schedule.
+
+        Args:
+            name: Schedule name (required).
+            description: Schedule description.
+            enabled: Whether schedule is enabled (default True).
+            repeat_every: Repeat interval (minute, hour, day, week, month, year, never).
+            repeat_iteration: Number of intervals between executions (default 1).
+            start_date: Start date in YYYY-MM-DD format.
+            end_date: Expiration date in YYYY-MM-DD HH:MM:SS format.
+            start_time_of_day: Start time in seconds from midnight (0-86400).
+            end_time_of_day: End time in seconds from midnight (0-86400).
+            day_of_month: Day of month for monthly schedules (first, last, 15th, start_date).
+            monday-sunday: Boolean flags for weekly schedules.
+            task: Bind to specific task key.
+
+        Returns:
+            Created TaskSchedule object.
+
+        Example:
+            >>> # Hourly schedule
+            >>> schedule = client.task_schedules.create(
+            ...     name="Hourly Check",
+            ...     repeat_every="hour",
+            ...     repeat_iteration=1,
+            ... )
+
+            >>> # Daily at 2 AM (7200 seconds from midnight)
+            >>> schedule = client.task_schedules.create(
+            ...     name="Nightly Backup",
+            ...     repeat_every="day",
+            ...     start_time_of_day=7200,
+            ... )
+
+            >>> # Weekly on weekdays only
+            >>> schedule = client.task_schedules.create(
+            ...     name="Weekday Report",
+            ...     repeat_every="week",
+            ...     saturday=False,
+            ...     sunday=False,
+            ... )
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "enabled": enabled,
+            "repeat_every": repeat_every,
+            "repeat_iteration": repeat_iteration,
+            "start_time_of_day": start_time_of_day,
+            "end_time_of_day": end_time_of_day,
+            "day_of_month": day_of_month,
+            "monday": monday,
+            "tuesday": tuesday,
+            "wednesday": wednesday,
+            "thursday": thursday,
+            "friday": friday,
+            "saturday": saturday,
+            "sunday": sunday,
+        }
+
+        if description is not None:
+            body["description"] = description
+
+        if start_date is not None:
+            body["start_date"] = start_date
+
+        if end_date is not None:
+            body["end_date"] = end_date
+
+        if task is not None:
+            body["task"] = task
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        # Get the full object with all fields
+        key = response.get("$key")
+        if key is not None:
+            return self.get(int(key))
+
+        return self._to_model(response)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        enabled: bool | None = None,
+        repeat_every: str | None = None,
+        repeat_iteration: int | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        start_time_of_day: int | None = None,
+        end_time_of_day: int | None = None,
+        day_of_month: str | None = None,
+        monday: bool | None = None,
+        tuesday: bool | None = None,
+        wednesday: bool | None = None,
+        thursday: bool | None = None,
+        friday: bool | None = None,
+        saturday: bool | None = None,
+        sunday: bool | None = None,
+    ) -> TaskSchedule:
+        """Update an existing task schedule.
+
+        Args:
+            key: Schedule $key (ID).
+            name: New name.
+            description: New description.
+            enabled: Enable/disable.
+            repeat_every: New repeat interval.
+            repeat_iteration: New iteration count.
+            start_date: New start date.
+            end_date: New expiration date.
+            start_time_of_day: New start time.
+            end_time_of_day: New end time.
+            day_of_month: New day of month setting.
+            monday-sunday: Day flags.
+
+        Returns:
+            Updated TaskSchedule object.
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if enabled is not None:
+            body["enabled"] = enabled
+        if repeat_every is not None:
+            body["repeat_every"] = repeat_every
+        if repeat_iteration is not None:
+            body["repeat_iteration"] = repeat_iteration
+        if start_date is not None:
+            body["start_date"] = start_date
+        if end_date is not None:
+            body["end_date"] = end_date
+        if start_time_of_day is not None:
+            body["start_time_of_day"] = start_time_of_day
+        if end_time_of_day is not None:
+            body["end_time_of_day"] = end_time_of_day
+        if day_of_month is not None:
+            body["day_of_month"] = day_of_month
+        if monday is not None:
+            body["monday"] = monday
+        if tuesday is not None:
+            body["tuesday"] = tuesday
+        if wednesday is not None:
+            body["wednesday"] = wednesday
+        if thursday is not None:
+            body["thursday"] = thursday
+        if friday is not None:
+            body["friday"] = friday
+        if saturday is not None:
+            body["saturday"] = saturday
+        if sunday is not None:
+            body["sunday"] = sunday
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a task schedule.
+
+        Note:
+            Schedules with active triggers cannot be deleted.
+
+        Args:
+            key: Schedule $key (ID).
+
+        Raises:
+            ConflictError: If schedule has active triggers.
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def enable(self, key: int) -> TaskSchedule:
+        """Enable a task schedule.
+
+        Args:
+            key: Schedule $key (ID).
+
+        Returns:
+            Updated TaskSchedule object.
+        """
+        return self.update(key, enabled=True)
+
+    def disable(self, key: int) -> TaskSchedule:
+        """Disable a task schedule.
+
+        Args:
+            key: Schedule $key (ID).
+
+        Returns:
+            Updated TaskSchedule object.
+        """
+        return self.update(key, enabled=False)
+
+    def get_schedule(
+        self,
+        key: int,
+        max_results: int = 100,
+        start_time: int | None = None,
+        end_time: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Get upcoming scheduled execution times for a schedule.
+
+        Args:
+            key: Schedule $key (ID).
+            max_results: Maximum number of results (1-1440, default 100).
+            start_time: Start timestamp for range.
+            end_time: End timestamp for range.
+
+        Returns:
+            List of scheduled execution time dicts.
+
+        Example:
+            >>> # Get next 10 scheduled times
+            >>> times = client.task_schedules.get_schedule(schedule.key, max_results=10)
+            >>> for t in times:
+            ...     print(t)
+        """
+        params: dict[str, Any] = {"max": min(max(max_results, 1), 1440)}
+
+        if start_time is not None:
+            params["start_time"] = start_time
+        if end_time is not None:
+            params["end_time"] = end_time
+
+        response = self.action(key, "get_schedule", **params)
+
+        if response is None:
+            return []
+        if isinstance(response, dict):
+            # Response might contain a list of times
+            times = response.get("times") or response.get("schedule") or []
+            if isinstance(times, list):
+                return times
+            return [response]
+        if isinstance(response, list):
+            return response
+
+        return []
+
+    def list_enabled(
+        self,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[TaskSchedule]:
+        """List enabled schedules.
+
+        Args:
+            fields: List of fields to return.
+            limit: Maximum number of results.
+
+        Returns:
+            List of enabled TaskSchedule objects.
+        """
+        return self.list(enabled=True, fields=fields, limit=limit)
+
+    def list_disabled(
+        self,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[TaskSchedule]:
+        """List disabled schedules.
+
+        Args:
+            fields: List of fields to return.
+            limit: Maximum number of results.
+
+        Returns:
+            List of disabled TaskSchedule objects.
+        """
+        return self.list(enabled=False, fields=fields, limit=limit)
+
+    def triggers(self, key: int) -> TaskScheduleTriggerManager:
+        """Get trigger manager scoped to a specific schedule.
+
+        Args:
+            key: Schedule $key (ID).
+
+        Returns:
+            TaskScheduleTriggerManager for the schedule.
+        """
+        from pyvergeos.resources.task_schedule_triggers import TaskScheduleTriggerManager
+
+        return TaskScheduleTriggerManager(self._client, schedule_key=key)
+
+
+# Import for type hints only to avoid circular import
+if TYPE_CHECKING:
+    from pyvergeos.resources.task_schedule_triggers import TaskScheduleTriggerManager

--- a/pyvergeos/resources/task_scripts.py
+++ b/pyvergeos/resources/task_scripts.py
@@ -1,0 +1,385 @@
+"""Task script resource manager for VergeOS automation scripts.
+
+Task scripts are GCS (VergeOS scripting) code that can be executed as tasks.
+Scripts can define questions (settings) that are prompted when running,
+allowing for reusable automation with configurable parameters.
+
+Example:
+    >>> # List all scripts
+    >>> for script in client.task_scripts.list():
+    ...     print(f"{script.name}: {script.task_count} tasks")
+
+    >>> # Create a simple script
+    >>> script = client.task_scripts.create(
+    ...     name="Cleanup Script",
+    ...     description="Removes old temporary files",
+    ...     script="# GCS script code here\\nlog('Cleanup started')",
+    ...     task_settings={"questions": []},
+    ... )
+
+    >>> # Run a script
+    >>> result = script.run()
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class TaskScript(ResourceObject):
+    """Task script resource object.
+
+    Represents a GCS automation script that can be executed as tasks.
+
+    Properties:
+        name: Script name (unique).
+        description: Script description.
+        script_code: The GCS script code.
+        task_settings: JSON settings/questions for the script.
+        task_count: Number of tasks using this script.
+    """
+
+    @property
+    def script_code(self) -> str | None:
+        """Get the script code."""
+        return self.get("script")
+
+    @property
+    def settings(self) -> dict[str, Any] | None:
+        """Get the script settings/questions."""
+        settings = self.get("task_settings")
+        if isinstance(settings, dict):
+            return settings
+        return None
+
+    @property
+    def task_count(self) -> int:
+        """Get the number of tasks using this script."""
+        return int(self.get("task_count", 0))
+
+    def run(self, **params: Any) -> dict[str, Any] | None:
+        """Run this script.
+
+        Args:
+            **params: Parameters to pass to the script.
+
+        Returns:
+            Run action response dict or None.
+        """
+        from typing import cast
+
+        manager = cast("TaskScriptManager", self._manager)
+        return manager.run(self.key, **params)
+
+
+class TaskScriptManager(ResourceManager[TaskScript]):
+    """Manager for task script operations.
+
+    Task scripts provide reusable GCS automation code.
+
+    Example:
+        >>> # List all scripts
+        >>> for script in client.task_scripts.list():
+        ...     print(f"{script.name}: {script.description}")
+
+        >>> # Create a script
+        >>> script = client.task_scripts.create(
+        ...     name="My Script",
+        ...     script="log('Hello World')",
+        ...     task_settings={"questions": []},
+        ... )
+
+        >>> # Get a script by name
+        >>> script = client.task_scripts.get(name="My Script")
+
+        >>> # Run a script
+        >>> result = client.task_scripts.run(script.key)
+
+        >>> # Update script code
+        >>> script = client.task_scripts.update(
+        ...     script.key,
+        ...     script="log('Updated code')"
+        ... )
+    """
+
+    _endpoint = "task_scripts"
+
+    _default_fields = [
+        "$key",
+        "name",
+        "description",
+        "script",
+        "task_settings",
+        "count(tasks) as task_count",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def _to_model(self, data: dict[str, Any]) -> TaskScript:
+        return TaskScript(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        name: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TaskScript]:
+        """List task scripts with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            name: Filter by name.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of TaskScript objects.
+
+        Example:
+            >>> # All scripts
+            >>> scripts = client.task_scripts.list()
+
+            >>> # Scripts by name pattern
+            >>> scripts = client.task_scripts.list(name="Backup*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter conditions
+        filters: builtins.list[str] = []
+
+        if filter:
+            filters.append(f"({filter})")
+
+        if name is not None:
+            if "*" in name or "?" in name:
+                search_term = name.replace("*", "").replace("?", "")
+                if search_term:
+                    filters.append(f"name ct '{search_term}'")
+            else:
+                escaped_name = name.replace("'", "''")
+                filters.append(f"name eq '{escaped_name}'")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> TaskScript:
+        """Get a task script by key or name.
+
+        Args:
+            key: Script $key (ID).
+            name: Script name (unique).
+            fields: List of fields to return.
+
+        Returns:
+            TaskScript object.
+
+        Raises:
+            NotFoundError: If script not found.
+            ValueError: If neither key nor name provided.
+        """
+        if key is not None:
+            params: dict[str, Any] = {}
+            if fields:
+                params["fields"] = ",".join(fields)
+            else:
+                params["fields"] = ",".join(self._default_fields)
+
+            response = self._client._request(
+                "GET", f"{self._endpoint}/{key}", params=params
+            )
+            if response is None:
+                raise NotFoundError(f"Task script {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Task script {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Task script with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        script: str,
+        *,
+        description: str | None = None,
+        task_settings: dict[str, Any] | None = None,
+    ) -> TaskScript:
+        """Create a new task script.
+
+        Args:
+            name: Script name (unique, required).
+            script: GCS script code (required).
+            description: Script description.
+            task_settings: JSON settings/questions for the script.
+
+        Returns:
+            Created TaskScript object.
+
+        Example:
+            >>> script = client.task_scripts.create(
+            ...     name="My Script",
+            ...     description="Does something useful",
+            ...     script="log('Hello World')",
+            ...     task_settings={"questions": []},
+            ... )
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "script": script,
+        }
+
+        if description is not None:
+            body["description"] = description
+
+        if task_settings is not None:
+            body["task_settings"] = task_settings
+        else:
+            # Provide default empty settings
+            body["task_settings"] = {"questions": []}
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        # Get the full object
+        key = response.get("$key")
+        if key is not None:
+            return self.get(int(key))
+
+        return self._to_model(response)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        script: str | None = None,
+        task_settings: dict[str, Any] | None = None,
+    ) -> TaskScript:
+        """Update an existing task script.
+
+        Args:
+            key: Script $key (ID).
+            name: New name.
+            description: New description.
+            script: New GCS script code.
+            task_settings: New settings/questions.
+
+        Returns:
+            Updated TaskScript object.
+
+        Example:
+            >>> script = client.task_scripts.update(
+            ...     script.key,
+            ...     script="log('Updated code')"
+            ... )
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if script is not None:
+            body["script"] = script
+        if task_settings is not None:
+            body["task_settings"] = task_settings
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a task script.
+
+        Note:
+            Scripts with associated tasks cannot be deleted.
+            The tasks will be cascade deleted.
+
+        Args:
+            key: Script $key (ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def run(self, key: int, **params: Any) -> dict[str, Any] | None:
+        """Run a task script.
+
+        Executes the script, optionally with provided parameters.
+
+        Args:
+            key: Script $key (ID).
+            **params: Parameters to pass to the script.
+
+        Returns:
+            Run action response dict or None.
+
+        Example:
+            >>> # Run a script
+            >>> result = client.task_scripts.run(script.key)
+
+            >>> # Run with parameters
+            >>> result = client.task_scripts.run(
+            ...     script.key,
+            ...     target_vm=123,
+            ...     cleanup=True,
+            ... )
+        """
+        return self.action(key, "run", **params)

--- a/tests/integration/test_task_scheduling.py
+++ b/tests/integration/test_task_scheduling.py
@@ -1,0 +1,410 @@
+"""Integration tests for Task Scheduling System.
+
+These tests require a live VergeOS system and will be skipped
+if the environment variables are not set.
+
+Tests cover:
+- TaskScheduleManager
+- TaskScheduleTriggerManager
+- TaskEventManager
+- TaskScriptManager
+- Enhanced TaskManager CRUD operations
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+
+# =============================================================================
+# Task Schedule Integration Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTaskScheduleListIntegration:
+    """Integration tests for TaskScheduleManager list operations."""
+
+    def test_list_schedules(self, live_client: VergeClient) -> None:
+        """Test listing task schedules from live system."""
+        schedules = live_client.task_schedules.list()
+
+        assert isinstance(schedules, list)
+        for schedule in schedules:
+            assert hasattr(schedule, "key")
+            assert hasattr(schedule, "name")
+            assert hasattr(schedule, "is_enabled")
+
+    def test_list_enabled_schedules(self, live_client: VergeClient) -> None:
+        """Test listing enabled schedules."""
+        schedules = live_client.task_schedules.list_enabled()
+
+        assert isinstance(schedules, list)
+        for schedule in schedules:
+            assert schedule.is_enabled is True
+
+    def test_list_disabled_schedules(self, live_client: VergeClient) -> None:
+        """Test listing disabled schedules."""
+        schedules = live_client.task_schedules.list_disabled()
+
+        assert isinstance(schedules, list)
+        for schedule in schedules:
+            assert schedule.is_enabled is False
+
+
+@pytest.mark.integration
+class TestTaskScheduleGetIntegration:
+    """Integration tests for TaskScheduleManager get operations."""
+
+    def test_get_schedule_by_key(self, live_client: VergeClient) -> None:
+        """Test getting a schedule by key."""
+        schedules = live_client.task_schedules.list()
+        if not schedules:
+            pytest.skip("No schedules available")
+
+        schedule = live_client.task_schedules.get(schedules[0].key)
+        assert schedule.key == schedules[0].key
+        assert schedule.name == schedules[0].name
+
+    def test_get_schedule_by_name(self, live_client: VergeClient) -> None:
+        """Test getting a schedule by name."""
+        schedules = live_client.task_schedules.list()
+        if not schedules:
+            pytest.skip("No schedules available")
+
+        schedule = live_client.task_schedules.get(name=schedules[0].name)
+        assert schedule.name == schedules[0].name
+
+    def test_get_nonexistent_schedule(self, live_client: VergeClient) -> None:
+        """Test NotFoundError for nonexistent schedule."""
+        with pytest.raises(NotFoundError):
+            live_client.task_schedules.get(999999)
+
+
+@pytest.mark.integration
+class TestTaskSchedulePropertiesIntegration:
+    """Integration tests for TaskSchedule properties."""
+
+    def test_schedule_properties(self, live_client: VergeClient) -> None:
+        """Test TaskSchedule property accessors."""
+        schedules = live_client.task_schedules.list()
+        if not schedules:
+            pytest.skip("No schedules available")
+
+        schedule = schedules[0]
+
+        # Basic properties
+        assert schedule.key is not None
+        assert schedule.name is not None
+        assert isinstance(schedule.is_enabled, bool)
+        assert isinstance(schedule.repeat_every_display, str)
+        assert isinstance(schedule.repeat_count, int)
+        assert isinstance(schedule.active_days, list)
+
+
+@pytest.mark.integration
+class TestTaskScheduleCRUDIntegration:
+    """Integration tests for TaskSchedule CRUD operations."""
+
+    def test_create_update_delete_schedule(self, live_client: VergeClient) -> None:
+        """Test creating, updating, and deleting a schedule."""
+        # Create
+        schedule = live_client.task_schedules.create(
+            name="PyVergeOS Test Schedule",
+            description="Integration test schedule",
+            repeat_every="day",
+            start_time_of_day=3600,  # 1 AM
+            enabled=False,  # Keep disabled for safety
+        )
+
+        try:
+            assert schedule.name == "PyVergeOS Test Schedule"
+            assert schedule.is_enabled is False
+            assert schedule.get("repeat_every") == "day"
+
+            # Update
+            updated = live_client.task_schedules.update(
+                schedule.key,
+                description="Updated description",
+                repeat_iteration=2,
+            )
+            assert updated.get("description") == "Updated description"
+            assert updated.repeat_count == 2
+
+        finally:
+            # Delete
+            live_client.task_schedules.delete(schedule.key)
+
+            # Verify deleted
+            with pytest.raises(NotFoundError):
+                live_client.task_schedules.get(schedule.key)
+
+
+# =============================================================================
+# Task Schedule Trigger Integration Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTaskScheduleTriggerListIntegration:
+    """Integration tests for TaskScheduleTriggerManager list operations."""
+
+    def test_list_triggers(self, live_client: VergeClient) -> None:
+        """Test listing task schedule triggers."""
+        triggers = live_client.task_schedule_triggers.list()
+
+        assert isinstance(triggers, list)
+        for trigger in triggers:
+            assert hasattr(trigger, "key")
+            assert hasattr(trigger, "task_key")
+            assert hasattr(trigger, "schedule_key")
+
+
+@pytest.mark.integration
+class TestTaskScheduleTriggerScopedIntegration:
+    """Integration tests for scoped trigger managers."""
+
+    def test_triggers_scoped_to_task(self, live_client: VergeClient) -> None:
+        """Test getting triggers scoped to a task."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        task = tasks[0]
+        triggers = task.triggers.list()
+
+        assert isinstance(triggers, list)
+        for trigger in triggers:
+            assert trigger.task_key == task.key
+
+    def test_triggers_scoped_to_schedule(self, live_client: VergeClient) -> None:
+        """Test getting triggers scoped to a schedule."""
+        schedules = live_client.task_schedules.list()
+        if not schedules:
+            pytest.skip("No schedules available")
+
+        schedule = schedules[0]
+        triggers = schedule.triggers.list()
+
+        assert isinstance(triggers, list)
+        for trigger in triggers:
+            assert trigger.schedule_key == schedule.key
+
+
+# =============================================================================
+# Task Event Integration Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTaskEventListIntegration:
+    """Integration tests for TaskEventManager list operations."""
+
+    def test_list_events(self, live_client: VergeClient) -> None:
+        """Test listing task events."""
+        events = live_client.task_events.list()
+
+        assert isinstance(events, list)
+        for event in events:
+            assert hasattr(event, "key")
+            assert hasattr(event, "task_key")
+            assert hasattr(event, "owner_key")
+
+    def test_list_events_by_table(self, live_client: VergeClient) -> None:
+        """Test listing events filtered by table."""
+        events = live_client.task_events.list(table="vms")
+
+        assert isinstance(events, list)
+        for event in events:
+            assert event.owner_table == "vms"
+
+
+@pytest.mark.integration
+class TestTaskEventScopedIntegration:
+    """Integration tests for scoped event managers."""
+
+    def test_events_scoped_to_task(self, live_client: VergeClient) -> None:
+        """Test getting events scoped to a task."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        task = tasks[0]
+        events = task.events.list()
+
+        assert isinstance(events, list)
+        for event in events:
+            assert event.task_key == task.key
+
+
+# =============================================================================
+# Task Script Integration Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTaskScriptListIntegration:
+    """Integration tests for TaskScriptManager list operations."""
+
+    def test_list_scripts(self, live_client: VergeClient) -> None:
+        """Test listing task scripts."""
+        scripts = live_client.task_scripts.list()
+
+        assert isinstance(scripts, list)
+        for script in scripts:
+            assert hasattr(script, "key")
+            assert hasattr(script, "name")
+            assert hasattr(script, "script_code")
+
+
+@pytest.mark.integration
+class TestTaskScriptGetIntegration:
+    """Integration tests for TaskScriptManager get operations."""
+
+    def test_get_script_by_key(self, live_client: VergeClient) -> None:
+        """Test getting a script by key."""
+        scripts = live_client.task_scripts.list()
+        if not scripts:
+            pytest.skip("No scripts available")
+
+        script = live_client.task_scripts.get(scripts[0].key)
+        assert script.key == scripts[0].key
+        assert script.name == scripts[0].name
+
+    def test_get_script_by_name(self, live_client: VergeClient) -> None:
+        """Test getting a script by name."""
+        scripts = live_client.task_scripts.list()
+        if not scripts:
+            pytest.skip("No scripts available")
+
+        script = live_client.task_scripts.get(name=scripts[0].name)
+        assert script.name == scripts[0].name
+
+
+@pytest.mark.integration
+class TestTaskScriptCRUDIntegration:
+    """Integration tests for TaskScript CRUD operations."""
+
+    def test_create_update_delete_script(self, live_client: VergeClient) -> None:
+        """Test creating, updating, and deleting a script."""
+        # Create - use valid GCS script syntax (simple return statement)
+        script = live_client.task_scripts.create(
+            name="PyVergeOS Test Script",
+            description="Integration test script",
+            script="return_success();",
+            task_settings={"questions": []},
+        )
+
+        try:
+            assert script.name == "PyVergeOS Test Script"
+            assert "return_success" in script.script_code
+
+            # Update
+            updated = live_client.task_scripts.update(
+                script.key,
+                description="Updated description",
+            )
+            assert updated.get("description") == "Updated description"
+
+        finally:
+            # Delete
+            live_client.task_scripts.delete(script.key)
+
+            # Verify deleted
+            with pytest.raises(NotFoundError):
+                live_client.task_scripts.get(script.key)
+
+
+# =============================================================================
+# Enhanced Task Manager Integration Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTaskEnhancedIntegration:
+    """Integration tests for enhanced Task properties."""
+
+    def test_task_trigger_count(self, live_client: VergeClient) -> None:
+        """Test trigger_count property."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        for task in tasks:
+            assert isinstance(task.trigger_count, int)
+            assert task.trigger_count >= 0
+
+    def test_task_event_count(self, live_client: VergeClient) -> None:
+        """Test event_count property."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        for task in tasks:
+            assert isinstance(task.event_count, int)
+            assert task.event_count >= 0
+
+    def test_task_owner_table(self, live_client: VergeClient) -> None:
+        """Test owner_table property."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        for task in tasks:
+            # owner_table might be None for some tasks
+            if task.owner_table is not None:
+                assert isinstance(task.owner_table, str)
+
+
+@pytest.mark.integration
+class TestTaskManagerHelperMethods:
+    """Integration tests for TaskManager helper methods."""
+
+    def test_triggers_method(self, live_client: VergeClient) -> None:
+        """Test triggers() method returns scoped manager."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        task = tasks[0]
+        triggers_manager = live_client.tasks.triggers(task.key)
+        triggers = triggers_manager.list()
+
+        assert isinstance(triggers, list)
+        for trigger in triggers:
+            assert trigger.task_key == task.key
+
+    def test_events_method(self, live_client: VergeClient) -> None:
+        """Test events() method returns scoped manager."""
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        task = tasks[0]
+        events_manager = live_client.tasks.events(task.key)
+        events = events_manager.list()
+
+        assert isinstance(events, list)
+        for event in events:
+            assert event.task_key == task.key
+
+    def test_list_by_action(self, live_client: VergeClient) -> None:
+        """Test list_by_action method."""
+        # Get all tasks to find an action type
+        tasks = live_client.tasks.list()
+        if not tasks:
+            pytest.skip("No tasks available")
+
+        # Get first task's action
+        action = tasks[0].action_type
+        if not action:
+            pytest.skip("No action type available")
+
+        # Filter by that action
+        filtered = live_client.tasks.list_by_action(action)
+
+        assert isinstance(filtered, list)
+        for task in filtered:
+            assert task.action_type == action

--- a/tests/unit/test_task_scheduling.py
+++ b/tests/unit/test_task_scheduling.py
@@ -1,0 +1,703 @@
+"""Unit tests for task scheduling system.
+
+Tests for:
+- TaskScheduleManager
+- TaskScheduleTriggerManager
+- TaskEventManager
+- TaskScriptManager
+- Enhanced TaskManager CRUD
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.task_events import TaskEvent, TaskEventManager
+from pyvergeos.resources.task_schedule_triggers import (
+    TaskScheduleTrigger,
+    TaskScheduleTriggerManager,
+)
+from pyvergeos.resources.task_schedules import TaskSchedule, TaskScheduleManager
+from pyvergeos.resources.task_scripts import TaskScript, TaskScriptManager
+from pyvergeos.resources.tasks import Task, TaskManager
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def task_manager(mock_client):
+    """Create a TaskManager with mock client."""
+    return TaskManager(mock_client)
+
+
+@pytest.fixture
+def schedule_manager(mock_client):
+    """Create a TaskScheduleManager with mock client."""
+    return TaskScheduleManager(mock_client)
+
+
+@pytest.fixture
+def trigger_manager(mock_client):
+    """Create a TaskScheduleTriggerManager with mock client."""
+    return TaskScheduleTriggerManager(mock_client)
+
+
+@pytest.fixture
+def scoped_trigger_manager(mock_client):
+    """Create a scoped TaskScheduleTriggerManager."""
+    return TaskScheduleTriggerManager(mock_client, task_key=1)
+
+
+@pytest.fixture
+def event_manager(mock_client):
+    """Create a TaskEventManager with mock client."""
+    return TaskEventManager(mock_client)
+
+
+@pytest.fixture
+def scoped_event_manager(mock_client):
+    """Create a scoped TaskEventManager."""
+    return TaskEventManager(mock_client, task_key=1)
+
+
+@pytest.fixture
+def script_manager(mock_client):
+    """Create a TaskScriptManager with mock client."""
+    return TaskScriptManager(mock_client)
+
+
+@pytest.fixture
+def sample_task():
+    """Sample task data from API."""
+    return {
+        "$key": 1,
+        "name": "Daily Backup",
+        "description": "Daily backup of production VM",
+        "enabled": True,
+        "status": "idle",
+        "action": "snapshot",
+        "action_display": "Snapshot",
+        "table": "vms",
+        "owner": 10,
+        "owner_display": "web-server",
+        "creator": 1,
+        "creator_display": "admin",
+        "last_run": "2024-01-01 02:00:00",
+        "delete_after_run": False,
+        "system_created": False,
+        "id": "a" * 40,
+        "triggers_count": 2,
+        "events_count": 1,
+    }
+
+
+@pytest.fixture
+def sample_schedule():
+    """Sample task schedule data from API."""
+    return {
+        "$key": 1,
+        "name": "Nightly",
+        "description": "Runs every night at 2 AM",
+        "enabled": True,
+        "task": None,
+        "repeat_every": "day",
+        "repeat_iteration": 1,
+        "start_date": "2024-01-01",
+        "start_date_epoch": 1704067200,
+        "end_date": "",
+        "start_time_of_day": 7200,
+        "end_time_of_day": 86400,
+        "all_day": False,
+        "day_of_month": "start_date",
+        "monday": True,
+        "tuesday": True,
+        "wednesday": True,
+        "thursday": True,
+        "friday": True,
+        "saturday": True,
+        "sunday": True,
+        "system_created": False,
+        "creator": 1,
+        "creator_display": "admin",
+    }
+
+
+@pytest.fixture
+def sample_trigger():
+    """Sample task schedule trigger data from API."""
+    return {
+        "$key": 1,
+        "task": 1,
+        "task_display": "Daily Backup",
+        "schedule": 1,
+        "schedule_display": "Nightly",
+        "trigger": 1704153600,
+        "sch_enabled": True,
+        "sch_repeat_every": "Day(s)",
+        "sch_start_time_of_day": 7200,
+    }
+
+
+@pytest.fixture
+def sample_event():
+    """Sample task event data from API."""
+    return {
+        "$key": 1,
+        "owner": 10,
+        "owner_display": "web-server",
+        "table": "vms",
+        "event": "poweron",
+        "event_name": "Power On",
+        "task": 1,
+        "task_display": "Notification Task",
+        "task_name": "Notification Task",
+        "table_event_filters": {"status": "running"},
+        "trigger": 0,
+        "context": {"notify": True},
+    }
+
+
+@pytest.fixture
+def sample_script():
+    """Sample task script data from API."""
+    return {
+        "$key": 1,
+        "name": "Cleanup Script",
+        "description": "Removes old temporary files",
+        "script": "log('Cleanup started')\n// cleanup code here",
+        "task_settings": {"questions": []},
+        "task_count": 2,
+    }
+
+
+# =============================================================================
+# TaskSchedule Tests
+# =============================================================================
+
+
+class TestTaskSchedule:
+    """Tests for TaskSchedule model."""
+
+    def test_is_enabled(self, schedule_manager, sample_schedule):
+        """Test is_enabled property."""
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert schedule.is_enabled is True
+
+        sample_schedule["enabled"] = False
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert schedule.is_enabled is False
+
+    def test_repeat_every_display(self, schedule_manager, sample_schedule):
+        """Test repeat_every_display property."""
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert schedule.repeat_every_display == "Day(s)"
+
+    def test_repeat_count(self, schedule_manager, sample_schedule):
+        """Test repeat_count property."""
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert schedule.repeat_count == 1
+
+    def test_active_days(self, schedule_manager, sample_schedule):
+        """Test active_days property returns all days."""
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert len(schedule.active_days) == 7
+        assert "Monday" in schedule.active_days
+        assert "Sunday" in schedule.active_days
+
+    def test_active_days_weekdays_only(self, schedule_manager, sample_schedule):
+        """Test active_days with weekdays only."""
+        sample_schedule["saturday"] = False
+        sample_schedule["sunday"] = False
+        schedule = TaskSchedule(sample_schedule, schedule_manager)
+        assert len(schedule.active_days) == 5
+        assert "Saturday" not in schedule.active_days
+        assert "Sunday" not in schedule.active_days
+
+
+class TestTaskScheduleManager:
+    """Tests for TaskScheduleManager."""
+
+    def test_list_returns_schedules(self, schedule_manager, mock_client, sample_schedule):
+        """Test listing schedules."""
+        mock_client._request.return_value = [sample_schedule]
+
+        schedules = schedule_manager.list()
+
+        assert len(schedules) == 1
+        assert isinstance(schedules[0], TaskSchedule)
+        assert schedules[0].name == "Nightly"
+        mock_client._request.assert_called_once()
+
+    def test_list_empty(self, schedule_manager, mock_client):
+        """Test listing returns empty list when no results."""
+        mock_client._request.return_value = None
+
+        schedules = schedule_manager.list()
+
+        assert schedules == []
+
+    def test_list_with_enabled_filter(self, schedule_manager, mock_client, sample_schedule):
+        """Test listing with enabled filter."""
+        mock_client._request.return_value = [sample_schedule]
+
+        schedules = schedule_manager.list(enabled=True)
+
+        assert len(schedules) == 1
+        call_args = mock_client._request.call_args
+        assert "enabled eq true" in call_args.kwargs.get("params", {}).get("filter", "")
+
+    def test_get_by_key(self, schedule_manager, mock_client, sample_schedule):
+        """Test getting schedule by key."""
+        mock_client._request.return_value = sample_schedule
+
+        schedule = schedule_manager.get(key=1)
+
+        assert isinstance(schedule, TaskSchedule)
+        assert schedule.name == "Nightly"
+
+    def test_get_by_name(self, schedule_manager, mock_client, sample_schedule):
+        """Test getting schedule by name."""
+        mock_client._request.return_value = [sample_schedule]
+
+        schedule = schedule_manager.get(name="Nightly")
+
+        assert schedule.name == "Nightly"
+
+    def test_get_not_found(self, schedule_manager, mock_client):
+        """Test get raises NotFoundError when not found."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError):
+            schedule_manager.get(key=999)
+
+    def test_create_schedule(self, schedule_manager, mock_client, sample_schedule):
+        """Test creating a schedule."""
+        mock_client._request.side_effect = [{"$key": 1}, sample_schedule]
+
+        schedule = schedule_manager.create(
+            name="Nightly",
+            repeat_every="day",
+            start_time_of_day=7200,
+        )
+
+        assert schedule.name == "Nightly"
+        assert mock_client._request.call_count == 2
+
+    def test_update_schedule(self, schedule_manager, mock_client, sample_schedule):
+        """Test updating a schedule."""
+        mock_client._request.side_effect = [None, sample_schedule]
+
+        schedule = schedule_manager.update(1, name="Updated Name")
+
+        assert schedule.name == "Nightly"  # Returns original from get
+        assert mock_client._request.call_count == 2
+
+    def test_delete_schedule(self, schedule_manager, mock_client):
+        """Test deleting a schedule."""
+        mock_client._request.return_value = None
+
+        schedule_manager.delete(1)
+
+        mock_client._request.assert_called_with("DELETE", "task_schedules/1")
+
+    def test_enable_schedule(self, schedule_manager, mock_client, sample_schedule):
+        """Test enabling a schedule."""
+        mock_client._request.side_effect = [None, sample_schedule]
+
+        schedule = schedule_manager.enable(1)
+
+        assert schedule.is_enabled
+
+    def test_disable_schedule(self, schedule_manager, mock_client, sample_schedule):
+        """Test disabling a schedule."""
+        sample_schedule["enabled"] = False
+        mock_client._request.side_effect = [None, sample_schedule]
+
+        schedule_manager.disable(1)
+
+        call_args = mock_client._request.call_args_list[0]
+        assert call_args.kwargs.get("json_data", {}).get("enabled") is False
+
+
+# =============================================================================
+# TaskScheduleTrigger Tests
+# =============================================================================
+
+
+class TestTaskScheduleTrigger:
+    """Tests for TaskScheduleTrigger model."""
+
+    def test_task_key(self, trigger_manager, sample_trigger):
+        """Test task_key property."""
+        trigger = TaskScheduleTrigger(sample_trigger, trigger_manager)
+        assert trigger.task_key == 1
+
+    def test_schedule_key(self, trigger_manager, sample_trigger):
+        """Test schedule_key property."""
+        trigger = TaskScheduleTrigger(sample_trigger, trigger_manager)
+        assert trigger.schedule_key == 1
+
+    def test_is_schedule_enabled(self, trigger_manager, sample_trigger):
+        """Test is_schedule_enabled property."""
+        trigger = TaskScheduleTrigger(sample_trigger, trigger_manager)
+        assert trigger.is_schedule_enabled is True
+
+
+class TestTaskScheduleTriggerManager:
+    """Tests for TaskScheduleTriggerManager."""
+
+    def test_list_returns_triggers(self, trigger_manager, mock_client, sample_trigger):
+        """Test listing triggers."""
+        mock_client._request.return_value = [sample_trigger]
+
+        triggers = trigger_manager.list()
+
+        assert len(triggers) == 1
+        assert isinstance(triggers[0], TaskScheduleTrigger)
+
+    def test_list_scoped_to_task(self, scoped_trigger_manager, mock_client, sample_trigger):
+        """Test scoped trigger manager filters by task."""
+        mock_client._request.return_value = [sample_trigger]
+
+        scoped_trigger_manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "task eq 1" in call_args.kwargs.get("params", {}).get("filter", "")
+
+    def test_create_trigger(self, trigger_manager, mock_client, sample_trigger):
+        """Test creating a trigger."""
+        mock_client._request.side_effect = [{"$key": 1}, sample_trigger]
+
+        trigger = trigger_manager.create(task=1, schedule=1)
+
+        assert trigger.task_key == 1
+        assert trigger.schedule_key == 1
+
+    def test_delete_trigger(self, trigger_manager, mock_client):
+        """Test deleting a trigger."""
+        mock_client._request.return_value = None
+
+        trigger_manager.delete(1)
+
+        mock_client._request.assert_called_with("DELETE", "task_schedule_triggers/1")
+
+    def test_trigger_action(self, trigger_manager, mock_client):
+        """Test trigger action."""
+        mock_client._request.return_value = {"task": "started"}
+
+        trigger_manager.trigger(1)
+
+        mock_client._request.assert_called_with(
+            "PUT", "task_schedule_triggers/1?action=trigger", json_data={}
+        )
+
+
+# =============================================================================
+# TaskEvent Tests
+# =============================================================================
+
+
+class TestTaskEvent:
+    """Tests for TaskEvent model."""
+
+    def test_owner_key(self, event_manager, sample_event):
+        """Test owner_key property."""
+        event = TaskEvent(sample_event, event_manager)
+        assert event.owner_key == 10
+
+    def test_event_type(self, event_manager, sample_event):
+        """Test event_type property."""
+        event = TaskEvent(sample_event, event_manager)
+        assert event.event_type == "poweron"
+
+    def test_task_key(self, event_manager, sample_event):
+        """Test task_key property."""
+        event = TaskEvent(sample_event, event_manager)
+        assert event.task_key == 1
+
+    def test_event_filters(self, event_manager, sample_event):
+        """Test event_filters property."""
+        event = TaskEvent(sample_event, event_manager)
+        assert event.event_filters == {"status": "running"}
+
+    def test_event_context(self, event_manager, sample_event):
+        """Test event_context property."""
+        event = TaskEvent(sample_event, event_manager)
+        assert event.event_context == {"notify": True}
+
+
+class TestTaskEventManager:
+    """Tests for TaskEventManager."""
+
+    def test_list_returns_events(self, event_manager, mock_client, sample_event):
+        """Test listing events."""
+        mock_client._request.return_value = [sample_event]
+
+        events = event_manager.list()
+
+        assert len(events) == 1
+        assert isinstance(events[0], TaskEvent)
+
+    def test_list_scoped_to_task(self, scoped_event_manager, mock_client, sample_event):
+        """Test scoped event manager filters by task."""
+        mock_client._request.return_value = [sample_event]
+
+        scoped_event_manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "task eq 1" in call_args.kwargs.get("params", {}).get("filter", "")
+
+    def test_list_by_table(self, event_manager, mock_client, sample_event):
+        """Test filtering events by table."""
+        mock_client._request.return_value = [sample_event]
+
+        event_manager.list(table="vms")
+
+        call_args = mock_client._request.call_args
+        assert "table eq 'vms'" in call_args.kwargs.get("params", {}).get("filter", "")
+
+    def test_create_event(self, event_manager, mock_client, sample_event):
+        """Test creating an event."""
+        mock_client._request.side_effect = [{"$key": 1}, sample_event]
+
+        event = event_manager.create(task=1, owner=10, event="poweron")
+
+        assert event.task_key == 1
+        assert event.owner_key == 10
+
+    def test_delete_event(self, event_manager, mock_client):
+        """Test deleting an event."""
+        mock_client._request.return_value = None
+
+        event_manager.delete(1)
+
+        mock_client._request.assert_called_with("DELETE", "task_events/1")
+
+    def test_trigger_event(self, event_manager, mock_client):
+        """Test trigger action."""
+        mock_client._request.return_value = {"task": "started"}
+
+        event_manager.trigger(1, context={"key": "value"})
+
+        mock_client._request.assert_called_with(
+            "PUT", "task_events/1?action=trigger", json_data={"context": {"key": "value"}}
+        )
+
+
+# =============================================================================
+# TaskScript Tests
+# =============================================================================
+
+
+class TestTaskScript:
+    """Tests for TaskScript model."""
+
+    def test_script_code(self, script_manager, sample_script):
+        """Test script_code property."""
+        script = TaskScript(sample_script, script_manager)
+        assert "Cleanup started" in script.script_code
+
+    def test_settings(self, script_manager, sample_script):
+        """Test settings property."""
+        script = TaskScript(sample_script, script_manager)
+        assert script.settings == {"questions": []}
+
+    def test_task_count(self, script_manager, sample_script):
+        """Test task_count property."""
+        script = TaskScript(sample_script, script_manager)
+        assert script.task_count == 2
+
+
+class TestTaskScriptManager:
+    """Tests for TaskScriptManager."""
+
+    def test_list_returns_scripts(self, script_manager, mock_client, sample_script):
+        """Test listing scripts."""
+        mock_client._request.return_value = [sample_script]
+
+        scripts = script_manager.list()
+
+        assert len(scripts) == 1
+        assert isinstance(scripts[0], TaskScript)
+        assert scripts[0].name == "Cleanup Script"
+
+    def test_get_by_key(self, script_manager, mock_client, sample_script):
+        """Test getting script by key."""
+        mock_client._request.return_value = sample_script
+
+        script = script_manager.get(key=1)
+
+        assert script.name == "Cleanup Script"
+
+    def test_get_by_name(self, script_manager, mock_client, sample_script):
+        """Test getting script by name."""
+        mock_client._request.return_value = [sample_script]
+
+        script = script_manager.get(name="Cleanup Script")
+
+        assert script.name == "Cleanup Script"
+
+    def test_create_script(self, script_manager, mock_client, sample_script):
+        """Test creating a script."""
+        mock_client._request.side_effect = [{"$key": 1}, sample_script]
+
+        script = script_manager.create(
+            name="Cleanup Script",
+            script="log('Cleanup started')",
+            description="Removes old files",
+        )
+
+        assert script.name == "Cleanup Script"
+
+    def test_update_script(self, script_manager, mock_client, sample_script):
+        """Test updating a script."""
+        mock_client._request.side_effect = [None, sample_script]
+
+        script_manager.update(1, description="Updated description")
+
+        assert mock_client._request.call_count == 2
+
+    def test_delete_script(self, script_manager, mock_client):
+        """Test deleting a script."""
+        mock_client._request.return_value = None
+
+        script_manager.delete(1)
+
+        mock_client._request.assert_called_with("DELETE", "task_scripts/1")
+
+    def test_run_script(self, script_manager, mock_client):
+        """Test running a script."""
+        mock_client._request.return_value = {"task": "started"}
+
+        script_manager.run(1, target_vm=10)
+
+        mock_client._request.assert_called_with(
+            "PUT", "task_scripts/1?action=run", json_data={"target_vm": 10}
+        )
+
+
+# =============================================================================
+# Enhanced Task Tests (CRUD)
+# =============================================================================
+
+
+class TestTaskEnhanced:
+    """Tests for enhanced Task model with triggers/events."""
+
+    def test_owner_table(self, task_manager, sample_task):
+        """Test owner_table property."""
+        task = Task(sample_task, task_manager)
+        assert task.owner_table == "vms"
+
+    def test_action_type(self, task_manager, sample_task):
+        """Test action_type property."""
+        task = Task(sample_task, task_manager)
+        assert task.action_type == "snapshot"
+
+    def test_is_delete_after_run(self, task_manager, sample_task):
+        """Test is_delete_after_run property."""
+        task = Task(sample_task, task_manager)
+        assert task.is_delete_after_run is False
+
+    def test_trigger_count(self, task_manager, sample_task):
+        """Test trigger_count property."""
+        task = Task(sample_task, task_manager)
+        assert task.trigger_count == 2
+
+    def test_event_count(self, task_manager, sample_task):
+        """Test event_count property."""
+        task = Task(sample_task, task_manager)
+        assert task.event_count == 1
+
+    def test_triggers_property(self, task_manager, mock_client, sample_task):
+        """Test triggers property returns scoped manager."""
+        task = Task(sample_task, task_manager)
+        triggers = task.triggers
+        assert isinstance(triggers, TaskScheduleTriggerManager)
+
+    def test_events_property(self, task_manager, mock_client, sample_task):
+        """Test events property returns scoped manager."""
+        task = Task(sample_task, task_manager)
+        events = task.events
+        assert isinstance(events, TaskEventManager)
+
+
+class TestTaskManagerCRUD:
+    """Tests for TaskManager CRUD operations."""
+
+    def test_create_task(self, task_manager, mock_client, sample_task):
+        """Test creating a task."""
+        mock_client._request.side_effect = [{"$key": 1}, sample_task]
+
+        task = task_manager.create(
+            name="Daily Backup",
+            owner=10,
+            action="snapshot",
+            description="Daily backup",
+        )
+
+        assert task.name == "Daily Backup"
+        # Verify POST was called first
+        first_call = mock_client._request.call_args_list[0]
+        assert first_call.args[0] == "POST"
+        assert first_call.args[1] == "tasks"
+
+    def test_update_task(self, task_manager, mock_client, sample_task):
+        """Test updating a task."""
+        mock_client._request.side_effect = [None, sample_task]
+
+        task_manager.update(1, description="Updated description", enabled=False)
+
+        first_call = mock_client._request.call_args_list[0]
+        assert first_call.args[0] == "PUT"
+        json_data = first_call.kwargs.get("json_data", {})
+        assert json_data.get("description") == "Updated description"
+        assert json_data.get("enabled") is False
+
+    def test_delete_task(self, task_manager, mock_client):
+        """Test deleting a task."""
+        mock_client._request.return_value = None
+
+        task_manager.delete(1)
+
+        mock_client._request.assert_called_with("DELETE", "tasks/1")
+
+    def test_triggers_method(self, task_manager, mock_client):
+        """Test triggers method returns scoped manager."""
+        manager = task_manager.triggers(1)
+        assert isinstance(manager, TaskScheduleTriggerManager)
+
+    def test_events_method(self, task_manager, mock_client):
+        """Test events method returns scoped manager."""
+        manager = task_manager.events(1)
+        assert isinstance(manager, TaskEventManager)
+
+    def test_list_by_owner(self, task_manager, mock_client, sample_task):
+        """Test listing tasks by owner."""
+        mock_client._request.return_value = [sample_task]
+
+        task_manager.list_by_owner(10)
+
+        call_args = mock_client._request.call_args
+        assert "owner eq 10" in call_args.kwargs.get("params", {}).get("filter", "")
+
+    def test_list_by_action(self, task_manager, mock_client, sample_task):
+        """Test listing tasks by action."""
+        mock_client._request.return_value = [sample_task]
+
+        task_manager.list_by_action("snapshot")
+
+        call_args = mock_client._request.call_args
+        assert "action eq 'snapshot'" in call_args.kwargs.get("params", {}).get("filter", "")


### PR DESCRIPTION
## Summary

Implements the VergeOS Task Engine components for automated operations triggered by events or schedules (Phase 1.3 from the v1.0 roadmap).

**New Resource Managers:**
- `task_schedules` - Cron-like schedule definitions (minute, hour, day, week, month, year)
- `task_schedule_triggers` - Link tasks to schedules for time-based automation
- `task_events` - Link tasks to system events for event-driven automation
- `task_scripts` - GCS script management with CRUD and run actions

**Enhanced TaskManager:**
- Added `create()`, `update()`, `delete()` methods for full CRUD
- Added `triggers()` and `events()` scoped manager methods
- Added `list_by_owner()` and `list_by_action()` helper methods
- Added properties: `owner_table`, `action_type`, `trigger_count`, `event_count`

**Documentation:**
- Updated docstrings to align with official VergeOS documentation
- Created `examples/task_automation_example.py` with comprehensive examples

## Test plan

- [x] 59 unit tests in `tests/unit/test_task_scheduling.py`
- [x] 24 integration tests in `tests/integration/test_task_scheduling.py`
- [x] All tests verified against live VergeOS system
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy pyvergeos`)