### PR TITLE
feat: add machine stats & monitoring for VMs and nodes

### DIFF
--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -12,6 +12,17 @@ from pyvergeos.resources.cloud_snapshots import (
     CloudSnapshotVMManager,
 )
 from pyvergeos.resources.cloudinit_files import CloudInitFile, CloudInitFileManager
+from pyvergeos.resources.machine_stats import (
+    MachineDevice,
+    MachineDeviceManager,
+    MachineLog,
+    MachineLogManager,
+    MachineStats,
+    MachineStatsHistory,
+    MachineStatsManager,
+    MachineStatus,
+    MachineStatusManager,
+)
 from pyvergeos.resources.nas_cifs import NASCIFSShare, NASCIFSShareManager
 from pyvergeos.resources.nas_nfs import NASNFSShare, NASNFSShareManager
 from pyvergeos.resources.nas_services import (
@@ -106,6 +117,15 @@ __all__ = [
     "CloudSnapshotTenantManager",
     "CloudSnapshotVM",
     "CloudSnapshotVMManager",
+    "MachineDevice",
+    "MachineDeviceManager",
+    "MachineLog",
+    "MachineLogManager",
+    "MachineStats",
+    "MachineStatsHistory",
+    "MachineStatsManager",
+    "MachineStatus",
+    "MachineStatusManager",
     "NASCIFSShare",
     "NASCIFSShareManager",
     "NASNFSShare",

--- a/pyvergeos/resources/machine_stats.py
+++ b/pyvergeos/resources/machine_stats.py
@@ -1,0 +1,1372 @@
+"""Machine Stats & Monitoring resource managers.
+
+This module provides access to machine performance metrics, status,
+logs, and device management. A "machine" in VergeOS represents both
+VMs and physical nodes.
+
+Example:
+    >>> # Access VM stats
+    >>> vm = client.vms.get(name="web-server")
+    >>> stats = vm.stats.get()
+    >>> print(f"CPU: {stats.total_cpu}%, RAM: {stats.ram_used_mb}MB")
+
+    >>> # Access stats history
+    >>> history = vm.stats.history_short()
+    >>> for point in history:
+    ...     print(f"{point.timestamp}: CPU {point.total_cpu}%")
+
+    >>> # Access machine status
+    >>> status = vm.machine_status.get()
+    >>> print(f"Status: {status.status}, Node: {status.node_name}")
+
+    >>> # Access machine logs
+    >>> logs = vm.machine_logs.list(level="error")
+    >>> for log in logs:
+    ...     print(f"[{log.level}] {log.text}")
+
+    >>> # Access machine devices
+    >>> devices = vm.devices.list()
+    >>> for device in devices:
+    ...     print(f"{device.name}: {device.type_display}")
+"""
+
+from __future__ import annotations
+
+import builtins
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Literal
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+# Status display mappings
+STATUS_DISPLAY = {
+    "initializing": "Initializing",
+    "starting": "Starting",
+    "running": "Running",
+    "stopping": "Stopping",
+    "unresponsive": "Unresponsive",
+    "stopped": "Stopped",
+    "hibernated": "Hibernated",
+    "hibernating": "Hibernating",
+    "initmigrate": "Migration Initializing",
+    "startmigrate": "Migration Starting",
+    "migrating": "Migrating",
+    "migratecomplete": "Migration Complete",
+    "importing": "Importing",
+    "maintenance": "Maintenance Mode",
+    "leavingmaintenance": "Leaving Maintenance",
+    "unlicensed": "Unlicensed",
+    "needsrefresh": "Needs Refresh",
+    "needsrestart": "Needs Restart",
+    "waitingforresources": "Waiting For Resources",
+    "error": "Error",
+    "driversreloading": "Drivers Reloading",
+}
+
+STATE_DISPLAY = {
+    "online": "Online",
+    "offline": "Offline",
+    "warning": "Warning",
+    "error": "Error",
+}
+
+LOG_LEVEL_DISPLAY = {
+    "audit": "Audit",
+    "message": "Message",
+    "warning": "Warning",
+    "error": "Error",
+    "critical": "Critical",
+    "summary": "Summary",
+    "debug": "Debug",
+}
+
+DEVICE_TYPE_DISPLAY = {
+    "gpu": "GPU Passthrough (Legacy)",
+    "nvidia_vgpu": "NVIDIA vGPU (Legacy)",
+    "tpm": "Trusted Platform Module (vTPM)",
+    "node_usb_devices": "USB",
+    "node_sriov_nic_devices": "SR-IOV NIC",
+    "node_pci_devices": "PCI",
+    "node_host_gpu_devices": "Host GPU",
+    "node_nvidia_vgpu_devices": "NVIDIA vGPU",
+}
+
+DEVICE_STATUS_DISPLAY = {
+    "online": "Online",
+    "offline": "Offline",
+    "errors": "Errors",
+    "warning": "Warning",
+    "hotplug": "Hot plugging",
+    "initializing": "Initializing",
+    "missing": "Missing",
+    "idle": "Idle",
+}
+
+
+# =============================================================================
+# Machine Stats
+# =============================================================================
+
+
+class MachineStats(ResourceObject):
+    """Machine statistics resource object.
+
+    Provides current performance metrics for a machine (VM or node).
+    """
+
+    @property
+    def machine_key(self) -> int:
+        """Parent machine key."""
+        return int(self.get("machine", 0))
+
+    @property
+    def total_cpu(self) -> int:
+        """Total CPU usage percentage (0-100)."""
+        return int(self.get("total_cpu", 0))
+
+    @property
+    def user_cpu(self) -> int:
+        """User CPU usage percentage."""
+        return int(self.get("user_cpu", 0))
+
+    @property
+    def system_cpu(self) -> int:
+        """System CPU usage percentage."""
+        return int(self.get("system_cpu", 0))
+
+    @property
+    def iowait_cpu(self) -> int:
+        """IO wait CPU percentage."""
+        return int(self.get("iowait_cpu", 0))
+
+    @property
+    def vmusage_cpu(self) -> int:
+        """VM usage CPU percentage (for nodes)."""
+        return int(self.get("vmusage_cpu", 0))
+
+    @property
+    def irq_cpu(self) -> int:
+        """IRQ CPU percentage."""
+        return int(self.get("irq_cpu", 0))
+
+    @property
+    def ram_used_mb(self) -> int:
+        """Physical RAM used in MB."""
+        return int(self.get("ram_used", 0))
+
+    @property
+    def ram_pct(self) -> int:
+        """Physical RAM used percentage."""
+        return int(self.get("ram_pct", 0))
+
+    @property
+    def vram_used_mb(self) -> int:
+        """Virtual RAM used in MB."""
+        return int(self.get("vram_used", 0))
+
+    @property
+    def core_usagelist(self) -> list[Any]:
+        """Per-core usage list."""
+        usage = self.get("core_usagelist")
+        if isinstance(usage, list):
+            return usage
+        return []
+
+    @property
+    def core_temp(self) -> int | None:
+        """Average core temperature in Celsius."""
+        temp = self.get("core_temp")
+        return int(temp) if temp is not None else None
+
+    @property
+    def core_temp_top(self) -> int | None:
+        """Top (highest) core temperature in Celsius."""
+        temp = self.get("core_temp_top")
+        return int(temp) if temp is not None else None
+
+    @property
+    def core_peak(self) -> int:
+        """Peak core usage percentage."""
+        return int(self.get("core_peak", 0))
+
+    @property
+    def cores_gt_25_pct(self) -> int:
+        """Count of cores above 25% usage."""
+        return int(self.get("core_count_gt_25", 0))
+
+    @property
+    def cores_gt_50_pct(self) -> int:
+        """Count of cores above 50% usage."""
+        return int(self.get("core_count_gt_50", 0))
+
+    @property
+    def cores_gt_75_pct(self) -> int:
+        """Count of cores above 75% usage."""
+        return int(self.get("core_count_gt_75", 0))
+
+    @property
+    def modified_at(self) -> datetime | None:
+        """Timestamp when stats were last updated."""
+        ts = self.get("modified")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def __repr__(self) -> str:
+        return (
+            f"<MachineStats machine={self.machine_key} "
+            f"cpu={self.total_cpu}% ram={self.ram_used_mb}MB>"
+        )
+
+
+class MachineStatsHistory(ResourceObject):
+    """Machine statistics history record.
+
+    Represents a single time point in the stats history.
+    """
+
+    @property
+    def machine_key(self) -> int:
+        """Parent machine key."""
+        return int(self.get("machine", 0))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp for this history point."""
+        ts = self.get("timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch(self) -> int:
+        """Timestamp as Unix epoch."""
+        return int(self.get("timestamp", 0))
+
+    @property
+    def total_cpu(self) -> int:
+        """Total CPU usage percentage."""
+        return int(self.get("total_cpu", 0))
+
+    @property
+    def user_cpu(self) -> int:
+        """User CPU usage percentage."""
+        return int(self.get("user_cpu", 0))
+
+    @property
+    def system_cpu(self) -> int:
+        """System CPU usage percentage."""
+        return int(self.get("system_cpu", 0))
+
+    @property
+    def iowait_cpu(self) -> int:
+        """IO wait CPU percentage."""
+        return int(self.get("iowait_cpu", 0))
+
+    @property
+    def vmusage_cpu(self) -> int:
+        """VM usage CPU percentage."""
+        return int(self.get("vmusage_cpu", 0))
+
+    @property
+    def irq_cpu(self) -> int:
+        """IRQ CPU percentage."""
+        return int(self.get("irq_cpu", 0))
+
+    @property
+    def ram_used_mb(self) -> int:
+        """Physical RAM used in MB."""
+        return int(self.get("ram_used", 0))
+
+    @property
+    def vram_used_mb(self) -> int:
+        """Virtual RAM used in MB."""
+        return int(self.get("vram_used", 0))
+
+    @property
+    def core_temp(self) -> int | None:
+        """Average core temperature."""
+        temp = self.get("core_temp")
+        return int(temp) if temp is not None else None
+
+    @property
+    def core_temp_top(self) -> int | None:
+        """Top core temperature."""
+        temp = self.get("core_temp_top")
+        return int(temp) if temp is not None else None
+
+    @property
+    def core_peak(self) -> int:
+        """Peak core usage percentage."""
+        return int(self.get("core_peak", 0))
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        return f"<MachineStatsHistory ts={ts} cpu={self.total_cpu}%>"
+
+
+class MachineStatsManager(ResourceManager[MachineStats]):
+    """Manager for machine statistics.
+
+    Provides access to current and historical performance metrics.
+    Scoped to a specific machine.
+
+    Example:
+        >>> # Get current stats
+        >>> stats = manager.get()
+        >>> print(f"CPU: {stats.total_cpu}%")
+
+        >>> # Get short-term history (high resolution)
+        >>> history = manager.history_short(limit=100)
+
+        >>> # Get long-term history (lower resolution, longer retention)
+        >>> history = manager.history_long(limit=1000)
+    """
+
+    _endpoint = "machine_stats"
+
+    _default_fields = [
+        "$key",
+        "machine",
+        "total_cpu",
+        "user_cpu",
+        "system_cpu",
+        "iowait_cpu",
+        "vmusage_cpu",
+        "irq_cpu",
+        "ram_used",
+        "ram_pct",
+        "vram_used",
+        "core_usagelist",
+        "core_temp",
+        "core_temp_top",
+        "core_peak",
+        "core_count_gt_25",
+        "core_count_gt_50",
+        "core_count_gt_75",
+        "modified",
+    ]
+
+    _history_fields = [
+        "$key",
+        "machine",
+        "timestamp",
+        "total_cpu",
+        "user_cpu",
+        "system_cpu",
+        "iowait_cpu",
+        "vmusage_cpu",
+        "irq_cpu",
+        "ram_used",
+        "vram_used",
+        "core_temp",
+        "core_temp_top",
+        "core_peak",
+        "core_count_gt_25",
+        "core_count_gt_50",
+        "core_count_gt_75",
+    ]
+
+    def __init__(self, client: VergeClient, machine_key: int) -> None:
+        super().__init__(client)
+        self._machine_key = machine_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineStats:
+        return MachineStats(data, self)
+
+    def _to_history_model(self, data: dict[str, Any]) -> MachineStatsHistory:
+        return MachineStatsHistory(data, self)
+
+    def get(self, fields: builtins.list[str] | None = None) -> MachineStats:  # type: ignore[override]
+        """Get current machine statistics.
+
+        Args:
+            fields: List of fields to return.
+
+        Returns:
+            MachineStats object.
+
+        Raises:
+            NotFoundError: If stats not found for this machine.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        params: dict[str, Any] = {
+            "filter": f"machine eq {self._machine_key}",
+            "fields": ",".join(fields),
+            "limit": 1,
+        }
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            raise NotFoundError(f"Stats not found for machine {self._machine_key}")
+
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Stats not found for machine {self._machine_key}")
+            return self._to_model(response[0])
+
+        return self._to_model(response)
+
+    def history_short(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[MachineStatsHistory]:
+        """Get short-term stats history (high resolution).
+
+        Args:
+            limit: Maximum number of records to return.
+            offset: Skip this many records.
+            since: Return records after this time (datetime or epoch).
+            until: Return records before this time (datetime or epoch).
+            fields: List of fields to return.
+
+        Returns:
+            List of MachineStatsHistory objects, sorted by timestamp descending.
+        """
+        return self._get_history(
+            "machine_stats_history_short",
+            limit=limit,
+            offset=offset,
+            since=since,
+            until=until,
+            fields=fields,
+        )
+
+    def history_long(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[MachineStatsHistory]:
+        """Get long-term stats history (lower resolution, longer retention).
+
+        Args:
+            limit: Maximum number of records to return.
+            offset: Skip this many records.
+            since: Return records after this time (datetime or epoch).
+            until: Return records before this time (datetime or epoch).
+            fields: List of fields to return.
+
+        Returns:
+            List of MachineStatsHistory objects, sorted by timestamp descending.
+        """
+        return self._get_history(
+            "machine_stats_history_long",
+            limit=limit,
+            offset=offset,
+            since=since,
+            until=until,
+            fields=fields,
+        )
+
+    def _get_history(
+        self,
+        endpoint: str,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[MachineStatsHistory]:
+        """Internal helper to get history from short or long endpoint."""
+        if fields is None:
+            fields = self._history_fields
+
+        filters = [f"machine eq {self._machine_key}"]
+
+        # Convert datetime to epoch if needed
+        if since is not None:
+            since_epoch = int(since.timestamp()) if isinstance(since, datetime) else int(since)
+            filters.append(f"timestamp ge {since_epoch}")
+
+        if until is not None:
+            until_epoch = int(until.timestamp()) if isinstance(until, datetime) else int(until)
+            filters.append(f"timestamp le {until_epoch}")
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [self._to_history_model(item) for item in response]
+
+        return [self._to_history_model(response)]
+
+
+# =============================================================================
+# Machine Status
+# =============================================================================
+
+
+class MachineStatus(ResourceObject):
+    """Machine status resource object.
+
+    Provides operational status for a machine (VM or node).
+    """
+
+    @property
+    def machine_key(self) -> int:
+        """Parent machine key."""
+        return int(self.get("machine", 0))
+
+    @property
+    def is_running(self) -> bool:
+        """Check if machine is currently running."""
+        return bool(self.get("running", False))
+
+    @property
+    def is_migratable(self) -> bool:
+        """Check if machine can be migrated."""
+        return bool(self.get("migratable", True))
+
+    @property
+    def status(self) -> str:
+        """Current status (running, stopped, migrating, etc.)."""
+        raw = str(self.get("status", "stopped"))
+        return STATUS_DISPLAY.get(raw, raw)
+
+    @property
+    def status_raw(self) -> str:
+        """Raw status value."""
+        return str(self.get("status", "stopped"))
+
+    @property
+    def status_info(self) -> str:
+        """Additional status information."""
+        return str(self.get("status_info", ""))
+
+    @property
+    def state(self) -> str:
+        """State (online, offline, warning, error)."""
+        raw = str(self.get("state", "offline"))
+        return STATE_DISPLAY.get(raw, raw)
+
+    @property
+    def state_raw(self) -> str:
+        """Raw state value."""
+        return str(self.get("state", "offline"))
+
+    @property
+    def powerstate(self) -> bool:
+        """Power state (on/off)."""
+        return bool(self.get("powerstate", False))
+
+    @property
+    def node_key(self) -> int | None:
+        """Node where machine is running."""
+        node = self.get("node")
+        return int(node) if node else None
+
+    @property
+    def node_name(self) -> str:
+        """Name of node where machine is running."""
+        return str(self.get("node_name", ""))
+
+    @property
+    def migrated_node_key(self) -> int | None:
+        """Node the machine was migrated from."""
+        node = self.get("migrated_node")
+        return int(node) if node else None
+
+    @property
+    def migration_destination_key(self) -> int | None:
+        """Node the machine is migrating to."""
+        node = self.get("migration_destination")
+        return int(node) if node else None
+
+    @property
+    def started_at(self) -> datetime | None:
+        """Timestamp when machine was started."""
+        ts = self.get("started")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def local_time(self) -> datetime | None:
+        """Machine local time."""
+        ts = self.get("local_time")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def last_update(self) -> datetime | None:
+        """Timestamp of last status update."""
+        ts = self.get("last_update")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def running_cores(self) -> int:
+        """Number of running CPU cores."""
+        return int(self.get("running_cores", 0))
+
+    @property
+    def running_ram_mb(self) -> int:
+        """Amount of running RAM in MB."""
+        return int(self.get("running_ram", 0))
+
+    @property
+    def agent_version(self) -> str:
+        """Guest agent version."""
+        return str(self.get("agent_version", ""))
+
+    @property
+    def has_agent(self) -> bool:
+        """Check if guest agent is installed."""
+        return bool(self.get("agent_version"))
+
+    @property
+    def agent_features(self) -> dict[str, Any]:
+        """Guest agent supported features."""
+        features = self.get("agent_features")
+        return features if isinstance(features, dict) else {}
+
+    @property
+    def agent_guest_info(self) -> dict[str, Any]:
+        """Guest OS information from agent."""
+        info = self.get("agent_guest_info")
+        return info if isinstance(info, dict) else {}
+
+    def __repr__(self) -> str:
+        return (
+            f"<MachineStatus machine={self.machine_key} "
+            f"status={self.status_raw} running={self.is_running}>"
+        )
+
+
+class MachineStatusManager(ResourceManager[MachineStatus]):
+    """Manager for machine status.
+
+    Provides access to operational status for a machine.
+    Scoped to a specific machine.
+
+    Example:
+        >>> status = manager.get()
+        >>> print(f"Status: {status.status}")
+        >>> if status.is_running:
+        ...     print(f"Running on node: {status.node_name}")
+    """
+
+    _endpoint = "machine_status"
+
+    _default_fields = [
+        "$key",
+        "machine",
+        "running",
+        "migratable",
+        "status",
+        "status_info",
+        "state",
+        "powerstate",
+        "node",
+        "node#name as node_name",
+        "migrated_node",
+        "migration_destination",
+        "started",
+        "local_time",
+        "last_update",
+        "running_cores",
+        "running_ram",
+        "agent_version",
+        "agent_features",
+        "agent_guest_info",
+    ]
+
+    def __init__(self, client: VergeClient, machine_key: int) -> None:
+        super().__init__(client)
+        self._machine_key = machine_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineStatus:
+        return MachineStatus(data, self)
+
+    def get(self, fields: builtins.list[str] | None = None) -> MachineStatus:  # type: ignore[override]
+        """Get machine status.
+
+        Args:
+            fields: List of fields to return.
+
+        Returns:
+            MachineStatus object.
+
+        Raises:
+            NotFoundError: If status not found for this machine.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        params: dict[str, Any] = {
+            "filter": f"machine eq {self._machine_key}",
+            "fields": ",".join(fields),
+            "limit": 1,
+        }
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            raise NotFoundError(f"Status not found for machine {self._machine_key}")
+
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Status not found for machine {self._machine_key}")
+            return self._to_model(response[0])
+
+        return self._to_model(response)
+
+
+# =============================================================================
+# Machine Logs
+# =============================================================================
+
+
+class MachineLog(ResourceObject):
+    """Machine log entry resource object."""
+
+    @property
+    def machine_key(self) -> int:
+        """Parent machine key."""
+        return int(self.get("machine", 0))
+
+    @property
+    def machine_name(self) -> str:
+        """Parent machine name."""
+        return str(self.get("machine_name", ""))
+
+    @property
+    def level(self) -> str:
+        """Log level (Audit, Message, Warning, Error, Critical)."""
+        raw = str(self.get("level", "message"))
+        return LOG_LEVEL_DISPLAY.get(raw, raw)
+
+    @property
+    def level_raw(self) -> str:
+        """Raw log level value."""
+        return str(self.get("level", "message"))
+
+    @property
+    def text(self) -> str:
+        """Log message text."""
+        return str(self.get("text", ""))
+
+    @property
+    def user(self) -> str:
+        """User who generated the log entry."""
+        return str(self.get("user", ""))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp of log entry (microseconds precision)."""
+        ts = self.get("timestamp")
+        if ts:
+            # timestamp is in microseconds
+            return datetime.fromtimestamp(int(ts) / 1_000_000, tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch_us(self) -> int:
+        """Timestamp as Unix epoch in microseconds."""
+        return int(self.get("timestamp", 0))
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error or critical log."""
+        return self.level_raw in ("error", "critical")
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning log."""
+        return self.level_raw == "warning"
+
+    @property
+    def is_audit(self) -> bool:
+        """Check if this is an audit log."""
+        return self.level_raw == "audit"
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        text_preview = self.text[:40] + "..." if len(self.text) > 40 else self.text
+        return f"<MachineLog [{self.level}] {ts}: {text_preview!r}>"
+
+
+class MachineLogManager(ResourceManager[MachineLog]):
+    """Manager for machine logs.
+
+    Provides access to log entries for a machine.
+    Scoped to a specific machine.
+
+    Example:
+        >>> # Get recent logs
+        >>> logs = manager.list(limit=20)
+
+        >>> # Get errors only
+        >>> errors = manager.list(level="error")
+
+        >>> # Get logs since a specific time
+        >>> logs = manager.list(since=datetime.now() - timedelta(hours=1))
+    """
+
+    _endpoint = "machine_logs"
+
+    _default_fields = [
+        "$key",
+        "machine",
+        "machine#name as machine_name",
+        "level",
+        "text",
+        "user",
+        "timestamp",
+    ]
+
+    def __init__(self, client: VergeClient, machine_key: int) -> None:
+        super().__init__(client)
+        self._machine_key = machine_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineLog:
+        return MachineLog(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        level: Literal["audit", "message", "warning", "error", "critical", "summary", "debug"]
+        | None = None,
+        errors_only: bool = False,
+        warnings_only: bool = False,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[MachineLog]:
+        """List machine log entries.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            level: Filter by log level.
+            errors_only: Only return error and critical logs.
+            warnings_only: Only return warning logs.
+            since: Return logs after this time (datetime or epoch microseconds).
+            until: Return logs before this time (datetime or epoch microseconds).
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of MachineLog objects, sorted by timestamp descending.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        filters = [f"machine eq {self._machine_key}"]
+
+        if filter:
+            filters.append(filter)
+
+        if level is not None:
+            filters.append(f"level eq '{level}'")
+        elif errors_only:
+            filters.append("(level eq 'error' or level eq 'critical')")
+        elif warnings_only:
+            filters.append("level eq 'warning'")
+
+        # Convert datetime to microseconds if needed
+        if since is not None:
+            if isinstance(since, datetime):
+                since_us = int(since.timestamp() * 1_000_000)
+            else:
+                since_us = int(since)
+            filters.append(f"timestamp ge {since_us}")
+
+        if until is not None:
+            if isinstance(until, datetime):
+                until_us = int(until.timestamp() * 1_000_000)
+            else:
+                until_us = int(until)
+            filters.append(f"timestamp le {until_us}")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [self._to_model(item) for item in response]
+
+        return [self._to_model(response)]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> MachineLog:
+        """Get a specific log entry by key.
+
+        Args:
+            key: Log entry $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            MachineLog object.
+
+        Raises:
+            NotFoundError: If log entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("key must be provided")
+
+        if fields is None:
+            fields = self._default_fields
+
+        params: dict[str, Any] = {"fields": ",".join(fields)}
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+
+        if response is None:
+            raise NotFoundError(f"Log entry {key} not found")
+
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Log entry {key} returned invalid response")
+
+        return self._to_model(response)
+
+
+# =============================================================================
+# Machine Devices
+# =============================================================================
+
+
+class MachineDevice(ResourceObject):
+    """Machine device resource object.
+
+    Represents a device attached to a machine (GPU, TPM, USB, etc.).
+    """
+
+    @property
+    def machine_key(self) -> int:
+        """Parent machine key."""
+        return int(self.get("machine", 0))
+
+    @property
+    def machine_name(self) -> str:
+        """Parent machine name."""
+        return str(self.get("machine_name", ""))
+
+    @property
+    def machine_type(self) -> str:
+        """Machine type (vm, node, etc.)."""
+        return str(self.get("machine_type", ""))
+
+    @property
+    def name(self) -> str:
+        """Device name."""
+        return str(self.get("name", ""))
+
+    @property
+    def description(self) -> str:
+        """Device description."""
+        return str(self.get("description", ""))
+
+    @property
+    def device_type(self) -> str:
+        """Device type (gpu, tpm, node_usb_devices, etc.)."""
+        raw = str(self.get("type", ""))
+        return DEVICE_TYPE_DISPLAY.get(raw, raw)
+
+    @property
+    def device_type_raw(self) -> str:
+        """Raw device type value."""
+        return str(self.get("type", ""))
+
+    @property
+    def orderid(self) -> int:
+        """Device order ID."""
+        return int(self.get("orderid", 0))
+
+    @property
+    def uuid(self) -> str:
+        """Device UUID."""
+        return str(self.get("uuid", ""))
+
+    @property
+    def is_enabled(self) -> bool:
+        """Check if device is enabled."""
+        return bool(self.get("enabled", True))
+
+    @property
+    def is_optional(self) -> bool:
+        """Check if device is optional (machine can start without it)."""
+        return bool(self.get("optional", False))
+
+    @property
+    def resource_group_key(self) -> int | None:
+        """Associated resource group key."""
+        rg = self.get("resource_group")
+        return int(rg) if rg else None
+
+    @property
+    def resource_group_name(self) -> str:
+        """Associated resource group name."""
+        return str(self.get("resource_group_name", ""))
+
+    @property
+    def status(self) -> str:
+        """Device status."""
+        raw = str(self.get("device_status", ""))
+        return DEVICE_STATUS_DISPLAY.get(raw, raw)
+
+    @property
+    def status_raw(self) -> str:
+        """Raw device status value."""
+        return str(self.get("device_status", ""))
+
+    @property
+    def status_info(self) -> str:
+        """Additional status information."""
+        return str(self.get("status_info", ""))
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Timestamp when device was created."""
+        ts = self.get("created")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def modified_at(self) -> datetime | None:
+        """Timestamp when device was last modified."""
+        ts = self.get("modified")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def is_gpu(self) -> bool:
+        """Check if this is a GPU device."""
+        return self.device_type_raw in (
+            "gpu",
+            "node_host_gpu_devices",
+            "nvidia_vgpu",
+            "node_nvidia_vgpu_devices",
+        )
+
+    @property
+    def is_tpm(self) -> bool:
+        """Check if this is a TPM device."""
+        return self.device_type_raw == "tpm"
+
+    @property
+    def is_usb(self) -> bool:
+        """Check if this is a USB device."""
+        return self.device_type_raw == "node_usb_devices"
+
+    @property
+    def is_pci(self) -> bool:
+        """Check if this is a PCI device."""
+        return self.device_type_raw == "node_pci_devices"
+
+    @property
+    def is_sriov(self) -> bool:
+        """Check if this is an SR-IOV NIC device."""
+        return self.device_type_raw == "node_sriov_nic_devices"
+
+    def __repr__(self) -> str:
+        return (
+            f"<MachineDevice key={self.get('$key', '?')} "
+            f"name={self.name!r} type={self.device_type_raw}>"
+        )
+
+
+class MachineDeviceManager(ResourceManager[MachineDevice]):
+    """Manager for machine devices.
+
+    Provides CRUD operations for devices attached to a machine.
+    Scoped to a specific machine.
+
+    Example:
+        >>> # List all devices
+        >>> devices = manager.list()
+
+        >>> # List GPUs only
+        >>> gpus = manager.list(device_type="gpu")
+
+        >>> # Get a specific device
+        >>> device = manager.get(key=123)
+    """
+
+    _endpoint = "machine_devices"
+
+    _default_fields = [
+        "$key",
+        "machine",
+        "machine#name as machine_name",
+        "machine_type",
+        "name",
+        "description",
+        "type",
+        "orderid",
+        "uuid",
+        "enabled",
+        "optional",
+        "resource_group",
+        "resource_group#name as resource_group_name",
+        "status#status as device_status",
+        "status#status_info as status_info",
+        "created",
+        "modified",
+    ]
+
+    def __init__(self, client: VergeClient, machine_key: int) -> None:
+        super().__init__(client)
+        self._machine_key = machine_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineDevice:
+        return MachineDevice(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        device_type: Literal[
+            "gpu",
+            "nvidia_vgpu",
+            "tpm",
+            "node_usb_devices",
+            "node_sriov_nic_devices",
+            "node_pci_devices",
+            "node_host_gpu_devices",
+            "node_nvidia_vgpu_devices",
+        ]
+        | None = None,
+        enabled_only: bool = False,
+        **filter_kwargs: Any,
+    ) -> builtins.list[MachineDevice]:
+        """List machine devices.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            device_type: Filter by device type.
+            enabled_only: Only return enabled devices.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of MachineDevice objects.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        filters = [f"machine eq {self._machine_key}"]
+
+        if filter:
+            filters.append(filter)
+
+        if device_type is not None:
+            filters.append(f"type eq '{device_type}'")
+
+        if enabled_only:
+            filters.append("enabled eq true")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(fields),
+            "sort": "+orderid",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [self._to_model(item) for item in response]
+
+        return [self._to_model(response)]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> MachineDevice:
+        """Get a specific device by key or name.
+
+        Args:
+            key: Device $key (ID).
+            name: Device name.
+            fields: List of fields to return.
+
+        Returns:
+            MachineDevice object.
+
+        Raises:
+            NotFoundError: If device not found.
+            ValueError: If neither key nor name provided.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+
+            if response is None:
+                raise NotFoundError(f"Device {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Device {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped = name.replace("'", "''")
+            devices = self.list(filter=f"name eq '{escaped}'", fields=fields, limit=1)
+            if not devices:
+                raise NotFoundError(f"Device with name '{name}' not found")
+            return devices[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        device_type: Literal[
+            "gpu",
+            "nvidia_vgpu",
+            "tpm",
+            "node_usb_devices",
+            "node_sriov_nic_devices",
+            "node_pci_devices",
+            "node_host_gpu_devices",
+            "node_nvidia_vgpu_devices",
+        ],
+        name: str | None = None,
+        description: str = "",
+        enabled: bool = True,
+        optional: bool = False,
+        resource_group: int | None = None,
+        **kwargs: Any,
+    ) -> MachineDevice:
+        """Create a new device for this machine.
+
+        Args:
+            device_type: Type of device to create.
+            name: Device name (auto-generated if not provided).
+            description: Device description.
+            enabled: Whether device is enabled.
+            optional: Allow machine to start without this device.
+            resource_group: Resource group key for the device.
+            **kwargs: Additional device settings.
+
+        Returns:
+            Created MachineDevice object.
+        """
+        body: dict[str, Any] = {
+            "machine": self._machine_key,
+            "type": device_type,
+            "enabled": enabled,
+            "optional": optional,
+        }
+
+        if name:
+            body["name"] = name
+        if description:
+            body["description"] = description
+        if resource_group is not None:
+            body["resource_group"] = resource_group
+
+        body.update(kwargs)
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        device = self._to_model(response)
+        return self.get(device.key)
+
+    def update(self, key: int, **kwargs: Any) -> MachineDevice:
+        """Update a device.
+
+        Args:
+            key: Device $key (ID).
+            **kwargs: Fields to update.
+
+        Returns:
+            Updated MachineDevice object.
+        """
+        response = self._client._request("PUT", f"{self._endpoint}/{key}", json_data=kwargs)
+        if response is None:
+            return self.get(key)
+        if not isinstance(response, dict):
+            return self.get(key)
+        return self._to_model(response)
+
+    def delete(self, key: int) -> None:
+        """Delete a device.
+
+        Args:
+            key: Device $key (ID).
+
+        Note:
+            Machine should typically be powered off before removing devices.
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")

--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -12,6 +12,11 @@ from pyvergeos.resources.base import ResourceManager, ResourceObject
 
 if TYPE_CHECKING:
     from pyvergeos.client import VergeClient
+    from pyvergeos.resources.machine_stats import (
+        MachineLogManager,
+        MachineStatsManager,
+        MachineStatusManager,
+    )
 
 
 # Status display mappings
@@ -343,6 +348,69 @@ class Node(ResourceObject):
 
         manager = cast("NodeManager", self._manager)
         return manager.usb_devices(self.key)
+
+    @property
+    def stats(self) -> MachineStatsManager:
+        """Access performance stats for this node.
+
+        Returns:
+            MachineStatsManager scoped to this node.
+
+        Example:
+            >>> stats = node.stats.get()
+            >>> print(f"CPU: {stats.total_cpu}%, RAM: {stats.ram_used_mb}MB")
+
+            >>> # Get stats history
+            >>> history = node.stats.history_short(limit=100)
+
+        Raises:
+            ValueError: If node has no associated machine.
+        """
+        from pyvergeos.resources.machine_stats import MachineStatsManager
+
+        if self.machine_key is None:
+            raise ValueError("Node has no associated machine")
+        return MachineStatsManager(self._manager._client, self.machine_key)
+
+    @property
+    def machine_status(self) -> MachineStatusManager:
+        """Access detailed operational status for this node.
+
+        Returns:
+            MachineStatusManager scoped to this node.
+
+        Example:
+            >>> status = node.machine_status.get()
+            >>> print(f"Status: {status.status}")
+
+        Raises:
+            ValueError: If node has no associated machine.
+        """
+        from pyvergeos.resources.machine_stats import MachineStatusManager
+
+        if self.machine_key is None:
+            raise ValueError("Node has no associated machine")
+        return MachineStatusManager(self._manager._client, self.machine_key)
+
+    @property
+    def machine_logs(self) -> MachineLogManager:
+        """Access log entries for this node.
+
+        Returns:
+            MachineLogManager scoped to this node.
+
+        Example:
+            >>> logs = node.machine_logs.list(limit=20)
+            >>> errors = node.machine_logs.list(errors_only=True)
+
+        Raises:
+            ValueError: If node has no associated machine.
+        """
+        from pyvergeos.resources.machine_stats import MachineLogManager
+
+        if self.machine_key is None:
+            raise ValueError("Node has no associated machine")
+        return MachineLogManager(self._manager._client, self.machine_key)
 
     def __repr__(self) -> str:
         return (

--- a/tests/integration/test_machine_stats.py
+++ b/tests/integration/test_machine_stats.py
@@ -1,0 +1,411 @@
+"""Integration tests for machine stats and monitoring."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.machine_stats import (
+    MachineDevice,
+    MachineLog,
+    MachineStats,
+    MachineStatsHistory,
+    MachineStatus,
+)
+
+
+@pytest.mark.integration
+class TestVMMachineStats:
+    """Integration tests for VM machine stats."""
+
+    @pytest.fixture
+    def test_vm(self, live_client: VergeClient):
+        """Get the test VM, or skip if not available."""
+        try:
+            return live_client.vms.get(name="test")
+        except NotFoundError:
+            pytest.skip("Test VM 'test' not available")
+
+    def test_vm_has_machine_key(self, live_client: VergeClient, test_vm) -> None:
+        """Test that VM has a machine_key property."""
+        assert test_vm.machine_key is not None
+        assert isinstance(test_vm.machine_key, int)
+        assert test_vm.machine_key > 0
+
+    def test_get_vm_stats(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting current VM stats."""
+        stats = test_vm.stats.get()
+
+        assert isinstance(stats, MachineStats)
+        assert stats.machine_key == test_vm.machine_key
+
+        # Check CPU metrics
+        assert isinstance(stats.total_cpu, int)
+        assert stats.total_cpu >= 0
+        assert stats.total_cpu <= 100
+
+        # Check RAM metrics
+        assert isinstance(stats.ram_used_mb, int)
+        assert stats.ram_used_mb >= 0
+
+        assert isinstance(stats.ram_pct, int)
+        assert stats.ram_pct >= 0
+        assert stats.ram_pct <= 100
+
+    def test_get_vm_stats_fields(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting VM stats with specific fields."""
+        stats = test_vm.stats.get(fields=["$key", "machine", "total_cpu", "ram_used"])
+
+        assert stats.machine_key == test_vm.machine_key
+        assert isinstance(stats.total_cpu, int)
+        assert isinstance(stats.ram_used_mb, int)
+
+    def test_vm_stats_history_short(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting short-term stats history."""
+        history = test_vm.stats.history_short(limit=10)
+
+        assert isinstance(history, list)
+        # History might be empty for stopped VMs, but should work
+        if history:
+            assert all(isinstance(h, MachineStatsHistory) for h in history)
+
+            # Check first record
+            record = history[0]
+            assert record.machine_key == test_vm.machine_key
+            assert record.timestamp is not None
+            assert isinstance(record.timestamp, datetime)
+            assert isinstance(record.total_cpu, int)
+
+    def test_vm_stats_history_long(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting long-term stats history."""
+        history = test_vm.stats.history_long(limit=10)
+
+        assert isinstance(history, list)
+        if history:
+            assert all(isinstance(h, MachineStatsHistory) for h in history)
+
+            record = history[0]
+            assert record.machine_key == test_vm.machine_key
+            assert record.timestamp is not None
+
+    def test_vm_stats_history_since(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting stats history since a specific time."""
+        since = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        history = test_vm.stats.history_short(limit=10, since=since)
+
+        assert isinstance(history, list)
+        # All records should be after 'since'
+        for record in history:
+            if record.timestamp:
+                assert record.timestamp >= since
+
+
+@pytest.mark.integration
+class TestVMMachineStatus:
+    """Integration tests for VM machine status."""
+
+    @pytest.fixture
+    def test_vm(self, live_client: VergeClient):
+        """Get the test VM, or skip if not available."""
+        try:
+            return live_client.vms.get(name="test")
+        except NotFoundError:
+            pytest.skip("Test VM 'test' not available")
+
+    def test_get_vm_status(self, live_client: VergeClient, test_vm) -> None:
+        """Test getting VM machine status."""
+        status = test_vm.machine_status.get()
+
+        assert isinstance(status, MachineStatus)
+        assert status.machine_key == test_vm.machine_key
+
+        # Check status fields
+        assert isinstance(status.status, str)
+        assert isinstance(status.status_raw, str)
+        assert isinstance(status.is_running, bool)
+
+    def test_vm_status_display_values(self, live_client: VergeClient, test_vm) -> None:
+        """Test that status has human-readable display values."""
+        status = test_vm.machine_status.get()
+
+        # status should be human-readable (e.g., "Running" not "running")
+        assert status.status[0].isupper() or status.status == status.status_raw
+
+        # state should also be human-readable
+        assert isinstance(status.state, str)
+        assert isinstance(status.state_raw, str)
+
+    def test_vm_status_running_properties(self, live_client: VergeClient, test_vm) -> None:
+        """Test VM status properties when running."""
+        status = test_vm.machine_status.get()
+
+        if status.is_running:
+            # Running VM should have node info
+            assert status.node_name is not None or status.node_key is not None
+            assert status.running_cores >= 0
+            assert status.running_ram_mb >= 0
+
+
+@pytest.mark.integration
+class TestVMMachineLogs:
+    """Integration tests for VM machine logs."""
+
+    @pytest.fixture
+    def test_vm(self, live_client: VergeClient):
+        """Get the test VM, or skip if not available."""
+        try:
+            return live_client.vms.get(name="test")
+        except NotFoundError:
+            pytest.skip("Test VM 'test' not available")
+
+    def test_list_vm_logs(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing VM logs."""
+        logs = test_vm.machine_logs.list(limit=10)
+
+        assert isinstance(logs, list)
+        if logs:
+            assert all(isinstance(log, MachineLog) for log in logs)
+
+            # Check first log
+            log = logs[0]
+            assert log.machine_key == test_vm.machine_key
+            assert isinstance(log.level, str)
+            assert isinstance(log.text, str)
+
+    def test_list_vm_logs_with_level_filter(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing VM logs filtered by level."""
+        # Test message level
+        logs = test_vm.machine_logs.list(limit=5, level="message")
+        assert isinstance(logs, list)
+        for log in logs:
+            assert log.level_raw == "message"
+
+    def test_list_vm_logs_errors_only(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing only error logs."""
+        logs = test_vm.machine_logs.list(limit=10, errors_only=True)
+
+        assert isinstance(logs, list)
+        for log in logs:
+            assert log.level_raw in ("error", "critical")
+            assert log.is_error is True
+
+    def test_list_vm_logs_since(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing logs since a specific time."""
+        since = datetime.now(tz=timezone.utc) - timedelta(days=1)
+        logs = test_vm.machine_logs.list(limit=10, since=since)
+
+        assert isinstance(logs, list)
+        for log in logs:
+            if log.timestamp:
+                assert log.timestamp >= since
+
+    def test_vm_log_properties(self, live_client: VergeClient, test_vm) -> None:
+        """Test VM log property accessors."""
+        logs = test_vm.machine_logs.list(limit=1)
+        if not logs:
+            pytest.skip("No logs available for test VM")
+
+        log = logs[0]
+
+        # Test timestamp
+        assert log.timestamp is not None
+        assert isinstance(log.timestamp, datetime)
+
+        # Test level display vs raw
+        assert isinstance(log.level, str)
+        assert isinstance(log.level_raw, str)
+
+        # Test text
+        assert isinstance(log.text, str)
+
+        # Test boolean helpers
+        assert isinstance(log.is_error, bool)
+        assert isinstance(log.is_warning, bool)
+        assert isinstance(log.is_audit, bool)
+
+
+@pytest.mark.integration
+class TestVMMachineDevices:
+    """Integration tests for VM machine devices."""
+
+    @pytest.fixture
+    def test_vm(self, live_client: VergeClient):
+        """Get the test VM, or skip if not available."""
+        try:
+            return live_client.vms.get(name="test")
+        except NotFoundError:
+            pytest.skip("Test VM 'test' not available")
+
+    def test_list_vm_devices(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing VM devices."""
+        devices = test_vm.devices.list()
+
+        assert isinstance(devices, list)
+        # Devices may be empty if none attached
+        if devices:
+            assert all(isinstance(d, MachineDevice) for d in devices)
+
+            device = devices[0]
+            assert device.machine_key == test_vm.machine_key
+            assert isinstance(device.name, str)
+            assert isinstance(device.device_type, str)
+
+    def test_list_vm_devices_by_type(self, live_client: VergeClient, test_vm) -> None:
+        """Test listing VM devices filtered by type."""
+        # Try listing TPM devices (common type)
+        devices = test_vm.devices.list(device_type="tpm")
+
+        assert isinstance(devices, list)
+        for device in devices:
+            assert device.device_type_raw == "tpm"
+
+    def test_create_and_delete_tpm_device(self, live_client: VergeClient, test_vm) -> None:
+        """Test creating and deleting a TPM device."""
+        # Check if VM already has a TPM
+        existing = test_vm.devices.list(device_type="tpm")
+        if existing:
+            pytest.skip("Test VM already has a TPM device")
+
+        # Check if VM is stopped (required for device changes)
+        if test_vm.is_running:
+            pytest.skip("Cannot add devices to running VM")
+
+        # Create TPM device
+        device = test_vm.devices.create(
+            device_type="tpm",
+            name="Test-TPM",
+            description="Integration test TPM",
+            enabled=True,
+            optional=True,
+        )
+
+        try:
+            assert device is not None
+            assert device.name == "Test-TPM"
+            assert device.device_type_raw == "tpm"
+            assert device.is_enabled is True
+            assert device.is_optional is True
+            assert device.is_tpm is True
+
+            # Verify it's in the list
+            devices = test_vm.devices.list()
+            tpm_devices = [d for d in devices if d.name == "Test-TPM"]
+            assert len(tpm_devices) == 1
+
+        finally:
+            # Cleanup: delete the device
+            test_vm.devices.delete(device.key)
+
+            # Verify deletion
+            devices = test_vm.devices.list()
+            for d in devices:
+                assert d.name != "Test-TPM"
+
+
+@pytest.mark.integration
+class TestNodeMachineStats:
+    """Integration tests for Node machine stats."""
+
+    @pytest.fixture
+    def test_node(self, live_client: VergeClient):
+        """Get a node for testing."""
+        nodes = live_client.nodes.list(limit=1)
+        if not nodes:
+            pytest.skip("No nodes available")
+        return nodes[0]
+
+    def test_node_has_machine_key(self, live_client: VergeClient, test_node) -> None:
+        """Test that Node has a machine_key property."""
+        assert test_node.machine_key is not None
+        assert isinstance(test_node.machine_key, int)
+        assert test_node.machine_key > 0
+
+    def test_get_node_stats(self, live_client: VergeClient, test_node) -> None:
+        """Test getting current node stats."""
+        stats = test_node.stats.get()
+
+        assert isinstance(stats, MachineStats)
+        assert stats.machine_key == test_node.machine_key
+
+        # Nodes should have CPU and RAM metrics
+        assert isinstance(stats.total_cpu, int)
+        assert isinstance(stats.ram_used_mb, int)
+        assert isinstance(stats.ram_pct, int)
+
+    def test_node_stats_history_short(self, live_client: VergeClient, test_node) -> None:
+        """Test getting short-term node stats history."""
+        history = test_node.stats.history_short(limit=5)
+
+        assert isinstance(history, list)
+        if history:
+            record = history[0]
+            assert isinstance(record, MachineStatsHistory)
+            assert record.machine_key == test_node.machine_key
+
+    def test_node_stats_history_long(self, live_client: VergeClient, test_node) -> None:
+        """Test getting long-term node stats history."""
+        history = test_node.stats.history_long(limit=5)
+
+        assert isinstance(history, list)
+        if history:
+            record = history[0]
+            assert isinstance(record, MachineStatsHistory)
+
+    def test_get_node_status(self, live_client: VergeClient, test_node) -> None:
+        """Test getting node machine status."""
+        status = test_node.machine_status.get()
+
+        assert isinstance(status, MachineStatus)
+        assert status.machine_key == test_node.machine_key
+        assert isinstance(status.status, str)
+        assert isinstance(status.is_running, bool)
+
+    def test_list_node_logs(self, live_client: VergeClient, test_node) -> None:
+        """Test listing node logs."""
+        logs = test_node.machine_logs.list(limit=5)
+
+        assert isinstance(logs, list)
+        if logs:
+            log = logs[0]
+            assert isinstance(log, MachineLog)
+            assert log.machine_key == test_node.machine_key
+
+
+@pytest.mark.integration
+class TestMachineStatsManager:
+    """Integration tests for direct MachineStatsManager access."""
+
+    def test_stats_manager_scoping(self, live_client: VergeClient) -> None:
+        """Test that stats managers are properly scoped to their machine."""
+        vms = live_client.vms.list(limit=2)
+        if len(vms) < 2:
+            pytest.skip("Need at least 2 VMs for this test")
+
+        vm1, vm2 = vms[0], vms[1]
+
+        # Get stats for each VM
+        stats1 = vm1.stats.get()
+        stats2 = vm2.stats.get()
+
+        # Verify they are for different machines
+        assert stats1.machine_key == vm1.machine_key
+        assert stats2.machine_key == vm2.machine_key
+
+        if vm1.machine_key != vm2.machine_key:
+            # The stats should be for different machines
+            assert stats1.machine_key != stats2.machine_key
+
+    def test_stats_manager_caching(self, live_client: VergeClient) -> None:
+        """Test that stats manager is cached on the VM object."""
+        try:
+            vm = live_client.vms.get(name="test")
+        except NotFoundError:
+            pytest.skip("Test VM 'test' not available")
+
+        # Access stats property twice
+        stats_manager1 = vm.stats
+        stats_manager2 = vm.stats
+
+        # Should be the same instance (cached)
+        assert stats_manager1 is stats_manager2

--- a/tests/unit/test_machine_stats.py
+++ b/tests/unit/test_machine_stats.py
@@ -1,0 +1,980 @@
+"""Unit tests for machine stats and monitoring managers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.machine_stats import (
+    MachineDevice,
+    MachineDeviceManager,
+    MachineLog,
+    MachineLogManager,
+    MachineStats,
+    MachineStatsHistory,
+    MachineStatsManager,
+    MachineStatus,
+    MachineStatusManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+# =============================================================================
+# Sample Data Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_stats_data() -> dict[str, Any]:
+    """Sample machine stats data from API."""
+    return {
+        "$key": 1,
+        "machine": 100,
+        "total_cpu": 45,
+        "user_cpu": 30,
+        "system_cpu": 10,
+        "iowait_cpu": 5,
+        "vmusage_cpu": 0,
+        "irq_cpu": 0,
+        "ram_used": 4096,
+        "ram_pct": 50,
+        "vram_used": 2048,
+        "core_usagelist": [45, 50, 40, 55],
+        "core_temp": 65,
+        "core_temp_top": 72,
+        "core_peak": 80,
+        "core_count_gt_25": 4,
+        "core_count_gt_50": 2,
+        "core_count_gt_75": 1,
+        "modified": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_stats_history_data() -> dict[str, Any]:
+    """Sample machine stats history data from API."""
+    return {
+        "$key": 1,
+        "machine": 100,
+        "timestamp": 1704067200,
+        "total_cpu": 45,
+        "user_cpu": 30,
+        "system_cpu": 10,
+        "iowait_cpu": 5,
+        "vmusage_cpu": 0,
+        "irq_cpu": 0,
+        "ram_used": 4096,
+        "vram_used": 2048,
+        "core_temp": 65,
+        "core_temp_top": 72,
+        "core_peak": 80,
+    }
+
+
+@pytest.fixture
+def sample_status_data() -> dict[str, Any]:
+    """Sample machine status data from API."""
+    return {
+        "$key": 1,
+        "machine": 100,
+        "running": True,
+        "migratable": True,
+        "status": "running",
+        "status_info": "",
+        "state": "online",
+        "powerstate": True,
+        "node": 1,
+        "node_name": "node1",
+        "migrated_node": None,
+        "migration_destination": None,
+        "started": 1704067200,
+        "local_time": 1704153600,
+        "last_update": 1704153600,
+        "running_cores": 4,
+        "running_ram": 4096,
+        "agent_version": "4.0.0",
+        "agent_features": {"file-open": True, "file-close": True},
+        "agent_guest_info": {"os": "Linux", "hostname": "test-vm"},
+    }
+
+
+@pytest.fixture
+def sample_log_data() -> dict[str, Any]:
+    """Sample machine log data from API."""
+    return {
+        "$key": 1,
+        "machine": 100,
+        "machine_name": "test-vm",
+        "level": "message",
+        "text": "VM started successfully",
+        "user": "admin",
+        "timestamp": 1704067200000000,  # microseconds
+    }
+
+
+@pytest.fixture
+def sample_log_list() -> list[dict[str, Any]]:
+    """Sample list of machine logs."""
+    return [
+        {
+            "$key": 1,
+            "machine": 100,
+            "machine_name": "test-vm",
+            "level": "message",
+            "text": "VM started successfully",
+            "user": "admin",
+            "timestamp": 1704067200000000,
+        },
+        {
+            "$key": 2,
+            "machine": 100,
+            "machine_name": "test-vm",
+            "level": "error",
+            "text": "Disk write error",
+            "user": "system",
+            "timestamp": 1704067201000000,
+        },
+        {
+            "$key": 3,
+            "machine": 100,
+            "machine_name": "test-vm",
+            "level": "warning",
+            "text": "High memory usage",
+            "user": "system",
+            "timestamp": 1704067202000000,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_device_data() -> dict[str, Any]:
+    """Sample machine device data from API."""
+    return {
+        "$key": 1,
+        "machine": 100,
+        "machine_name": "test-vm",
+        "machine_type": "vm",
+        "name": "gpu_0",
+        "description": "NVIDIA GPU",
+        "type": "node_nvidia_vgpu_devices",
+        "orderid": 0,
+        "uuid": "abc-123-def",
+        "enabled": True,
+        "optional": False,
+        "resource_group": 5,
+        "resource_group_name": "GPU Pool",
+        "device_status": "online",
+        "status_info": "",
+        "created": 1704067200,
+        "modified": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_device_list() -> list[dict[str, Any]]:
+    """Sample list of machine devices."""
+    return [
+        {
+            "$key": 1,
+            "machine": 100,
+            "machine_name": "test-vm",
+            "machine_type": "vm",
+            "name": "gpu_0",
+            "type": "node_nvidia_vgpu_devices",
+            "orderid": 0,
+            "enabled": True,
+            "device_status": "online",
+        },
+        {
+            "$key": 2,
+            "machine": 100,
+            "machine_name": "test-vm",
+            "machine_type": "vm",
+            "name": "tpm_0",
+            "type": "tpm",
+            "orderid": 1,
+            "enabled": True,
+            "device_status": "online",
+        },
+    ]
+
+
+# =============================================================================
+# MachineStats Model Tests
+# =============================================================================
+
+
+class TestMachineStats:
+    """Tests for MachineStats model."""
+
+    def test_stats_properties(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test stats properties."""
+        manager = MagicMock()
+        stats = MachineStats(sample_stats_data, manager)
+
+        assert stats.machine_key == 100
+        assert stats.total_cpu == 45
+        assert stats.user_cpu == 30
+        assert stats.system_cpu == 10
+        assert stats.iowait_cpu == 5
+        assert stats.vmusage_cpu == 0
+        assert stats.irq_cpu == 0
+        assert stats.ram_used_mb == 4096
+        assert stats.ram_pct == 50
+        assert stats.vram_used_mb == 2048
+        assert stats.core_temp == 65
+        assert stats.core_temp_top == 72
+        assert stats.core_peak == 80
+        assert stats.cores_gt_25_pct == 4
+        assert stats.cores_gt_50_pct == 2
+        assert stats.cores_gt_75_pct == 1
+
+    def test_stats_core_usagelist(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test core usage list."""
+        manager = MagicMock()
+        stats = MachineStats(sample_stats_data, manager)
+
+        assert stats.core_usagelist == [45, 50, 40, 55]
+
+    def test_stats_core_usagelist_empty(self) -> None:
+        """Test empty core usage list."""
+        manager = MagicMock()
+        stats = MachineStats({"$key": 1, "machine": 100}, manager)
+
+        assert stats.core_usagelist == []
+
+    def test_stats_modified_at(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test modified timestamp."""
+        manager = MagicMock()
+        stats = MachineStats(sample_stats_data, manager)
+
+        assert stats.modified_at is not None
+        assert stats.modified_at.year == 2024
+        assert stats.modified_at.tzinfo == timezone.utc
+
+    def test_stats_modified_at_none(self) -> None:
+        """Test modified timestamp when not set."""
+        manager = MagicMock()
+        stats = MachineStats({"$key": 1, "machine": 100}, manager)
+
+        assert stats.modified_at is None
+
+    def test_stats_repr(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test stats repr."""
+        manager = MagicMock()
+        stats = MachineStats(sample_stats_data, manager)
+
+        assert "MachineStats" in repr(stats)
+        assert "machine=100" in repr(stats)
+        assert "cpu=45%" in repr(stats)
+        assert "ram=4096MB" in repr(stats)
+
+
+# =============================================================================
+# MachineStatsHistory Model Tests
+# =============================================================================
+
+
+class TestMachineStatsHistory:
+    """Tests for MachineStatsHistory model."""
+
+    def test_history_properties(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test history properties."""
+        manager = MagicMock()
+        history = MachineStatsHistory(sample_stats_history_data, manager)
+
+        assert history.machine_key == 100
+        assert history.timestamp_epoch == 1704067200
+        assert history.total_cpu == 45
+        assert history.ram_used_mb == 4096
+
+    def test_history_timestamp(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test timestamp property."""
+        manager = MagicMock()
+        history = MachineStatsHistory(sample_stats_history_data, manager)
+
+        assert history.timestamp is not None
+        assert history.timestamp.year == 2024
+        assert history.timestamp.tzinfo == timezone.utc
+
+    def test_history_repr(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test history repr."""
+        manager = MagicMock()
+        history = MachineStatsHistory(sample_stats_history_data, manager)
+
+        assert "MachineStatsHistory" in repr(history)
+        assert "cpu=45%" in repr(history)
+
+
+# =============================================================================
+# MachineStatsManager Tests
+# =============================================================================
+
+
+class TestMachineStatsManager:
+    """Tests for MachineStatsManager."""
+
+    def test_get_stats(
+        self,
+        mock_client: MagicMock,
+        sample_stats_data: dict[str, Any],
+    ) -> None:
+        """Test getting current stats."""
+        mock_client._request.return_value = [sample_stats_data]
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        stats = manager.get()
+
+        assert stats.total_cpu == 45
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "machine_stats"
+        assert "machine eq 100" in call_args[1]["params"]["filter"]
+
+    def test_get_stats_not_found(self, mock_client: MagicMock) -> None:
+        """Test getting stats when not found."""
+        mock_client._request.return_value = []
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+    def test_history_short(
+        self,
+        mock_client: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test getting short history."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        history = manager.history_short(limit=100)
+
+        assert len(history) == 1
+        assert history[0].total_cpu == 45
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "machine_stats_history_short" in call_args[0][1]
+
+    def test_history_long(
+        self,
+        mock_client: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test getting long history."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        history = manager.history_long(limit=100)
+
+        assert len(history) == 1
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "machine_stats_history_long" in call_args[0][1]
+
+    def test_history_with_datetime_filter(
+        self,
+        mock_client: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test history with datetime filter."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        history = manager.history_short(since=since)
+
+        assert len(history) == 1
+        call_args = mock_client._request.call_args
+        assert "timestamp ge" in call_args[1]["params"]["filter"]
+
+    def test_history_with_epoch_filter(
+        self,
+        mock_client: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test history with epoch timestamp filter."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = MachineStatsManager(mock_client, machine_key=100)
+
+        history = manager.history_short(since=1704067200, until=1704153600)
+
+        assert len(history) == 1
+        call_args = mock_client._request.call_args
+        assert "timestamp ge 1704067200" in call_args[1]["params"]["filter"]
+        assert "timestamp le 1704153600" in call_args[1]["params"]["filter"]
+
+
+# =============================================================================
+# MachineStatus Model Tests
+# =============================================================================
+
+
+class TestMachineStatus:
+    """Tests for MachineStatus model."""
+
+    def test_status_properties(self, sample_status_data: dict[str, Any]) -> None:
+        """Test status properties."""
+        manager = MagicMock()
+        status = MachineStatus(sample_status_data, manager)
+
+        assert status.machine_key == 100
+        assert status.is_running is True
+        assert status.is_migratable is True
+        assert status.status == "Running"
+        assert status.status_raw == "running"
+        assert status.state == "Online"
+        assert status.state_raw == "online"
+        assert status.powerstate is True
+        assert status.node_key == 1
+        assert status.node_name == "node1"
+        assert status.running_cores == 4
+        assert status.running_ram_mb == 4096
+
+    def test_status_agent_info(self, sample_status_data: dict[str, Any]) -> None:
+        """Test agent information."""
+        manager = MagicMock()
+        status = MachineStatus(sample_status_data, manager)
+
+        assert status.agent_version == "4.0.0"
+        assert status.has_agent is True
+        assert status.agent_features.get("file-open") is True
+        assert status.agent_guest_info.get("os") == "Linux"
+
+    def test_status_no_agent(self) -> None:
+        """Test when no agent is installed."""
+        manager = MagicMock()
+        status = MachineStatus({"$key": 1, "machine": 100}, manager)
+
+        assert status.agent_version == ""
+        assert status.has_agent is False
+        assert status.agent_features == {}
+        assert status.agent_guest_info == {}
+
+    def test_status_timestamps(self, sample_status_data: dict[str, Any]) -> None:
+        """Test status timestamps."""
+        manager = MagicMock()
+        status = MachineStatus(sample_status_data, manager)
+
+        assert status.started_at is not None
+        assert status.started_at.tzinfo == timezone.utc
+        assert status.last_update is not None
+
+    def test_status_repr(self, sample_status_data: dict[str, Any]) -> None:
+        """Test status repr."""
+        manager = MagicMock()
+        status = MachineStatus(sample_status_data, manager)
+
+        assert "MachineStatus" in repr(status)
+        assert "status=running" in repr(status)
+
+
+# =============================================================================
+# MachineStatusManager Tests
+# =============================================================================
+
+
+class TestMachineStatusManager:
+    """Tests for MachineStatusManager."""
+
+    def test_get_status(
+        self,
+        mock_client: MagicMock,
+        sample_status_data: dict[str, Any],
+    ) -> None:
+        """Test getting status."""
+        mock_client._request.return_value = [sample_status_data]
+        manager = MachineStatusManager(mock_client, machine_key=100)
+
+        status = manager.get()
+
+        assert status.is_running is True
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "machine eq 100" in call_args[1]["params"]["filter"]
+
+    def test_get_status_not_found(self, mock_client: MagicMock) -> None:
+        """Test getting status when not found."""
+        mock_client._request.return_value = []
+        manager = MachineStatusManager(mock_client, machine_key=100)
+
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+
+# =============================================================================
+# MachineLog Model Tests
+# =============================================================================
+
+
+class TestMachineLog:
+    """Tests for MachineLog model."""
+
+    def test_log_properties(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log properties."""
+        manager = MagicMock()
+        log = MachineLog(sample_log_data, manager)
+
+        assert log.machine_key == 100
+        assert log.machine_name == "test-vm"
+        assert log.level == "Message"
+        assert log.level_raw == "message"
+        assert log.text == "VM started successfully"
+        assert log.user == "admin"
+
+    def test_log_timestamp(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log timestamp (microsecond precision)."""
+        manager = MagicMock()
+        log = MachineLog(sample_log_data, manager)
+
+        assert log.timestamp is not None
+        assert log.timestamp_epoch_us == 1704067200000000
+
+    def test_log_level_checks(self, sample_log_list: list[dict[str, Any]]) -> None:
+        """Test log level helper properties."""
+        manager = MagicMock()
+
+        message_log = MachineLog(sample_log_list[0], manager)
+        error_log = MachineLog(sample_log_list[1], manager)
+        warning_log = MachineLog(sample_log_list[2], manager)
+
+        assert message_log.is_error is False
+        assert message_log.is_warning is False
+        assert message_log.is_audit is False
+
+        assert error_log.is_error is True
+        assert error_log.is_warning is False
+
+        assert warning_log.is_warning is True
+        assert warning_log.is_error is False
+
+    def test_log_repr(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log repr."""
+        manager = MagicMock()
+        log = MachineLog(sample_log_data, manager)
+
+        assert "MachineLog" in repr(log)
+        assert "Message" in repr(log)
+
+
+# =============================================================================
+# MachineLogManager Tests
+# =============================================================================
+
+
+class TestMachineLogManager:
+    """Tests for MachineLogManager."""
+
+    def test_list_logs(
+        self,
+        mock_client: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs."""
+        mock_client._request.return_value = sample_log_list
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        logs = manager.list()
+
+        assert len(logs) == 3
+        mock_client._request.assert_called_once()
+
+    def test_list_logs_by_level(
+        self,
+        mock_client: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs filtered by level."""
+        mock_client._request.return_value = [sample_log_list[1]]
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        logs = manager.list(level="error")
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'error'" in call_args[1]["params"]["filter"]
+
+    def test_list_errors_only(
+        self,
+        mock_client: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing errors only."""
+        mock_client._request.return_value = [sample_log_list[1]]
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        logs = manager.list(errors_only=True)
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'error' or level eq 'critical'" in call_args[1]["params"]["filter"]
+
+    def test_list_warnings_only(
+        self,
+        mock_client: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing warnings only."""
+        mock_client._request.return_value = [sample_log_list[2]]
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        logs = manager.list(warnings_only=True)
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'warning'" in call_args[1]["params"]["filter"]
+
+    def test_list_logs_with_time_filter(
+        self,
+        mock_client: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs with time filter."""
+        mock_client._request.return_value = sample_log_list
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        logs = manager.list(since=since)
+
+        assert len(logs) == 3
+        call_args = mock_client._request.call_args
+        assert "timestamp ge" in call_args[1]["params"]["filter"]
+
+    def test_get_log(
+        self,
+        mock_client: MagicMock,
+        sample_log_data: dict[str, Any],
+    ) -> None:
+        """Test getting a specific log."""
+        mock_client._request.return_value = sample_log_data
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        log = manager.get(key=1)
+
+        assert log.text == "VM started successfully"
+
+    def test_get_log_not_found(self, mock_client: MagicMock) -> None:
+        """Test getting a log that doesn't exist."""
+        mock_client._request.return_value = None
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        with pytest.raises(NotFoundError):
+            manager.get(key=999)
+
+    def test_get_log_key_required(self, mock_client: MagicMock) -> None:
+        """Test that key is required for get."""
+        manager = MachineLogManager(mock_client, machine_key=100)
+
+        with pytest.raises(ValueError, match="key must be provided"):
+            manager.get()
+
+
+# =============================================================================
+# MachineDevice Model Tests
+# =============================================================================
+
+
+class TestMachineDevice:
+    """Tests for MachineDevice model."""
+
+    def test_device_properties(self, sample_device_data: dict[str, Any]) -> None:
+        """Test device properties."""
+        manager = MagicMock()
+        device = MachineDevice(sample_device_data, manager)
+
+        assert device.machine_key == 100
+        assert device.machine_name == "test-vm"
+        assert device.machine_type == "vm"
+        assert device.name == "gpu_0"
+        assert device.description == "NVIDIA GPU"
+        assert device.device_type == "NVIDIA vGPU"
+        assert device.device_type_raw == "node_nvidia_vgpu_devices"
+        assert device.orderid == 0
+        assert device.uuid == "abc-123-def"
+        assert device.is_enabled is True
+        assert device.is_optional is False
+        assert device.resource_group_key == 5
+        assert device.resource_group_name == "GPU Pool"
+
+    def test_device_status(self, sample_device_data: dict[str, Any]) -> None:
+        """Test device status."""
+        manager = MagicMock()
+        device = MachineDevice(sample_device_data, manager)
+
+        assert device.status == "Online"
+        assert device.status_raw == "online"
+
+    def test_device_type_checks(self, sample_device_list: list[dict[str, Any]]) -> None:
+        """Test device type helper properties."""
+        manager = MagicMock()
+
+        gpu_device = MachineDevice(sample_device_list[0], manager)
+        tpm_device = MachineDevice(sample_device_list[1], manager)
+
+        assert gpu_device.is_gpu is True
+        assert gpu_device.is_tpm is False
+        assert gpu_device.is_usb is False
+
+        assert tpm_device.is_tpm is True
+        assert tpm_device.is_gpu is False
+
+    def test_device_repr(self, sample_device_data: dict[str, Any]) -> None:
+        """Test device repr."""
+        manager = MagicMock()
+        device = MachineDevice(sample_device_data, manager)
+
+        assert "MachineDevice" in repr(device)
+        assert "gpu_0" in repr(device)
+
+
+# =============================================================================
+# MachineDeviceManager Tests
+# =============================================================================
+
+
+class TestMachineDeviceManager:
+    """Tests for MachineDeviceManager."""
+
+    def test_list_devices(
+        self,
+        mock_client: MagicMock,
+        sample_device_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing devices."""
+        mock_client._request.return_value = sample_device_list
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        devices = manager.list()
+
+        assert len(devices) == 2
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "machine eq 100" in call_args[1]["params"]["filter"]
+
+    def test_list_devices_by_type(
+        self,
+        mock_client: MagicMock,
+        sample_device_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing devices by type."""
+        mock_client._request.return_value = [sample_device_list[0]]
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        devices = manager.list(device_type="node_nvidia_vgpu_devices")
+
+        assert len(devices) == 1
+        call_args = mock_client._request.call_args
+        assert "type eq 'node_nvidia_vgpu_devices'" in call_args[1]["params"]["filter"]
+
+    def test_list_enabled_only(
+        self,
+        mock_client: MagicMock,
+        sample_device_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing only enabled devices."""
+        mock_client._request.return_value = sample_device_list
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        manager.list(enabled_only=True)
+
+        call_args = mock_client._request.call_args
+        assert "enabled eq true" in call_args[1]["params"]["filter"]
+
+    def test_get_device_by_key(
+        self,
+        mock_client: MagicMock,
+        sample_device_data: dict[str, Any],
+    ) -> None:
+        """Test getting a device by key."""
+        mock_client._request.return_value = sample_device_data
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        device = manager.get(key=1)
+
+        assert device.name == "gpu_0"
+
+    def test_get_device_by_name(
+        self,
+        mock_client: MagicMock,
+        sample_device_data: dict[str, Any],
+    ) -> None:
+        """Test getting a device by name."""
+        mock_client._request.return_value = [sample_device_data]
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        device = manager.get(name="gpu_0")
+
+        assert device.key == 1
+
+    def test_get_device_not_found(self, mock_client: MagicMock) -> None:
+        """Test getting a device that doesn't exist."""
+        mock_client._request.return_value = None
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        with pytest.raises(NotFoundError):
+            manager.get(key=999)
+
+    def test_get_device_key_or_name_required(self, mock_client: MagicMock) -> None:
+        """Test that key or name is required for get."""
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            manager.get()
+
+    def test_create_device(
+        self,
+        mock_client: MagicMock,
+        sample_device_data: dict[str, Any],
+    ) -> None:
+        """Test creating a device."""
+        # First call returns created device, second call returns full device
+        mock_client._request.side_effect = [
+            sample_device_data,  # POST response
+            sample_device_data,  # GET for full device
+        ]
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        device = manager.create(
+            device_type="node_nvidia_vgpu_devices",
+            name="gpu_0",
+            description="NVIDIA GPU",
+            resource_group=5,
+        )
+
+        assert device.name == "gpu_0"
+        # Check that POST was called with correct body
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call[0][0] == "POST"
+        assert post_call[1]["json_data"]["machine"] == 100
+        assert post_call[1]["json_data"]["type"] == "node_nvidia_vgpu_devices"
+
+    def test_update_device(
+        self,
+        mock_client: MagicMock,
+        sample_device_data: dict[str, Any],
+    ) -> None:
+        """Test updating a device."""
+        mock_client._request.return_value = sample_device_data
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        device = manager.update(key=1, enabled=False)
+
+        assert device.name == "gpu_0"
+        mock_client._request.assert_called()
+        call_args = mock_client._request.call_args
+        assert call_args[0][0] == "PUT"
+        assert call_args[1]["json_data"]["enabled"] is False
+
+    def test_delete_device(self, mock_client: MagicMock) -> None:
+        """Test deleting a device."""
+        mock_client._request.return_value = None
+        manager = MachineDeviceManager(mock_client, machine_key=100)
+
+        manager.delete(key=1)
+
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert "machine_devices/1" in call_args[0][1]
+
+
+# =============================================================================
+# Integration Tests with VM/Node
+# =============================================================================
+
+
+class TestVMIntegration:
+    """Tests for VM integration with machine stats."""
+
+    def test_vm_has_stats_property(self, mock_client: MagicMock) -> None:
+        """Test that VM has stats property."""
+        from pyvergeos.resources.vms import VM
+
+        vm_data = {
+            "$key": 1,
+            "name": "test-vm",
+            "machine": 100,
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        vm = VM(vm_data, manager)
+
+        stats_manager = vm.stats
+        assert isinstance(stats_manager, MachineStatsManager)
+        assert stats_manager._machine_key == 100
+
+    def test_vm_has_machine_status_property(self, mock_client: MagicMock) -> None:
+        """Test that VM has machine_status property."""
+        from pyvergeos.resources.vms import VM
+
+        vm_data = {
+            "$key": 1,
+            "name": "test-vm",
+            "machine": 100,
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        vm = VM(vm_data, manager)
+
+        status_manager = vm.machine_status
+        assert isinstance(status_manager, MachineStatusManager)
+
+    def test_vm_has_machine_logs_property(self, mock_client: MagicMock) -> None:
+        """Test that VM has machine_logs property."""
+        from pyvergeos.resources.vms import VM
+
+        vm_data = {
+            "$key": 1,
+            "name": "test-vm",
+            "machine": 100,
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        vm = VM(vm_data, manager)
+
+        logs_manager = vm.machine_logs
+        assert isinstance(logs_manager, MachineLogManager)
+
+    def test_vm_has_devices_property(self, mock_client: MagicMock) -> None:
+        """Test that VM has devices property."""
+        from pyvergeos.resources.vms import VM
+
+        vm_data = {
+            "$key": 1,
+            "name": "test-vm",
+            "machine": 100,
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        vm = VM(vm_data, manager)
+
+        devices_manager = vm.devices
+        assert isinstance(devices_manager, MachineDeviceManager)
+
+    def test_vm_machine_key_error(self, mock_client: MagicMock) -> None:
+        """Test error when VM has no machine key."""
+        from pyvergeos.resources.vms import VM
+
+        vm_data = {
+            "$key": 1,
+            "name": "test-vm",
+            # No machine key
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        vm = VM(vm_data, manager)
+
+        with pytest.raises(ValueError, match="no machine key"):
+            _ = vm.stats


### PR DESCRIPTION
## Summary

Implements section 3.1 Machine Stats & Monitoring from the v1.0 release plan. Adds comprehensive machine performance monitoring with scoped managers accessible via `vm.stats`, `vm.machine_status`, `vm.machine_logs`, `vm.devices` and equivalent properties on nodes.

- **MachineStats/MachineStatsManager** - CPU, RAM, temperature, per-core usage metrics
- **MachineStatsHistory** - Short-term and long-term historical data via `history_short()` and `history_long()` methods
- **MachineStatus/MachineStatusManager** - Operational status, node info, guest agent info
- **MachineLog/MachineLogManager** - Machine-specific logs with level/time filtering
- **MachineDevice/MachineDeviceManager** - GPU, TPM, USB device management with full CRUD

### Usage Example

```python
# VM stats
vm = client.vms.get(name="web-server")
stats = vm.stats.get()
print(f"CPU: {stats.total_cpu}%, RAM: {stats.ram_used_mb}MB")

# Stats history
history = vm.stats.history_short(limit=100)
for point in history:
    print(f"{point.timestamp}: CPU {point.total_cpu}%")

# Machine status
status = vm.machine_status.get()
print(f"Status: {status.status}, Node: {status.node_name}")

# Machine logs
logs = vm.machine_logs.list(errors_only=True, limit=10)

# Devices
devices = vm.devices.list()
tpm = vm.devices.create(device_type="tpm", name="vTPM")
```

## Test plan

- [x] 53 unit tests covering all managers and resource objects
- [x] 25 integration tests verified against live VergeOS system
- [x] Ruff lint/format passing
- [x] Mypy type checking passing
- [x] All 2864 unit tests passing