### PR TITLE
✨ feat: add cluster tier management

### DIFF
--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -12,6 +12,14 @@ from pyvergeos.resources.cloud_snapshots import (
     CloudSnapshotVMManager,
 )
 from pyvergeos.resources.cloudinit_files import CloudInitFile, CloudInitFileManager
+from pyvergeos.resources.cluster_tiers import (
+    ClusterTier,
+    ClusterTierManager,
+    ClusterTierStats,
+    ClusterTierStatsHistoryLong,
+    ClusterTierStatsHistoryShort,
+    ClusterTierStatus,
+)
 from pyvergeos.resources.devices import Device, DeviceManager
 from pyvergeos.resources.gpu import (
     NodeGpu,
@@ -142,6 +150,12 @@ __all__ = [
     "Certificate",
     "CertificateManager",
     "CIFSSettings",
+    "ClusterTier",
+    "ClusterTierManager",
+    "ClusterTierStats",
+    "ClusterTierStatsHistoryLong",
+    "ClusterTierStatsHistoryShort",
+    "ClusterTierStatus",
     "CloudInitFile",
     "CloudInitFileManager",
     "CloudSnapshot",

--- a/pyvergeos/resources/cluster_tiers.py
+++ b/pyvergeos/resources/cluster_tiers.py
@@ -1,0 +1,1240 @@
+"""Cluster Tier Management for VergeOS vSAN.
+
+This module provides access to cluster storage tiers, their status,
+performance stats, and historical metrics.
+
+Example:
+    >>> # Access tiers for a cluster
+    >>> cluster = client.clusters.get(name="Production")
+    >>> for tier in cluster.tiers.list():
+    ...     print(f"Tier {tier.tier}: {tier.used_percent}% used")
+
+    >>> # Get tier status
+    >>> tier = cluster.tiers.get(tier=1)
+    >>> status = tier.get_status()
+    >>> print(f"Status: {status.status}, Redundant: {status.is_redundant}")
+
+    >>> # Get tier stats
+    >>> stats = tier.get_stats()
+    >>> print(f"IOPS: {stats.read_ops} read, {stats.write_ops} write")
+
+    >>> # Get stats history
+    >>> history = tier.stats_history_short(limit=100)
+    >>> for point in history:
+    ...     print(f"{point.timestamp}: {point.read_ops} IOPS")
+"""
+
+from __future__ import annotations
+
+import builtins
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+# Status display mappings
+TIER_STATUS_DISPLAY = {
+    "online": "Online",
+    "offline": "Offline",
+    "repairing": "Repairing",
+    "initializing": "Initializing",
+    "verifying": "Verifying",
+    "noredundant": "Online - No Redundancy",
+    "outofspace": "Tier Throttled (Low Space)",
+}
+
+TIER_STATE_DISPLAY = {
+    "online": "Online",
+    "offline": "Offline",
+    "warning": "Warning",
+    "error": "Error",
+}
+
+
+# =============================================================================
+# Cluster Tier Stats History (Long-term)
+# =============================================================================
+
+
+class ClusterTierStatsHistoryLong(ResourceObject):
+    """Long-term cluster tier stats history record.
+
+    Contains peak and average metrics with longer retention but lower resolution.
+    """
+
+    @property
+    def tier_key(self) -> int:
+        """Parent tier key."""
+        return int(self.get("tier", 0))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp for this history point."""
+        ts = self.get("timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch(self) -> int:
+        """Timestamp as Unix epoch."""
+        return int(self.get("timestamp", 0))
+
+    # Peak metrics
+    @property
+    def read_ops_peak(self) -> int:
+        """Peak read operations per second."""
+        return int(self.get("rops_peak", 0))
+
+    @property
+    def write_ops_peak(self) -> int:
+        """Peak write operations per second."""
+        return int(self.get("wops_peak", 0))
+
+    @property
+    def read_bps_peak(self) -> int:
+        """Peak read bytes per second."""
+        return int(self.get("rbps_peak", 0))
+
+    @property
+    def write_bps_peak(self) -> int:
+        """Peak write bytes per second."""
+        return int(self.get("wbps_peak", 0))
+
+    # Average metrics
+    @property
+    def read_ops_avg(self) -> int:
+        """Average read operations per second."""
+        return int(self.get("rops_avg", 0))
+
+    @property
+    def write_ops_avg(self) -> int:
+        """Average write operations per second."""
+        return int(self.get("wops_avg", 0))
+
+    @property
+    def read_bps_avg(self) -> int:
+        """Average read bytes per second."""
+        return int(self.get("rbps_avg", 0))
+
+    @property
+    def write_bps_avg(self) -> int:
+        """Average write bytes per second."""
+        return int(self.get("wbps_avg", 0))
+
+    # Cumulative metrics
+    @property
+    def total_reads(self) -> int:
+        """Total read operations."""
+        return int(self.get("reads", 0))
+
+    @property
+    def total_writes(self) -> int:
+        """Total write operations."""
+        return int(self.get("writes", 0))
+
+    @property
+    def total_read_bytes(self) -> int:
+        """Total bytes read."""
+        return int(self.get("read_bytes", 0))
+
+    @property
+    def total_write_bytes(self) -> int:
+        """Total bytes written."""
+        return int(self.get("write_bytes", 0))
+
+    # Capacity metrics
+    @property
+    def capacity_bytes(self) -> int:
+        """Capacity in bytes at this point."""
+        return int(self.get("capacity", 0))
+
+    @property
+    def capacity_gb(self) -> float:
+        """Capacity in GB."""
+        return round(self.capacity_bytes / 1073741824, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def used_bytes(self) -> int:
+        """Used space in bytes at this point."""
+        return int(self.get("used", 0))
+
+    @property
+    def used_gb(self) -> float:
+        """Used space in GB."""
+        return round(self.used_bytes / 1073741824, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_percent(self) -> float:
+        """Usage percentage at this point."""
+        if self.capacity_bytes > 0:
+            return round((self.used_bytes / self.capacity_bytes) * 100, 1)
+        return 0.0
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        return (
+            f"<ClusterTierStatsHistoryLong ts={ts} "
+            f"rops_avg={self.read_ops_avg} wops_avg={self.write_ops_avg}>"
+        )
+
+
+# =============================================================================
+# Cluster Tier Stats History (Short-term)
+# =============================================================================
+
+
+class ClusterTierStatsHistoryShort(ResourceObject):
+    """Short-term cluster tier stats history record.
+
+    Contains high-resolution metrics with shorter retention.
+    """
+
+    @property
+    def tier_key(self) -> int:
+        """Parent tier key."""
+        return int(self.get("tier", 0))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp for this history point."""
+        ts = self.get("timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch(self) -> int:
+        """Timestamp as Unix epoch."""
+        return int(self.get("timestamp", 0))
+
+    @property
+    def read_ops(self) -> int:
+        """Read operations per second."""
+        return int(self.get("rops", 0))
+
+    @property
+    def write_ops(self) -> int:
+        """Write operations per second."""
+        return int(self.get("wops", 0))
+
+    @property
+    def read_bps(self) -> int:
+        """Read bytes per second."""
+        return int(self.get("rbps", 0))
+
+    @property
+    def write_bps(self) -> int:
+        """Write bytes per second."""
+        return int(self.get("wbps", 0))
+
+    @property
+    def total_reads(self) -> int:
+        """Total read operations."""
+        return int(self.get("reads", 0))
+
+    @property
+    def total_writes(self) -> int:
+        """Total write operations."""
+        return int(self.get("writes", 0))
+
+    @property
+    def total_read_bytes(self) -> int:
+        """Total bytes read."""
+        return int(self.get("read_bytes", 0))
+
+    @property
+    def total_write_bytes(self) -> int:
+        """Total bytes written."""
+        return int(self.get("write_bytes", 0))
+
+    @property
+    def capacity_bytes(self) -> int:
+        """Capacity in bytes at this point."""
+        return int(self.get("capacity", 0))
+
+    @property
+    def capacity_gb(self) -> float:
+        """Capacity in GB."""
+        return round(self.capacity_bytes / 1073741824, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def used_bytes(self) -> int:
+        """Used space in bytes at this point."""
+        return int(self.get("used", 0))
+
+    @property
+    def used_gb(self) -> float:
+        """Used space in GB."""
+        return round(self.used_bytes / 1073741824, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_percent(self) -> float:
+        """Usage percentage at this point."""
+        if self.capacity_bytes > 0:
+            return round((self.used_bytes / self.capacity_bytes) * 100, 1)
+        return 0.0
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        return f"<ClusterTierStatsHistoryShort ts={ts} rops={self.read_ops} wops={self.write_ops}>"
+
+
+# =============================================================================
+# Cluster Tier Stats
+# =============================================================================
+
+
+class ClusterTierStats(ResourceObject):
+    """Current cluster tier statistics.
+
+    Provides real-time I/O performance metrics for a tier.
+    """
+
+    @property
+    def tier_key(self) -> int:
+        """Parent tier key."""
+        return int(self.get("tier", 0))
+
+    @property
+    def read_ops(self) -> int:
+        """Current read operations per second."""
+        return int(self.get("rops", 0))
+
+    @property
+    def write_ops(self) -> int:
+        """Current write operations per second."""
+        return int(self.get("wops", 0))
+
+    @property
+    def read_bps(self) -> int:
+        """Current read bytes per second."""
+        return int(self.get("rbps", 0))
+
+    @property
+    def write_bps(self) -> int:
+        """Current write bytes per second."""
+        return int(self.get("wbps", 0))
+
+    @property
+    def read_mbps(self) -> float:
+        """Current read MB per second."""
+        return round(self.read_bps / 1048576, 2) if self.read_bps else 0.0
+
+    @property
+    def write_mbps(self) -> float:
+        """Current write MB per second."""
+        return round(self.write_bps / 1048576, 2) if self.write_bps else 0.0
+
+    @property
+    def total_reads(self) -> int:
+        """Total read operations."""
+        return int(self.get("reads", 0))
+
+    @property
+    def total_writes(self) -> int:
+        """Total write operations."""
+        return int(self.get("writes", 0))
+
+    @property
+    def total_read_bytes(self) -> int:
+        """Total bytes read."""
+        return int(self.get("read_bytes", 0))
+
+    @property
+    def total_write_bytes(self) -> int:
+        """Total bytes written."""
+        return int(self.get("write_bytes", 0))
+
+    @property
+    def last_update(self) -> datetime | None:
+        """Timestamp of last update."""
+        ts = self.get("last_update")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def __repr__(self) -> str:
+        return f"<ClusterTierStats tier={self.tier_key} rops={self.read_ops} wops={self.write_ops}>"
+
+
+# =============================================================================
+# Cluster Tier Status
+# =============================================================================
+
+
+class ClusterTierStatus(ResourceObject):
+    """Cluster tier health and capacity status.
+
+    Provides operational status, capacity metrics, and health indicators.
+    """
+
+    @property
+    def tier_key(self) -> int:
+        """Parent tier key."""
+        return int(self.get("tier", 0))
+
+    @property
+    def status(self) -> str:
+        """Status (Online, Offline, Repairing, etc.)."""
+        raw = str(self.get("status", "offline"))
+        return TIER_STATUS_DISPLAY.get(raw, raw)
+
+    @property
+    def status_raw(self) -> str:
+        """Raw status value."""
+        return str(self.get("status", "offline"))
+
+    @property
+    def state(self) -> str:
+        """State (Online, Offline, Warning, Error)."""
+        raw = str(self.get("state", "offline"))
+        return TIER_STATE_DISPLAY.get(raw, raw)
+
+    @property
+    def state_raw(self) -> str:
+        """Raw state value."""
+        return str(self.get("state", "offline"))
+
+    @property
+    def is_online(self) -> bool:
+        """Check if tier is online."""
+        return self.status_raw == "online"
+
+    @property
+    def is_healthy(self) -> bool:
+        """Check if tier is healthy (online state)."""
+        return self.state_raw == "online"
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if tier is in warning state."""
+        return self.state_raw == "warning"
+
+    @property
+    def is_error(self) -> bool:
+        """Check if tier is in error state."""
+        return self.state_raw == "error"
+
+    @property
+    def capacity_bytes(self) -> int:
+        """Total capacity in bytes."""
+        return int(self.get("capacity", 0))
+
+    @property
+    def capacity_gb(self) -> float:
+        """Total capacity in GB."""
+        return round(self.capacity_bytes / 1073741824, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def capacity_tb(self) -> float:
+        """Total capacity in TB."""
+        return round(self.capacity_bytes / 1099511627776, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def used_bytes(self) -> int:
+        """Used space in bytes."""
+        return int(self.get("used", 0))
+
+    @property
+    def used_gb(self) -> float:
+        """Used space in GB."""
+        return round(self.used_bytes / 1073741824, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_tb(self) -> float:
+        """Used space in TB."""
+        return round(self.used_bytes / 1099511627776, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_percent(self) -> float:
+        """Usage percentage."""
+        pct = self.get("used_pct")
+        if pct is not None:
+            return float(pct)
+        if self.capacity_bytes > 0:
+            return round((self.used_bytes / self.capacity_bytes) * 100, 1)
+        return 0.0
+
+    @property
+    def free_bytes(self) -> int:
+        """Free space in bytes."""
+        return max(0, self.capacity_bytes - self.used_bytes)
+
+    @property
+    def free_gb(self) -> float:
+        """Free space in GB."""
+        return round(self.free_bytes / 1073741824, 2) if self.free_bytes else 0.0
+
+    @property
+    def is_redundant(self) -> bool:
+        """Check if tier has redundancy."""
+        return bool(self.get("redundant", False))
+
+    @property
+    def is_encrypted(self) -> bool:
+        """Check if tier is encrypted."""
+        return bool(self.get("encrypted", False))
+
+    @property
+    def is_working(self) -> bool:
+        """Check if tier is actively working."""
+        return bool(self.get("working", False))
+
+    @property
+    def last_walk_time_ms(self) -> int:
+        """Last walk time in milliseconds."""
+        return int(self.get("last_walk_time_ms", 0))
+
+    @property
+    def last_fullwalk_time_ms(self) -> int:
+        """Last full walk time in milliseconds."""
+        return int(self.get("last_fullwalk_time_ms", 0))
+
+    @property
+    def transaction(self) -> int:
+        """Current transaction ID."""
+        return int(self.get("transaction", 0))
+
+    @property
+    def repairs(self) -> int:
+        """Number of repairs."""
+        return int(self.get("repairs", 0))
+
+    @property
+    def bad_drives(self) -> int:
+        """Number of unavailable drives."""
+        return int(self.get("bad_drives", 0))
+
+    @property
+    def is_fullwalk(self) -> bool:
+        """Check if full walk is in progress."""
+        return bool(self.get("fullwalk", False))
+
+    @property
+    def walk_progress(self) -> float:
+        """Walk progress percentage (0-100)."""
+        return float(self.get("progress", 0))
+
+    @property
+    def index_unique(self) -> int:
+        """Unique index count."""
+        return int(self.get("index_unique", 0))
+
+    @property
+    def throttle_ms(self) -> float:
+        """Current space throttle in milliseconds."""
+        return float(self.get("cur_space_throttle_ms", 0))
+
+    @property
+    def is_throttled(self) -> bool:
+        """Check if tier is being throttled due to low space."""
+        return self.throttle_ms > 0
+
+    @property
+    def transaction_start(self) -> datetime | None:
+        """Transaction start timestamp."""
+        ts = self.get("transaction_start_stamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def state_timestamp(self) -> datetime | None:
+        """Timestamp when state last changed."""
+        ts = self.get("state_timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def __repr__(self) -> str:
+        return (
+            f"<ClusterTierStatus tier={self.tier_key} "
+            f"status={self.status_raw} used={self.used_percent}%>"
+        )
+
+
+# =============================================================================
+# Cluster Tier
+# =============================================================================
+
+
+class ClusterTier(ResourceObject):
+    """Cluster storage tier resource object.
+
+    Represents a storage tier within a specific cluster.
+
+    Example:
+        >>> tier = cluster.tiers.get(tier=1)
+        >>> print(f"Tier {tier.tier}: {tier.description}")
+        >>> print(f"  Status: {tier.status}, Capacity: {tier.capacity_gb} GB")
+    """
+
+    @property
+    def tier(self) -> int:
+        """Tier number (0-5)."""
+        return int(self.get("tier", 0))
+
+    @property
+    def cluster_key(self) -> int:
+        """Parent cluster key."""
+        return int(self.get("cluster", 0))
+
+    @property
+    def description(self) -> str:
+        """Tier description."""
+        return str(self.get("description", ""))
+
+    @property
+    def cost_per_gb(self) -> float:
+        """Cost per GB."""
+        return float(self.get("cost_per_gb", 0))
+
+    @property
+    def price_per_gb(self) -> float:
+        """Price per GB."""
+        return float(self.get("price_per_gb", 0))
+
+    # Embedded status properties (from list view)
+    @property
+    def status(self) -> str:
+        """Status from embedded status field."""
+        raw = str(self.get("display_status") or self.get("status_status", "offline"))
+        return TIER_STATUS_DISPLAY.get(raw, raw)
+
+    @property
+    def status_raw(self) -> str:
+        """Raw status value."""
+        return str(self.get("display_status") or self.get("status_status", "offline"))
+
+    @property
+    def capacity_bytes(self) -> int:
+        """Total capacity in bytes."""
+        return int(self.get("capacity") or self.get("status_capacity", 0))
+
+    @property
+    def capacity_gb(self) -> float:
+        """Total capacity in GB."""
+        return round(self.capacity_bytes / 1073741824, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def capacity_tb(self) -> float:
+        """Total capacity in TB."""
+        return round(self.capacity_bytes / 1099511627776, 2) if self.capacity_bytes else 0.0
+
+    @property
+    def used_bytes(self) -> int:
+        """Used space in bytes."""
+        return int(self.get("used") or self.get("status_used", 0))
+
+    @property
+    def used_gb(self) -> float:
+        """Used space in GB."""
+        return round(self.used_bytes / 1073741824, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_tb(self) -> float:
+        """Used space in TB."""
+        return round(self.used_bytes / 1099511627776, 2) if self.used_bytes else 0.0
+
+    @property
+    def used_percent(self) -> float:
+        """Usage percentage."""
+        pct = self.get("used_pct") or self.get("status_used_pct")
+        if pct is not None:
+            return float(pct)
+        if self.capacity_bytes > 0:
+            return round((self.used_bytes / self.capacity_bytes) * 100, 1)
+        return 0.0
+
+    @property
+    def free_bytes(self) -> int:
+        """Free space in bytes."""
+        return max(0, self.capacity_bytes - self.used_bytes)
+
+    @property
+    def free_gb(self) -> float:
+        """Free space in GB."""
+        return round(self.free_bytes / 1073741824, 2) if self.free_bytes else 0.0
+
+    @property
+    def is_redundant(self) -> bool:
+        """Check if tier has redundancy."""
+        return bool(self.get("redundant") or self.get("status_redundant", False))
+
+    @property
+    def is_working(self) -> bool:
+        """Check if tier is actively working."""
+        return bool(self.get("working") or self.get("status_working", False))
+
+    @property
+    def is_encrypted(self) -> bool:
+        """Check if tier is encrypted."""
+        return bool(self.get("encrypted") or self.get("status_encrypted", False))
+
+    # Embedded stats properties (from list view)
+    @property
+    def read_ops(self) -> int:
+        """Current read operations per second."""
+        return int(self.get("rops") or self.get("stats_rops", 0))
+
+    @property
+    def write_ops(self) -> int:
+        """Current write operations per second."""
+        return int(self.get("wops") or self.get("stats_wops", 0))
+
+    @property
+    def read_bps(self) -> int:
+        """Current read bytes per second."""
+        return int(self.get("rbps") or self.get("stats_rbps", 0))
+
+    @property
+    def write_bps(self) -> int:
+        """Current write bytes per second."""
+        return int(self.get("wbps") or self.get("stats_wbps", 0))
+
+    def get_status(self) -> ClusterTierStatus:
+        """Get detailed tier status.
+
+        Returns:
+            ClusterTierStatus object with full status information.
+        """
+        from typing import cast
+
+        manager = cast("ClusterTierManager", self._manager)
+        return manager.get_tier_status(self.key)
+
+    def get_stats(self) -> ClusterTierStats:
+        """Get current tier statistics.
+
+        Returns:
+            ClusterTierStats object with current I/O metrics.
+        """
+        from typing import cast
+
+        manager = cast("ClusterTierManager", self._manager)
+        return manager.get_tier_stats(self.key)
+
+    def stats_history_short(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+    ) -> builtins.list[ClusterTierStatsHistoryShort]:
+        """Get short-term stats history (high resolution).
+
+        Args:
+            limit: Maximum number of records.
+            offset: Skip this many records.
+            since: Return records after this time.
+            until: Return records before this time.
+
+        Returns:
+            List of ClusterTierStatsHistoryShort objects.
+        """
+        from typing import cast
+
+        manager = cast("ClusterTierManager", self._manager)
+        return manager.get_stats_history_short(
+            self.key, limit=limit, offset=offset, since=since, until=until
+        )
+
+    def stats_history_long(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+    ) -> builtins.list[ClusterTierStatsHistoryLong]:
+        """Get long-term stats history (lower resolution, longer retention).
+
+        Args:
+            limit: Maximum number of records.
+            offset: Skip this many records.
+            since: Return records after this time.
+            until: Return records before this time.
+
+        Returns:
+            List of ClusterTierStatsHistoryLong objects.
+        """
+        from typing import cast
+
+        manager = cast("ClusterTierManager", self._manager)
+        return manager.get_stats_history_long(
+            self.key, limit=limit, offset=offset, since=since, until=until
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ClusterTier tier={self.tier} cluster={self.cluster_key} "
+            f"{self.used_gb:.1f}/{self.capacity_gb:.1f} GB ({self.used_percent}%)>"
+        )
+
+
+# =============================================================================
+# Cluster Tier Manager
+# =============================================================================
+
+
+class ClusterTierManager(ResourceManager[ClusterTier]):
+    """Manager for cluster tier operations.
+
+    Provides access to storage tiers within a specific cluster, including
+    status, statistics, and historical metrics.
+
+    Scoped to a specific cluster.
+
+    Example:
+        >>> # Access via cluster object
+        >>> cluster = client.clusters.get(name="Production")
+        >>> for tier in cluster.tiers.list():
+        ...     print(f"Tier {tier.tier}: {tier.used_percent}% used")
+
+        >>> # Get specific tier
+        >>> tier = cluster.tiers.get(tier=1)
+
+        >>> # Get tier status
+        >>> status = cluster.tiers.get_tier_status(tier.key)
+        >>> print(f"Status: {status.status}")
+
+        >>> # Get tier stats
+        >>> stats = cluster.tiers.get_tier_stats(tier.key)
+        >>> print(f"IOPS: {stats.read_ops} read, {stats.write_ops} write")
+    """
+
+    _endpoint = "cluster_tiers"
+
+    _default_fields = [
+        "$key",
+        "tier",
+        "cluster",
+        "description",
+        "cost_per_gb",
+        "price_per_gb",
+        "status#status as display_status",
+        "status#state as display_state",
+        "status#capacity as capacity",
+        "status#used as used",
+        "status#used_pct as used_pct",
+        "status#redundant as redundant",
+        "status#encrypted as encrypted",
+        "status#working as working",
+        "stats#rops as rops",
+        "stats#wops as wops",
+        "stats#rbps as rbps",
+        "stats#wbps as wbps",
+    ]
+
+    _status_fields = [
+        "$key",
+        "tier",
+        "status",
+        "state",
+        "capacity",
+        "used",
+        "used_pct",
+        "redundant",
+        "encrypted",
+        "working",
+        "last_walk_time_ms",
+        "last_fullwalk_time_ms",
+        "transaction",
+        "repairs",
+        "bad_drives",
+        "fullwalk",
+        "progress",
+        "index_unique",
+        "state_timestamp",
+        "cur_space_throttle_ms",
+        "transaction_start_stamp",
+    ]
+
+    _stats_fields = [
+        "$key",
+        "tier",
+        "rops",
+        "wops",
+        "rbps",
+        "wbps",
+        "reads",
+        "writes",
+        "read_bytes",
+        "write_bytes",
+        "last_update",
+    ]
+
+    _history_short_fields = [
+        "$key",
+        "tier",
+        "timestamp",
+        "rops",
+        "wops",
+        "rbps",
+        "wbps",
+        "reads",
+        "writes",
+        "read_bytes",
+        "write_bytes",
+        "capacity",
+        "used",
+    ]
+
+    _history_long_fields = [
+        "$key",
+        "tier",
+        "timestamp",
+        "rops_peak",
+        "wops_peak",
+        "rbps_peak",
+        "wbps_peak",
+        "rops_avg",
+        "wops_avg",
+        "rbps_avg",
+        "wbps_avg",
+        "reads",
+        "writes",
+        "read_bytes",
+        "write_bytes",
+        "capacity",
+        "used",
+    ]
+
+    def __init__(self, client: VergeClient, cluster_key: int) -> None:
+        super().__init__(client)
+        self._cluster_key = cluster_key
+
+    def _to_model(self, data: dict[str, Any]) -> ClusterTier:
+        return ClusterTier(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        tier: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[ClusterTier]:
+        """List cluster tiers.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            tier: Filter by tier number (0-5).
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of ClusterTier objects.
+
+        Example:
+            >>> # List all tiers for this cluster
+            >>> for tier in cluster.tiers.list():
+            ...     print(f"Tier {tier.tier}: {tier.used_percent}% used")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter scoped to this cluster
+        filters = [f"cluster eq {self._cluster_key}"]
+
+        if filter:
+            filters.append(filter)
+
+        if tier is not None:
+            filters.append(f"tier eq {tier}")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        # Sort by tier number
+        params["sort"] = "tier"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        tier: int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> ClusterTier:
+        """Get a cluster tier by key or tier number.
+
+        Args:
+            key: Tier $key.
+            tier: Tier number (0-5) - alternative to key.
+            fields: List of fields to return.
+
+        Returns:
+            ClusterTier object.
+
+        Raises:
+            NotFoundError: If tier not found.
+            ValueError: If neither key nor tier provided.
+
+        Example:
+            >>> tier1 = cluster.tiers.get(tier=1)
+            >>> print(f"Tier 1: {tier1.used_gb} GB used")
+        """
+        if key is not None:
+            # Get by key
+            if fields is None:
+                fields = self._default_fields
+
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+
+            if response is None:
+                raise NotFoundError(f"Tier {key} not found")
+
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Tier {key} returned invalid response")
+
+            return self._to_model(response)
+
+        if tier is not None:
+            # Search by tier number within this cluster
+            results = self.list(tier=tier, fields=fields)
+            if not results:
+                raise NotFoundError(f"Tier {tier} not found in cluster {self._cluster_key}")
+            return results[0]
+
+        raise ValueError("Either key or tier must be provided")
+
+    def get_tier_status(self, tier_key: int) -> ClusterTierStatus:
+        """Get detailed status for a tier.
+
+        Args:
+            tier_key: Tier $key.
+
+        Returns:
+            ClusterTierStatus object.
+
+        Raises:
+            NotFoundError: If status not found.
+        """
+        params: dict[str, Any] = {
+            "filter": f"tier eq {tier_key}",
+            "fields": ",".join(self._status_fields),
+            "limit": 1,
+        }
+
+        response = self._client._request("GET", "cluster_tier_status", params=params)
+
+        if response is None:
+            raise NotFoundError(f"Status not found for tier {tier_key}")
+
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Status not found for tier {tier_key}")
+            return ClusterTierStatus(response[0], self)
+
+        return ClusterTierStatus(response, self)
+
+    def get_tier_stats(self, tier_key: int) -> ClusterTierStats:
+        """Get current statistics for a tier.
+
+        Args:
+            tier_key: Tier $key.
+
+        Returns:
+            ClusterTierStats object.
+
+        Raises:
+            NotFoundError: If stats not found.
+        """
+        params: dict[str, Any] = {
+            "filter": f"tier eq {tier_key}",
+            "fields": ",".join(self._stats_fields),
+            "limit": 1,
+        }
+
+        response = self._client._request("GET", "cluster_tier_stats", params=params)
+
+        if response is None:
+            raise NotFoundError(f"Stats not found for tier {tier_key}")
+
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Stats not found for tier {tier_key}")
+            return ClusterTierStats(response[0], self)
+
+        return ClusterTierStats(response, self)
+
+    def get_stats_history_short(
+        self,
+        tier_key: int,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+    ) -> builtins.list[ClusterTierStatsHistoryShort]:
+        """Get short-term stats history for a tier.
+
+        Args:
+            tier_key: Tier $key.
+            limit: Maximum number of records.
+            offset: Skip this many records.
+            since: Return records after this time.
+            until: Return records before this time.
+
+        Returns:
+            List of ClusterTierStatsHistoryShort objects.
+        """
+        filters = [f"tier eq {tier_key}"]
+
+        # Convert datetime to epoch if needed
+        if since is not None:
+            since_epoch = int(since.timestamp()) if isinstance(since, datetime) else int(since)
+            filters.append(f"timestamp ge {since_epoch}")
+
+        if until is not None:
+            until_epoch = int(until.timestamp()) if isinstance(until, datetime) else int(until)
+            filters.append(f"timestamp le {until_epoch}")
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(self._history_short_fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", "cluster_tier_stats_history_short", params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [ClusterTierStatsHistoryShort(item, self) for item in response]
+
+        return [ClusterTierStatsHistoryShort(response, self)]
+
+    def get_stats_history_long(
+        self,
+        tier_key: int,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+    ) -> builtins.list[ClusterTierStatsHistoryLong]:
+        """Get long-term stats history for a tier.
+
+        Args:
+            tier_key: Tier $key.
+            limit: Maximum number of records.
+            offset: Skip this many records.
+            since: Return records after this time.
+            until: Return records before this time.
+
+        Returns:
+            List of ClusterTierStatsHistoryLong objects.
+        """
+        filters = [f"tier eq {tier_key}"]
+
+        # Convert datetime to epoch if needed
+        if since is not None:
+            since_epoch = int(since.timestamp()) if isinstance(since, datetime) else int(since)
+            filters.append(f"timestamp ge {since_epoch}")
+
+        if until is not None:
+            until_epoch = int(until.timestamp()) if isinstance(until, datetime) else int(until)
+            filters.append(f"timestamp le {until_epoch}")
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(self._history_long_fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", "cluster_tier_stats_history_long", params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [ClusterTierStatsHistoryLong(item, self) for item in response]
+
+        return [ClusterTierStatsHistoryLong(response, self)]
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get a summary of all tiers in this cluster.
+
+        Returns:
+            Dictionary with aggregate tier information.
+
+        Example:
+            >>> summary = cluster.tiers.get_summary()
+            >>> print(f"Total: {summary['total_capacity_gb']} GB")
+            >>> print(f"Used: {summary['total_used_gb']} GB ({summary['used_percent']}%)")
+        """
+        tiers = self.list()
+
+        total_capacity = sum(t.capacity_bytes for t in tiers)
+        total_used = sum(t.used_bytes for t in tiers)
+        total_free = sum(t.free_bytes for t in tiers)
+
+        return {
+            "cluster_key": self._cluster_key,
+            "tier_count": len(tiers),
+            "total_capacity_bytes": total_capacity,
+            "total_capacity_gb": round(total_capacity / 1073741824, 2),
+            "total_capacity_tb": round(total_capacity / 1099511627776, 2),
+            "total_used_bytes": total_used,
+            "total_used_gb": round(total_used / 1073741824, 2),
+            "total_used_tb": round(total_used / 1099511627776, 2),
+            "total_free_bytes": total_free,
+            "total_free_gb": round(total_free / 1073741824, 2),
+            "total_free_tb": round(total_free / 1099511627776, 2),
+            "used_percent": round((total_used / total_capacity) * 100, 1) if total_capacity else 0,
+            "tiers": {
+                t.tier: {
+                    "status": t.status,
+                    "used_percent": t.used_percent,
+                    "capacity_gb": t.capacity_gb,
+                    "used_gb": t.used_gb,
+                    "free_gb": t.free_gb,
+                    "redundant": t.is_redundant,
+                }
+                for t in tiers
+            },
+        }

--- a/pyvergeos/resources/clusters.py
+++ b/pyvergeos/resources/clusters.py
@@ -12,6 +12,7 @@ from pyvergeos.resources.base import ResourceManager, ResourceObject
 
 if TYPE_CHECKING:
     from pyvergeos.client import VergeClient
+    from pyvergeos.resources.cluster_tiers import ClusterTierManager
 
 
 # Status display mappings
@@ -271,6 +272,22 @@ class Cluster(ResourceObject):
     def running_machines(self) -> int:
         """Number of running VMs."""
         return int(self.get("running_machines") or 0)
+
+    @property
+    def tiers(self) -> ClusterTierManager:
+        """Access tier management for this cluster.
+
+        Returns:
+            ClusterTierManager scoped to this cluster.
+
+        Example:
+            >>> cluster = client.clusters.get(name="Production")
+            >>> for tier in cluster.tiers.list():
+            ...     print(f"Tier {tier.tier}: {tier.used_percent}% used")
+        """
+        from pyvergeos.resources.cluster_tiers import ClusterTierManager
+
+        return ClusterTierManager(self._manager._client, self.key)
 
     def __repr__(self) -> str:
         return (

--- a/tests/integration/test_cluster_tiers.py
+++ b/tests/integration/test_cluster_tiers.py
@@ -1,0 +1,421 @@
+"""Integration tests for cluster tier management.
+
+These tests require a live VergeOS system with storage tiers configured.
+Run with: pytest tests/integration/test_cluster_tiers.py -v
+
+Prerequisites:
+    - At least one cluster with storage tiers configured
+    - Environment variables set (VERGE_HOST, VERGE_USERNAME, VERGE_PASSWORD)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.resources.cluster_tiers import (
+    ClusterTier,
+    ClusterTierManager,
+    ClusterTierStats,
+    ClusterTierStatsHistoryLong,
+    ClusterTierStatsHistoryShort,
+    ClusterTierStatus,
+)
+
+
+@pytest.fixture
+def client() -> VergeClient:
+    """Create a connected VergeClient from environment variables."""
+    import os
+
+    host = os.environ.get("VERGE_HOST")
+    username = os.environ.get("VERGE_USERNAME")
+    password = os.environ.get("VERGE_PASSWORD")
+
+    if not all([host, username, password]):
+        pytest.skip("Live VergeOS credentials not configured")
+
+    return VergeClient(
+        host=host,
+        username=username,
+        password=password,
+        verify_ssl=False,  # Required for self-signed certs
+    )
+
+
+@pytest.fixture
+def cluster_with_tiers(client: VergeClient) -> int | None:
+    """Get a cluster key that has storage tiers."""
+    clusters = client.clusters.list(storage=True)
+    if clusters:
+        return clusters[0].key
+    return None
+
+
+# =============================================================================
+# Cluster Tier List and Get Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTierList:
+    """Integration tests for listing cluster tiers."""
+
+    def test_list_tiers_via_cluster(self, client: VergeClient) -> None:
+        """Test listing tiers via cluster.tiers property."""
+        clusters = client.clusters.list(storage=True)
+        if not clusters:
+            pytest.skip("No storage clusters available")
+
+        cluster = clusters[0]
+        tiers = cluster.tiers.list()
+
+        # Should have at least one tier if storage cluster exists
+        assert isinstance(tiers, list)
+        for tier in tiers:
+            assert isinstance(tier, ClusterTier)
+            assert tier.tier >= 0
+            assert tier.tier <= 5
+            assert tier.cluster_key == cluster.key
+
+    def test_list_tiers_returns_capacity_info(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test that tier list includes capacity information."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        tier = tiers[0]
+        assert tier.capacity_bytes >= 0
+        assert tier.used_bytes >= 0
+        assert tier.capacity_gb >= 0
+        assert tier.used_percent >= 0
+        assert tier.used_percent <= 100
+
+    def test_list_tiers_by_tier_number(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test filtering tiers by tier number."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        all_tiers = cluster.tiers.list()
+
+        if not all_tiers:
+            pytest.skip("No tiers in cluster")
+
+        tier_num = all_tiers[0].tier
+        filtered = cluster.tiers.list(tier=tier_num)
+
+        assert len(filtered) == 1
+        assert filtered[0].tier == tier_num
+
+
+@pytest.mark.integration
+class TestClusterTierGet:
+    """Integration tests for getting specific tiers."""
+
+    def test_get_tier_by_key(self, client: VergeClient, cluster_with_tiers: int | None) -> None:
+        """Test getting tier by key."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        tier = cluster.tiers.get(key=tiers[0].key)
+
+        assert isinstance(tier, ClusterTier)
+        assert tier.key == tiers[0].key
+
+    def test_get_tier_by_tier_number(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test getting tier by tier number."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        tier_num = tiers[0].tier
+        tier = cluster.tiers.get(tier=tier_num)
+
+        assert tier.tier == tier_num
+
+
+# =============================================================================
+# Cluster Tier Status Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTierStatus:
+    """Integration tests for tier status."""
+
+    def test_get_tier_status(self, client: VergeClient, cluster_with_tiers: int | None) -> None:
+        """Test getting tier status."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        status = tiers[0].get_status()
+
+        assert isinstance(status, ClusterTierStatus)
+        assert status.tier_key == tiers[0].key
+        assert status.status_raw in [
+            "online",
+            "offline",
+            "repairing",
+            "initializing",
+            "verifying",
+            "noredundant",
+            "outofspace",
+        ]
+        assert status.state_raw in ["online", "offline", "warning", "error"]
+
+    def test_tier_status_capacity(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test tier status includes capacity info."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        status = tiers[0].get_status()
+
+        assert status.capacity_bytes >= 0
+        assert status.used_bytes >= 0
+        assert status.used_percent >= 0
+
+    def test_tier_status_health_flags(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test tier status health flags."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        status = tiers[0].get_status()
+
+        # These should be boolean
+        assert isinstance(status.is_redundant, bool)
+        assert isinstance(status.is_encrypted, bool)
+        assert isinstance(status.is_working, bool)
+        assert isinstance(status.is_fullwalk, bool)
+        assert isinstance(status.is_throttled, bool)
+
+
+# =============================================================================
+# Cluster Tier Stats Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTierStats:
+    """Integration tests for tier stats."""
+
+    def test_get_tier_stats(self, client: VergeClient, cluster_with_tiers: int | None) -> None:
+        """Test getting tier stats."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        stats = tiers[0].get_stats()
+
+        assert isinstance(stats, ClusterTierStats)
+        assert stats.tier_key == tiers[0].key
+        assert stats.read_ops >= 0
+        assert stats.write_ops >= 0
+        assert stats.read_bps >= 0
+        assert stats.write_bps >= 0
+
+    def test_tier_stats_totals(self, client: VergeClient, cluster_with_tiers: int | None) -> None:
+        """Test tier stats includes total counters."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        stats = tiers[0].get_stats()
+
+        assert stats.total_reads >= 0
+        assert stats.total_writes >= 0
+        assert stats.total_read_bytes >= 0
+        assert stats.total_write_bytes >= 0
+
+
+# =============================================================================
+# Cluster Tier Stats History Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTierStatsHistory:
+    """Integration tests for tier stats history."""
+
+    def test_get_stats_history_short(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test getting short-term stats history."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        history = tiers[0].stats_history_short(limit=10)
+
+        assert isinstance(history, list)
+        for point in history:
+            assert isinstance(point, ClusterTierStatsHistoryShort)
+            assert point.tier_key == tiers[0].key
+            assert point.timestamp is not None
+
+    def test_get_stats_history_long(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test getting long-term stats history."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        history = tiers[0].stats_history_long(limit=10)
+
+        assert isinstance(history, list)
+        for point in history:
+            assert isinstance(point, ClusterTierStatsHistoryLong)
+            assert point.tier_key == tiers[0].key
+
+    def test_stats_history_with_time_filter(
+        self, client: VergeClient, cluster_with_tiers: int | None
+    ) -> None:
+        """Test getting history with time range filter."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        tiers = cluster.tiers.list()
+
+        if not tiers:
+            pytest.skip("No tiers in cluster")
+
+        now = datetime.now(timezone.utc)
+        since = now - timedelta(hours=24)
+
+        history = tiers[0].stats_history_short(since=since, limit=100)
+
+        assert isinstance(history, list)
+        # All returned points should be after 'since'
+        for point in history:
+            if point.timestamp:
+                assert point.timestamp >= since
+
+
+# =============================================================================
+# Cluster Tier Summary Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTierSummary:
+    """Integration tests for tier summary."""
+
+    def test_get_tier_summary(self, client: VergeClient, cluster_with_tiers: int | None) -> None:
+        """Test getting tier summary for a cluster."""
+        if cluster_with_tiers is None:
+            pytest.skip("No storage clusters available")
+
+        cluster = client.clusters.get(key=cluster_with_tiers)
+        summary = cluster.tiers.get_summary()
+
+        assert "cluster_key" in summary
+        assert summary["cluster_key"] == cluster.key
+        assert "tier_count" in summary
+        assert summary["tier_count"] >= 0
+        assert "total_capacity_gb" in summary
+        assert "total_used_gb" in summary
+        assert "used_percent" in summary
+        assert "tiers" in summary
+
+
+# =============================================================================
+# Cluster.tiers Property Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestClusterTiersProperty:
+    """Integration tests for Cluster.tiers property."""
+
+    def test_tiers_property_returns_manager(self, client: VergeClient) -> None:
+        """Test that cluster.tiers returns a ClusterTierManager."""
+        clusters = client.clusters.list(storage=True)
+        if not clusters:
+            pytest.skip("No storage clusters available")
+
+        cluster = clusters[0]
+        tier_manager = cluster.tiers
+
+        assert isinstance(tier_manager, ClusterTierManager)
+        assert tier_manager._cluster_key == cluster.key
+
+    def test_tiers_scoped_to_cluster(self, client: VergeClient) -> None:
+        """Test that tier manager is properly scoped to its cluster."""
+        clusters = client.clusters.list(storage=True)
+        if len(clusters) < 1:
+            pytest.skip("Need at least one storage cluster")
+
+        cluster = clusters[0]
+        tiers = cluster.tiers.list()
+
+        # All tiers should belong to this cluster
+        for tier in tiers:
+            assert tier.cluster_key == cluster.key

--- a/tests/unit/test_cluster_tiers.py
+++ b/tests/unit/test_cluster_tiers.py
@@ -1,0 +1,757 @@
+"""Unit tests for cluster tier management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.cluster_tiers import (
+    ClusterTier,
+    ClusterTierManager,
+    ClusterTierStats,
+    ClusterTierStatsHistoryLong,
+    ClusterTierStatsHistoryShort,
+    ClusterTierStatus,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def tier_manager(mock_client: MagicMock) -> ClusterTierManager:
+    """Create a ClusterTierManager scoped to cluster 1."""
+    return ClusterTierManager(mock_client, cluster_key=1)
+
+
+@pytest.fixture
+def sample_tier_data() -> dict[str, Any]:
+    """Sample tier data as returned from API."""
+    return {
+        "$key": 1,
+        "tier": 1,
+        "cluster": 1,
+        "description": "High Performance SSD",
+        "cost_per_gb": 0.10,
+        "price_per_gb": 0.15,
+        "display_status": "online",
+        "display_state": "online",
+        "capacity": 1099511627776,  # 1 TB
+        "used": 549755813888,  # 512 GB
+        "used_pct": 50,
+        "redundant": True,
+        "encrypted": True,
+        "working": False,
+        "rops": 5000,
+        "wops": 3000,
+        "rbps": 524288000,  # 500 MB/s
+        "wbps": 262144000,  # 250 MB/s
+    }
+
+
+@pytest.fixture
+def sample_status_data() -> dict[str, Any]:
+    """Sample tier status data."""
+    return {
+        "$key": 1,
+        "tier": 1,
+        "status": "online",
+        "state": "online",
+        "capacity": 1099511627776,
+        "used": 549755813888,
+        "used_pct": 50,
+        "redundant": True,
+        "encrypted": True,
+        "working": False,
+        "last_walk_time_ms": 150,
+        "last_fullwalk_time_ms": 5000,
+        "transaction": 12345,
+        "repairs": 2,
+        "bad_drives": 0,
+        "fullwalk": False,
+        "progress": 0,
+        "index_unique": 987654,
+        "state_timestamp": 1706745600,
+        "cur_space_throttle_ms": 0,
+        "transaction_start_stamp": 1706745000,
+    }
+
+
+@pytest.fixture
+def sample_stats_data() -> dict[str, Any]:
+    """Sample tier stats data."""
+    return {
+        "$key": 1,
+        "tier": 1,
+        "rops": 5000,
+        "wops": 3000,
+        "rbps": 524288000,
+        "wbps": 262144000,
+        "reads": 1000000,
+        "writes": 500000,
+        "read_bytes": 1099511627776,
+        "write_bytes": 549755813888,
+        "last_update": 1706745600,
+    }
+
+
+@pytest.fixture
+def sample_history_short_data() -> dict[str, Any]:
+    """Sample short-term history data."""
+    return {
+        "$key": 1,
+        "tier": 1,
+        "timestamp": 1706745600,
+        "rops": 5000,
+        "wops": 3000,
+        "rbps": 524288000,
+        "wbps": 262144000,
+        "reads": 100000,
+        "writes": 50000,
+        "read_bytes": 107374182400,
+        "write_bytes": 53687091200,
+        "capacity": 1099511627776,
+        "used": 549755813888,
+    }
+
+
+@pytest.fixture
+def sample_history_long_data() -> dict[str, Any]:
+    """Sample long-term history data."""
+    return {
+        "$key": 1,
+        "tier": 1,
+        "timestamp": 1706745600,
+        "rops_peak": 10000,
+        "wops_peak": 6000,
+        "rbps_peak": 1048576000,
+        "wbps_peak": 524288000,
+        "rops_avg": 4000,
+        "wops_avg": 2000,
+        "rbps_avg": 419430400,
+        "wbps_avg": 209715200,
+        "reads": 1000000,
+        "writes": 500000,
+        "read_bytes": 1099511627776,
+        "write_bytes": 549755813888,
+        "capacity": 1099511627776,
+        "used": 549755813888,
+    }
+
+
+# =============================================================================
+# ClusterTier Tests
+# =============================================================================
+
+
+class TestClusterTier:
+    """Tests for ClusterTier resource object."""
+
+    def test_tier_properties(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test basic tier properties."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+
+        assert tier.tier == 1
+        assert tier.cluster_key == 1
+        assert tier.description == "High Performance SSD"
+        assert tier.cost_per_gb == 0.10
+        assert tier.price_per_gb == 0.15
+
+    def test_tier_status_properties(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test tier status properties."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+
+        assert tier.status == "Online"
+        assert tier.status_raw == "online"
+
+    def test_tier_capacity_properties(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test tier capacity properties."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+
+        assert tier.capacity_bytes == 1099511627776
+        assert tier.capacity_gb == 1024.0
+        assert tier.capacity_tb == 1.0
+        assert tier.used_bytes == 549755813888
+        assert tier.used_gb == 512.0
+        assert tier.used_tb == 0.5
+        assert tier.used_percent == 50.0
+        assert tier.free_bytes == 549755813888
+        assert tier.free_gb == 512.0
+
+    def test_tier_redundancy_properties(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test tier redundancy and encryption properties."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+
+        assert tier.is_redundant is True
+        assert tier.is_encrypted is True
+        assert tier.is_working is False
+
+    def test_tier_io_properties(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test tier I/O properties."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+
+        assert tier.read_ops == 5000
+        assert tier.write_ops == 3000
+        assert tier.read_bps == 524288000
+        assert tier.write_bps == 262144000
+
+    def test_tier_repr(
+        self, tier_manager: ClusterTierManager, sample_tier_data: dict[str, Any]
+    ) -> None:
+        """Test tier string representation."""
+        tier = ClusterTier(sample_tier_data, tier_manager)
+        repr_str = repr(tier)
+
+        assert "ClusterTier" in repr_str
+        assert "tier=1" in repr_str
+        assert "cluster=1" in repr_str
+
+
+# =============================================================================
+# ClusterTierStatus Tests
+# =============================================================================
+
+
+class TestClusterTierStatus:
+    """Tests for ClusterTierStatus resource object."""
+
+    def test_status_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.tier_key == 1
+        assert status.status == "Online"
+        assert status.status_raw == "online"
+        assert status.state == "Online"
+        assert status.state_raw == "online"
+
+    def test_status_boolean_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status boolean helpers."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.is_online is True
+        assert status.is_healthy is True
+        assert status.is_warning is False
+        assert status.is_error is False
+
+    def test_status_capacity_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status capacity properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.capacity_bytes == 1099511627776
+        assert status.capacity_gb == 1024.0
+        assert status.capacity_tb == 1.0
+        assert status.used_bytes == 549755813888
+        assert status.used_percent == 50.0
+        assert status.free_gb == 512.0
+
+    def test_status_health_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status health properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.is_redundant is True
+        assert status.is_encrypted is True
+        assert status.is_working is False
+        assert status.repairs == 2
+        assert status.bad_drives == 0
+
+    def test_status_walk_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status walk properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.last_walk_time_ms == 150
+        assert status.last_fullwalk_time_ms == 5000
+        assert status.is_fullwalk is False
+        assert status.walk_progress == 0
+
+    def test_status_throttle_properties(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status throttle properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.throttle_ms == 0
+        assert status.is_throttled is False
+
+    def test_status_timestamps(
+        self, tier_manager: ClusterTierManager, sample_status_data: dict[str, Any]
+    ) -> None:
+        """Test status timestamp properties."""
+        status = ClusterTierStatus(sample_status_data, tier_manager)
+
+        assert status.state_timestamp is not None
+        assert isinstance(status.state_timestamp, datetime)
+        assert status.transaction_start is not None
+
+
+# =============================================================================
+# ClusterTierStats Tests
+# =============================================================================
+
+
+class TestClusterTierStats:
+    """Tests for ClusterTierStats resource object."""
+
+    def test_stats_io_properties(
+        self, tier_manager: ClusterTierManager, sample_stats_data: dict[str, Any]
+    ) -> None:
+        """Test stats I/O properties."""
+        stats = ClusterTierStats(sample_stats_data, tier_manager)
+
+        assert stats.tier_key == 1
+        assert stats.read_ops == 5000
+        assert stats.write_ops == 3000
+        assert stats.read_bps == 524288000
+        assert stats.write_bps == 262144000
+        assert stats.read_mbps == 500.0
+        assert stats.write_mbps == 250.0
+
+    def test_stats_totals(
+        self, tier_manager: ClusterTierManager, sample_stats_data: dict[str, Any]
+    ) -> None:
+        """Test stats total counters."""
+        stats = ClusterTierStats(sample_stats_data, tier_manager)
+
+        assert stats.total_reads == 1000000
+        assert stats.total_writes == 500000
+        assert stats.total_read_bytes == 1099511627776
+        assert stats.total_write_bytes == 549755813888
+
+    def test_stats_last_update(
+        self, tier_manager: ClusterTierManager, sample_stats_data: dict[str, Any]
+    ) -> None:
+        """Test stats last update timestamp."""
+        stats = ClusterTierStats(sample_stats_data, tier_manager)
+
+        assert stats.last_update is not None
+        assert isinstance(stats.last_update, datetime)
+
+
+# =============================================================================
+# ClusterTierStatsHistoryShort Tests
+# =============================================================================
+
+
+class TestClusterTierStatsHistoryShort:
+    """Tests for ClusterTierStatsHistoryShort resource object."""
+
+    def test_history_short_properties(
+        self, tier_manager: ClusterTierManager, sample_history_short_data: dict[str, Any]
+    ) -> None:
+        """Test short history properties."""
+        history = ClusterTierStatsHistoryShort(sample_history_short_data, tier_manager)
+
+        assert history.tier_key == 1
+        assert history.timestamp is not None
+        assert history.timestamp_epoch == 1706745600
+        assert history.read_ops == 5000
+        assert history.write_ops == 3000
+        assert history.read_bps == 524288000
+        assert history.write_bps == 262144000
+
+    def test_history_short_capacity(
+        self, tier_manager: ClusterTierManager, sample_history_short_data: dict[str, Any]
+    ) -> None:
+        """Test short history capacity properties."""
+        history = ClusterTierStatsHistoryShort(sample_history_short_data, tier_manager)
+
+        assert history.capacity_bytes == 1099511627776
+        assert history.capacity_gb == 1024.0
+        assert history.used_bytes == 549755813888
+        assert history.used_percent == 50.0
+
+
+# =============================================================================
+# ClusterTierStatsHistoryLong Tests
+# =============================================================================
+
+
+class TestClusterTierStatsHistoryLong:
+    """Tests for ClusterTierStatsHistoryLong resource object."""
+
+    def test_history_long_peak_properties(
+        self, tier_manager: ClusterTierManager, sample_history_long_data: dict[str, Any]
+    ) -> None:
+        """Test long history peak properties."""
+        history = ClusterTierStatsHistoryLong(sample_history_long_data, tier_manager)
+
+        assert history.read_ops_peak == 10000
+        assert history.write_ops_peak == 6000
+        assert history.read_bps_peak == 1048576000
+        assert history.write_bps_peak == 524288000
+
+    def test_history_long_avg_properties(
+        self, tier_manager: ClusterTierManager, sample_history_long_data: dict[str, Any]
+    ) -> None:
+        """Test long history average properties."""
+        history = ClusterTierStatsHistoryLong(sample_history_long_data, tier_manager)
+
+        assert history.read_ops_avg == 4000
+        assert history.write_ops_avg == 2000
+        assert history.read_bps_avg == 419430400
+        assert history.write_bps_avg == 209715200
+
+    def test_history_long_totals(
+        self, tier_manager: ClusterTierManager, sample_history_long_data: dict[str, Any]
+    ) -> None:
+        """Test long history total counters."""
+        history = ClusterTierStatsHistoryLong(sample_history_long_data, tier_manager)
+
+        assert history.total_reads == 1000000
+        assert history.total_writes == 500000
+
+
+# =============================================================================
+# ClusterTierManager Tests
+# =============================================================================
+
+
+class TestClusterTierManager:
+    """Tests for ClusterTierManager."""
+
+    def test_manager_initialization(self, mock_client: MagicMock) -> None:
+        """Test manager initialization with cluster scope."""
+        manager = ClusterTierManager(mock_client, cluster_key=1)
+
+        assert manager._cluster_key == 1
+        assert manager._endpoint == "cluster_tiers"
+
+    def test_list_tiers(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_tier_data: dict[str, Any],
+    ) -> None:
+        """Test listing tiers."""
+        mock_client._request.return_value = [sample_tier_data]
+
+        tiers = tier_manager.list()
+
+        assert len(tiers) == 1
+        assert isinstance(tiers[0], ClusterTier)
+        assert tiers[0].tier == 1
+
+        # Verify filter includes cluster scope
+        call_args = mock_client._request.call_args
+        assert "cluster eq 1" in call_args[1]["params"]["filter"]
+
+    def test_list_tiers_by_tier_number(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_tier_data: dict[str, Any],
+    ) -> None:
+        """Test listing tiers filtered by tier number."""
+        mock_client._request.return_value = [sample_tier_data]
+
+        tiers = tier_manager.list(tier=1)
+
+        assert len(tiers) == 1
+
+        # Verify filter includes tier number
+        call_args = mock_client._request.call_args
+        assert "tier eq 1" in call_args[1]["params"]["filter"]
+
+    def test_list_tiers_empty(
+        self, tier_manager: ClusterTierManager, mock_client: MagicMock
+    ) -> None:
+        """Test listing tiers returns empty list when none exist."""
+        mock_client._request.return_value = None
+
+        tiers = tier_manager.list()
+
+        assert tiers == []
+
+    def test_get_tier_by_key(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_tier_data: dict[str, Any],
+    ) -> None:
+        """Test getting tier by key."""
+        mock_client._request.return_value = sample_tier_data
+
+        tier = tier_manager.get(key=1)
+
+        assert isinstance(tier, ClusterTier)
+        assert tier.key == 1
+        mock_client._request.assert_called_once()
+
+    def test_get_tier_by_tier_number(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_tier_data: dict[str, Any],
+    ) -> None:
+        """Test getting tier by tier number."""
+        mock_client._request.return_value = [sample_tier_data]
+
+        tier = tier_manager.get(tier=1)
+
+        assert isinstance(tier, ClusterTier)
+        assert tier.tier == 1
+
+    def test_get_tier_not_found(
+        self, tier_manager: ClusterTierManager, mock_client: MagicMock
+    ) -> None:
+        """Test getting tier that doesn't exist."""
+        mock_client._request.return_value = None
+
+        with pytest.raises(NotFoundError):
+            tier_manager.get(key=999)
+
+    def test_get_tier_no_args(self, tier_manager: ClusterTierManager) -> None:
+        """Test getting tier without key or tier raises ValueError."""
+        with pytest.raises(ValueError, match="Either key or tier must be provided"):
+            tier_manager.get()
+
+    def test_get_tier_status(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_status_data: dict[str, Any],
+    ) -> None:
+        """Test getting tier status."""
+        mock_client._request.return_value = [sample_status_data]
+
+        status = tier_manager.get_tier_status(tier_key=1)
+
+        assert isinstance(status, ClusterTierStatus)
+        assert status.status == "Online"
+
+        # Verify correct endpoint called
+        call_args = mock_client._request.call_args
+        assert call_args[0][1] == "cluster_tier_status"
+
+    def test_get_tier_stats(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_stats_data: dict[str, Any],
+    ) -> None:
+        """Test getting tier stats."""
+        mock_client._request.return_value = [sample_stats_data]
+
+        stats = tier_manager.get_tier_stats(tier_key=1)
+
+        assert isinstance(stats, ClusterTierStats)
+        assert stats.read_ops == 5000
+
+        # Verify correct endpoint called
+        call_args = mock_client._request.call_args
+        assert call_args[0][1] == "cluster_tier_stats"
+
+    def test_get_stats_history_short(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_history_short_data: dict[str, Any],
+    ) -> None:
+        """Test getting short-term stats history."""
+        mock_client._request.return_value = [sample_history_short_data]
+
+        history = tier_manager.get_stats_history_short(tier_key=1, limit=10)
+
+        assert len(history) == 1
+        assert isinstance(history[0], ClusterTierStatsHistoryShort)
+
+        # Verify correct endpoint called
+        call_args = mock_client._request.call_args
+        assert call_args[0][1] == "cluster_tier_stats_history_short"
+
+    def test_get_stats_history_short_with_time_range(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_history_short_data: dict[str, Any],
+    ) -> None:
+        """Test getting short-term stats history with time range."""
+        mock_client._request.return_value = [sample_history_short_data]
+
+        since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        until = datetime(2024, 1, 31, tzinfo=timezone.utc)
+
+        tier_manager.get_stats_history_short(tier_key=1, since=since, until=until)
+
+        call_args = mock_client._request.call_args
+        filter_str = call_args[1]["params"]["filter"]
+        assert "timestamp ge" in filter_str
+        assert "timestamp le" in filter_str
+
+    def test_get_stats_history_long(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_history_long_data: dict[str, Any],
+    ) -> None:
+        """Test getting long-term stats history."""
+        mock_client._request.return_value = [sample_history_long_data]
+
+        history = tier_manager.get_stats_history_long(tier_key=1, limit=10)
+
+        assert len(history) == 1
+        assert isinstance(history[0], ClusterTierStatsHistoryLong)
+
+        # Verify correct endpoint called
+        call_args = mock_client._request.call_args
+        assert call_args[0][1] == "cluster_tier_stats_history_long"
+
+    def test_get_summary(
+        self,
+        tier_manager: ClusterTierManager,
+        mock_client: MagicMock,
+        sample_tier_data: dict[str, Any],
+    ) -> None:
+        """Test getting tier summary."""
+        mock_client._request.return_value = [sample_tier_data]
+
+        summary = tier_manager.get_summary()
+
+        assert summary["cluster_key"] == 1
+        assert summary["tier_count"] == 1
+        assert summary["total_capacity_gb"] == 1024.0
+        assert summary["total_used_gb"] == 512.0
+        assert summary["used_percent"] == 50.0
+        assert 1 in summary["tiers"]
+
+
+# =============================================================================
+# Cluster.tiers Integration Tests
+# =============================================================================
+
+
+class TestClusterTiersProperty:
+    """Tests for Cluster.tiers property."""
+
+    def test_cluster_tiers_property(self, mock_client: MagicMock) -> None:
+        """Test accessing tiers via cluster object."""
+        from pyvergeos.resources.clusters import Cluster, ClusterManager
+
+        cluster_manager = ClusterManager(mock_client)
+        cluster_data = {"$key": 1, "name": "Test Cluster"}
+        cluster = Cluster(cluster_data, cluster_manager)
+
+        tier_manager = cluster.tiers
+
+        assert isinstance(tier_manager, ClusterTierManager)
+        assert tier_manager._cluster_key == 1
+
+
+# =============================================================================
+# Status Display Mapping Tests
+# =============================================================================
+
+
+class TestStatusDisplayMappings:
+    """Tests for status display string mappings."""
+
+    def test_tier_status_display_online(self, tier_manager: ClusterTierManager) -> None:
+        """Test online status display."""
+        status = ClusterTierStatus({"status": "online", "tier": 1}, tier_manager)
+        assert status.status == "Online"
+
+    def test_tier_status_display_repairing(self, tier_manager: ClusterTierManager) -> None:
+        """Test repairing status display."""
+        status = ClusterTierStatus({"status": "repairing", "tier": 1}, tier_manager)
+        assert status.status == "Repairing"
+
+    def test_tier_status_display_noredundant(self, tier_manager: ClusterTierManager) -> None:
+        """Test no redundancy status display."""
+        status = ClusterTierStatus({"status": "noredundant", "tier": 1}, tier_manager)
+        assert status.status == "Online - No Redundancy"
+
+    def test_tier_status_display_outofspace(self, tier_manager: ClusterTierManager) -> None:
+        """Test out of space status display."""
+        status = ClusterTierStatus({"status": "outofspace", "tier": 1}, tier_manager)
+        assert status.status == "Tier Throttled (Low Space)"
+
+    def test_tier_state_display_warning(self, tier_manager: ClusterTierManager) -> None:
+        """Test warning state display."""
+        status = ClusterTierStatus({"state": "warning", "tier": 1}, tier_manager)
+        assert status.state == "Warning"
+        assert status.is_warning is True
+        assert status.is_healthy is False
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_zero_capacity_tier(self, tier_manager: ClusterTierManager) -> None:
+        """Test tier with zero capacity doesn't cause division by zero."""
+        tier = ClusterTier({"$key": 1, "tier": 1, "capacity": 0, "used": 0}, tier_manager)
+
+        assert tier.used_percent == 0.0
+        assert tier.free_bytes == 0
+
+    def test_missing_optional_fields(self, tier_manager: ClusterTierManager) -> None:
+        """Test tier with missing optional fields uses defaults."""
+        tier = ClusterTier({"$key": 1, "tier": 1}, tier_manager)
+
+        assert tier.description == ""
+        assert tier.cost_per_gb == 0.0
+        assert tier.is_redundant is False
+        assert tier.read_ops == 0
+
+    def test_status_not_found(
+        self, tier_manager: ClusterTierManager, mock_client: MagicMock
+    ) -> None:
+        """Test getting status when none exists raises NotFoundError."""
+        mock_client._request.return_value = []
+
+        with pytest.raises(NotFoundError):
+            tier_manager.get_tier_status(tier_key=999)
+
+    def test_stats_not_found(
+        self, tier_manager: ClusterTierManager, mock_client: MagicMock
+    ) -> None:
+        """Test getting stats when none exist raises NotFoundError."""
+        mock_client._request.return_value = []
+
+        with pytest.raises(NotFoundError):
+            tier_manager.get_tier_stats(tier_key=999)
+
+    def test_history_empty(self, tier_manager: ClusterTierManager, mock_client: MagicMock) -> None:
+        """Test getting history when none exists returns empty list."""
+        mock_client._request.return_value = None
+
+        history = tier_manager.get_stats_history_short(tier_key=1)
+
+        assert history == []


### PR DESCRIPTION
## Summary
- Add comprehensive cluster tier monitoring for storage clusters
- Implement read-only API for tier health, capacity, and performance metrics
- Enable access via `cluster.tiers` property on Cluster objects

## Changes
- **New file:** `pyvergeos/resources/cluster_tiers.py` - Main implementation with:
  - `ClusterTier` - Resource object with capacity/usage info
  - `ClusterTierStatus` - Health monitoring (online/offline, redundancy, encryption)
  - `ClusterTierStats` - I/O performance metrics (read/write ops and throughput)
  - `ClusterTierStatsHistoryShort` - High-resolution historical metrics
  - `ClusterTierStatsHistoryLong` - Long-term historical metrics with peak/avg values
  - `ClusterTierManager` - Scoped manager for per-cluster tier operations
- **Updated:** `pyvergeos/resources/clusters.py` - Added `tiers` property to Cluster
- **Updated:** `pyvergeos/resources/__init__.py` - Added cluster tier exports
- **New file:** `tests/unit/test_cluster_tiers.py` - 46 unit tests
- **New file:** `tests/integration/test_cluster_tiers.py` - 16 integration tests

## Test plan
- [x] All 3015 unit tests pass
- [x] Ruff lint passes
- [x] Mypy type check passes
- [x] Integration tests verified against live VergeOS system