### PR TITLE
✨ feat: add tenant stats & monitoring (3.4)

### DIFF
--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
         TenantRecipeLogManager,
         TenantRecipeManager,
     )
+    from pyvergeos.resources.tenant_stats import TenantDashboardManager
     from pyvergeos.resources.users import UserManager
     from pyvergeos.resources.vm_imports import VmImportLogManager, VmImportManager
     from pyvergeos.resources.vm_recipes import (
@@ -207,6 +208,7 @@ class VergeClient:
         self._catalog_repository_logs: CatalogRepositoryLogManager | None = None
         self._catalog_repository_status: CatalogRepositoryStatusManager | None = None
         self._vgpu_profiles: NvidiaVgpuProfileManager | None = None
+        self._tenant_dashboard: TenantDashboardManager | None = None
 
         if auto_connect:
             self.connect()
@@ -528,6 +530,24 @@ class VergeClient:
 
             self._tenants = TenantManager(self)
         return self._tenants
+
+    @property
+    def tenant_dashboard(self) -> TenantDashboardManager:
+        """Access tenant dashboard with aggregated metrics.
+
+        Provides high-level overview of all tenant status and resource
+        utilization for monitoring and capacity planning.
+
+        Example:
+            >>> dashboard = client.tenant_dashboard.get()
+            >>> print(f"Online: {dashboard.tenants_online}/{dashboard.tenants_count}")
+            >>> print(f"Errors: {dashboard.tenants_error}")
+        """
+        if self._tenant_dashboard is None:
+            from pyvergeos.resources.tenant_stats import TenantDashboardManager
+
+            self._tenant_dashboard = TenantDashboardManager(self)
+        return self._tenant_dashboard
 
     @property
     def users(self) -> UserManager:

--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -132,6 +132,15 @@ from pyvergeos.resources.tenant_recipes import (
     TenantRecipeManager,
 )
 from pyvergeos.resources.tenant_snapshots import TenantSnapshot, TenantSnapshotManager
+from pyvergeos.resources.tenant_stats import (
+    TenantDashboard,
+    TenantDashboardManager,
+    TenantLog,
+    TenantLogManager,
+    TenantStats,
+    TenantStatsHistory,
+    TenantStatsManager,
+)
 from pyvergeos.resources.tenant_storage import TenantStorage, TenantStorageManager
 from pyvergeos.resources.vm_recipes import (
     VmRecipe,
@@ -253,6 +262,13 @@ __all__ = [
     "TenantNetworkBlockManager",
     "TenantSnapshot",
     "TenantSnapshotManager",
+    "TenantStats",
+    "TenantStatsHistory",
+    "TenantStatsManager",
+    "TenantLog",
+    "TenantLogManager",
+    "TenantDashboard",
+    "TenantDashboardManager",
     "TenantStorage",
     "TenantStorageManager",
     "Webhook",

--- a/pyvergeos/resources/tenant_manager.py
+++ b/pyvergeos/resources/tenant_manager.py
@@ -14,6 +14,7 @@ from pyvergeos.resources.tenant_layer2 import TenantLayer2Manager
 from pyvergeos.resources.tenant_network_blocks import TenantNetworkBlockManager
 from pyvergeos.resources.tenant_nodes import TenantNodeManager
 from pyvergeos.resources.tenant_snapshots import TenantSnapshotManager
+from pyvergeos.resources.tenant_stats import TenantLogManager, TenantStatsManager
 from pyvergeos.resources.tenant_storage import TenantStorageManager
 
 if TYPE_CHECKING:
@@ -371,6 +372,49 @@ class Tenant(ResourceObject):
 
         manager = cast("TenantManager", self._manager)
         return manager._client.shared_objects.list(tenant_key=self.key)
+
+    @property
+    def stats(self) -> TenantStatsManager:
+        """Get the stats manager for this tenant.
+
+        Returns:
+            TenantStatsManager for accessing tenant metrics and history.
+
+        Example:
+            >>> tenant = client.tenants.get(name="my-tenant")
+            >>> # Get current stats
+            >>> stats = tenant.stats.get()
+            >>> print(f"RAM: {stats.ram_used_mb}MB")
+            >>> # Get stats history for billing/capacity planning
+            >>> history = tenant.stats.history_short(limit=100)
+            >>> for point in history:
+            ...     print(f"{point.timestamp}: CPU {point.total_cpu}%")
+        """
+        from typing import cast
+
+        manager = cast("TenantManager", self._manager)
+        return TenantStatsManager(manager._client, self)
+
+    @property
+    def logs(self) -> TenantLogManager:
+        """Get the log manager for this tenant.
+
+        Returns:
+            TenantLogManager for accessing tenant-specific logs.
+
+        Example:
+            >>> tenant = client.tenants.get(name="my-tenant")
+            >>> # Get recent logs
+            >>> logs = tenant.logs.list(limit=20)
+            >>> # Get errors only
+            >>> errors = tenant.logs.list(errors_only=True)
+            >>> for log in errors:
+            ...     print(f"[{log.level}] {log.text}")
+        """
+        from typing import cast
+
+        manager = cast("TenantManager", self._manager)
+        return TenantLogManager(manager._client, self)
 
     def set_ui_ip(self, ip: str, network_name: str = "External") -> dict[str, Any] | None:
         """Set the UI IP address for this tenant.

--- a/pyvergeos/resources/tenant_stats.py
+++ b/pyvergeos/resources/tenant_stats.py
@@ -1,0 +1,1008 @@
+"""Tenant Stats & Monitoring resource managers.
+
+This module provides access to tenant performance metrics, status, logs,
+and dashboard information for monitoring and billing/chargeback purposes.
+
+Example:
+    >>> # Access tenant stats
+    >>> tenant = client.tenants.get(name="customer-a")
+    >>> stats = tenant.stats.get()
+    >>> print(f"RAM: {stats.ram_used_mb}MB")
+
+    >>> # Access stats history for billing/capacity planning
+    >>> history = tenant.stats.history_short(limit=100)
+    >>> for point in history:
+    ...     print(f"{point.timestamp}: CPU {point.total_cpu}%, RAM {point.ram_used_mb}MB")
+
+    >>> # Access tenant-specific logs
+    >>> logs = tenant.logs.list(level="error")
+    >>> for log in logs:
+    ...     print(f"[{log.level}] {log.text}")
+
+    >>> # Access dashboard summary
+    >>> dashboard = client.tenant_dashboard.get()
+    >>> print(f"Online: {dashboard.tenants_online}/{dashboard.tenants_count}")
+"""
+
+from __future__ import annotations
+
+import builtins
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Literal
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+    from pyvergeos.resources.tenant_manager import Tenant
+
+
+# Log level display mappings
+LOG_LEVEL_DISPLAY = {
+    "audit": "Audit",
+    "message": "Message",
+    "warning": "Warning",
+    "error": "Error",
+    "critical": "Critical",
+    "summary": "Summary",
+    "debug": "Debug",
+}
+
+
+# =============================================================================
+# Tenant Stats
+# =============================================================================
+
+
+class TenantStats(ResourceObject):
+    """Tenant statistics resource object.
+
+    Provides current performance metrics for a tenant.
+    """
+
+    @property
+    def tenant_key(self) -> int:
+        """Parent tenant key."""
+        return int(self.get("tenant", 0))
+
+    @property
+    def ram_used_mb(self) -> int:
+        """RAM used in MB."""
+        return int(self.get("ram_used", 0))
+
+    @property
+    def last_update(self) -> datetime | None:
+        """Timestamp when stats were last updated."""
+        ts = self.get("last_update")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def __repr__(self) -> str:
+        return f"<TenantStats tenant={self.tenant_key} ram={self.ram_used_mb}MB>"
+
+
+class TenantStatsHistory(ResourceObject):
+    """Tenant statistics history record.
+
+    Represents a single time point in the stats history with comprehensive
+    resource utilization metrics for billing and capacity planning.
+    """
+
+    @property
+    def tenant_key(self) -> int:
+        """Parent tenant key."""
+        return int(self.get("tenant", 0))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp for this history point."""
+        ts = self.get("timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch(self) -> int:
+        """Timestamp as Unix epoch."""
+        return int(self.get("timestamp", 0))
+
+    # CPU metrics
+    @property
+    def total_cpu(self) -> int:
+        """Total CPU usage percentage."""
+        return int(self.get("total_cpu", 0))
+
+    @property
+    def core_count(self) -> int:
+        """Number of allocated CPU cores."""
+        return int(self.get("core_count", 0))
+
+    # RAM metrics
+    @property
+    def ram_used_mb(self) -> int:
+        """Physical RAM used in MB."""
+        return int(self.get("ram_used", 0))
+
+    @property
+    def vram_used_mb(self) -> int:
+        """Virtual RAM used in MB."""
+        return int(self.get("vram_used", 0))
+
+    @property
+    def ram_allocated_mb(self) -> int:
+        """RAM allocated to tenant in MB."""
+        return int(self.get("ram_allocated", 0))
+
+    @property
+    def ram_pct(self) -> int:
+        """RAM usage percentage."""
+        return int(self.get("ram_pct", 0))
+
+    # Network metrics
+    @property
+    def ip_count(self) -> int:
+        """Number of IP addresses assigned."""
+        return int(self.get("ip_count", 0))
+
+    # Storage tier metrics (Tier 0)
+    @property
+    def tier0_provisioned(self) -> int:
+        """Tier 0 storage provisioned in bytes."""
+        return int(self.get("tier0_provisioned", 0))
+
+    @property
+    def tier0_used(self) -> int:
+        """Tier 0 storage used in bytes."""
+        return int(self.get("tier0_used", 0))
+
+    @property
+    def tier0_allocated(self) -> int:
+        """Tier 0 storage allocated in bytes."""
+        return int(self.get("tier0_allocated", 0))
+
+    @property
+    def tier0_pct(self) -> int:
+        """Tier 0 storage usage percentage."""
+        return int(self.get("tier0_pct", 0))
+
+    # Storage tier metrics (Tier 1)
+    @property
+    def tier1_provisioned(self) -> int:
+        """Tier 1 storage provisioned in bytes."""
+        return int(self.get("tier1_provisioned", 0))
+
+    @property
+    def tier1_used(self) -> int:
+        """Tier 1 storage used in bytes."""
+        return int(self.get("tier1_used", 0))
+
+    @property
+    def tier1_allocated(self) -> int:
+        """Tier 1 storage allocated in bytes."""
+        return int(self.get("tier1_allocated", 0))
+
+    @property
+    def tier1_pct(self) -> int:
+        """Tier 1 storage usage percentage."""
+        return int(self.get("tier1_pct", 0))
+
+    # Storage tier metrics (Tier 2)
+    @property
+    def tier2_provisioned(self) -> int:
+        """Tier 2 storage provisioned in bytes."""
+        return int(self.get("tier2_provisioned", 0))
+
+    @property
+    def tier2_used(self) -> int:
+        """Tier 2 storage used in bytes."""
+        return int(self.get("tier2_used", 0))
+
+    @property
+    def tier2_allocated(self) -> int:
+        """Tier 2 storage allocated in bytes."""
+        return int(self.get("tier2_allocated", 0))
+
+    @property
+    def tier2_pct(self) -> int:
+        """Tier 2 storage usage percentage."""
+        return int(self.get("tier2_pct", 0))
+
+    # Storage tier metrics (Tier 3)
+    @property
+    def tier3_provisioned(self) -> int:
+        """Tier 3 storage provisioned in bytes."""
+        return int(self.get("tier3_provisioned", 0))
+
+    @property
+    def tier3_used(self) -> int:
+        """Tier 3 storage used in bytes."""
+        return int(self.get("tier3_used", 0))
+
+    @property
+    def tier3_allocated(self) -> int:
+        """Tier 3 storage allocated in bytes."""
+        return int(self.get("tier3_allocated", 0))
+
+    @property
+    def tier3_pct(self) -> int:
+        """Tier 3 storage usage percentage."""
+        return int(self.get("tier3_pct", 0))
+
+    # Storage tier metrics (Tier 4)
+    @property
+    def tier4_provisioned(self) -> int:
+        """Tier 4 storage provisioned in bytes."""
+        return int(self.get("tier4_provisioned", 0))
+
+    @property
+    def tier4_used(self) -> int:
+        """Tier 4 storage used in bytes."""
+        return int(self.get("tier4_used", 0))
+
+    @property
+    def tier4_allocated(self) -> int:
+        """Tier 4 storage allocated in bytes."""
+        return int(self.get("tier4_allocated", 0))
+
+    @property
+    def tier4_pct(self) -> int:
+        """Tier 4 storage usage percentage."""
+        return int(self.get("tier4_pct", 0))
+
+    # Storage tier metrics (Tier 5)
+    @property
+    def tier5_provisioned(self) -> int:
+        """Tier 5 storage provisioned in bytes."""
+        return int(self.get("tier5_provisioned", 0))
+
+    @property
+    def tier5_used(self) -> int:
+        """Tier 5 storage used in bytes."""
+        return int(self.get("tier5_used", 0))
+
+    @property
+    def tier5_allocated(self) -> int:
+        """Tier 5 storage allocated in bytes."""
+        return int(self.get("tier5_allocated", 0))
+
+    @property
+    def tier5_pct(self) -> int:
+        """Tier 5 storage usage percentage."""
+        return int(self.get("tier5_pct", 0))
+
+    # GPU metrics
+    @property
+    def gpus_used(self) -> int:
+        """Number of physical GPUs in use."""
+        return int(self.get("gpus_used", 0))
+
+    @property
+    def gpus_total(self) -> int:
+        """Total physical GPUs allocated."""
+        return int(self.get("gpus_total", 0))
+
+    @property
+    def gpus_pct(self) -> int:
+        """GPU usage percentage."""
+        return int(self.get("gpus_pct", 0))
+
+    @property
+    def vgpus_used(self) -> int:
+        """Number of vGPUs in use."""
+        return int(self.get("vgpus_used", 0))
+
+    @property
+    def vgpus_total(self) -> int:
+        """Total vGPUs allocated."""
+        return int(self.get("vgpus_total", 0))
+
+    @property
+    def vgpus_pct(self) -> int:
+        """vGPU usage percentage."""
+        return int(self.get("vgpus_pct", 0))
+
+    # Helper methods for storage totals
+    def get_tier_stats(self, tier: int) -> dict[str, int]:
+        """Get stats for a specific storage tier.
+
+        Args:
+            tier: Tier number (0-5).
+
+        Returns:
+            Dict with provisioned, used, allocated, and pct values.
+
+        Raises:
+            ValueError: If tier is not 0-5.
+        """
+        if tier < 0 or tier > 5:
+            raise ValueError("Tier must be 0-5")
+        return {
+            "provisioned": getattr(self, f"tier{tier}_provisioned"),
+            "used": getattr(self, f"tier{tier}_used"),
+            "allocated": getattr(self, f"tier{tier}_allocated"),
+            "pct": getattr(self, f"tier{tier}_pct", 0),
+        }
+
+    @property
+    def total_storage_used(self) -> int:
+        """Total storage used across all tiers in bytes."""
+        return sum(getattr(self, f"tier{i}_used", 0) for i in range(6))
+
+    @property
+    def total_storage_provisioned(self) -> int:
+        """Total storage provisioned across all tiers in bytes."""
+        return sum(getattr(self, f"tier{i}_provisioned", 0) for i in range(6))
+
+    @property
+    def total_storage_allocated(self) -> int:
+        """Total storage allocated across all tiers in bytes."""
+        return sum(getattr(self, f"tier{i}_allocated", 0) for i in range(6))
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        return (
+            f"<TenantStatsHistory ts={ts} cpu={self.total_cpu}% "
+            f"ram={self.ram_used_mb}MB cores={self.core_count}>"
+        )
+
+
+class TenantStatsManager(ResourceManager[TenantStats]):
+    """Manager for tenant statistics.
+
+    Provides access to current and historical performance metrics for a tenant.
+    Scoped to a specific tenant.
+
+    Example:
+        >>> # Get current stats
+        >>> stats = manager.get()
+        >>> print(f"RAM: {stats.ram_used_mb}MB")
+
+        >>> # Get short-term history (high resolution)
+        >>> history = manager.history_short(limit=100)
+
+        >>> # Get long-term history (lower resolution, longer retention)
+        >>> history = manager.history_long(limit=1000)
+    """
+
+    _endpoint = "tenant_stats"
+
+    _default_fields = [
+        "$key",
+        "tenant",
+        "ram_used",
+        "last_update",
+    ]
+
+    _history_fields = [
+        "$key",
+        "tenant",
+        "timestamp",
+        "total_cpu",
+        "core_count",
+        "ram_used",
+        "vram_used",
+        "ram_allocated",
+        "ram_pct",
+        "ip_count",
+        "tier0_provisioned",
+        "tier0_used",
+        "tier0_allocated",
+        "tier0_pct",
+        "tier1_provisioned",
+        "tier1_used",
+        "tier1_allocated",
+        "tier1_pct",
+        "tier2_provisioned",
+        "tier2_used",
+        "tier2_allocated",
+        "tier2_pct",
+        "tier3_provisioned",
+        "tier3_used",
+        "tier3_allocated",
+        "tier3_pct",
+        "tier4_provisioned",
+        "tier4_used",
+        "tier4_allocated",
+        "tier4_pct",
+        "tier5_provisioned",
+        "tier5_used",
+        "tier5_allocated",
+        "tier5_pct",
+        "gpus_used",
+        "gpus_total",
+        "gpus_pct",
+        "vgpus_used",
+        "vgpus_total",
+        "vgpus_pct",
+    ]
+
+    def __init__(self, client: VergeClient, tenant: Tenant) -> None:
+        super().__init__(client)
+        self._tenant = tenant
+        self._tenant_key = tenant.key
+
+    def _to_model(self, data: dict[str, Any]) -> TenantStats:
+        return TenantStats(data, self)
+
+    def _to_history_model(self, data: dict[str, Any]) -> TenantStatsHistory:
+        return TenantStatsHistory(data, self)
+
+    def get(self, fields: builtins.list[str] | None = None) -> TenantStats:  # type: ignore[override]
+        """Get current tenant statistics.
+
+        Args:
+            fields: List of fields to return.
+
+        Returns:
+            TenantStats object.
+
+        Raises:
+            NotFoundError: If stats not found for this tenant.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        params: dict[str, Any] = {
+            "filter": f"tenant eq {self._tenant_key}",
+            "fields": ",".join(fields),
+            "limit": 1,
+        }
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            raise NotFoundError(f"Stats not found for tenant {self._tenant_key}")
+
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Stats not found for tenant {self._tenant_key}")
+            return self._to_model(response[0])
+
+        return self._to_model(response)
+
+    def history_short(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[TenantStatsHistory]:
+        """Get short-term stats history (high resolution).
+
+        Args:
+            limit: Maximum number of records to return.
+            offset: Skip this many records.
+            since: Return records after this time (datetime or epoch).
+            until: Return records before this time (datetime or epoch).
+            fields: List of fields to return.
+
+        Returns:
+            List of TenantStatsHistory objects, sorted by timestamp descending.
+        """
+        return self._get_history(
+            "tenant_stats_history_short",
+            limit=limit,
+            offset=offset,
+            since=since,
+            until=until,
+            fields=fields,
+        )
+
+    def history_long(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[TenantStatsHistory]:
+        """Get long-term stats history (lower resolution, longer retention).
+
+        Args:
+            limit: Maximum number of records to return.
+            offset: Skip this many records.
+            since: Return records after this time (datetime or epoch).
+            until: Return records before this time (datetime or epoch).
+            fields: List of fields to return.
+
+        Returns:
+            List of TenantStatsHistory objects, sorted by timestamp descending.
+        """
+        return self._get_history(
+            "tenant_stats_history_long",
+            limit=limit,
+            offset=offset,
+            since=since,
+            until=until,
+            fields=fields,
+        )
+
+    def _get_history(
+        self,
+        endpoint: str,
+        limit: int | None = None,
+        offset: int | None = None,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> builtins.list[TenantStatsHistory]:
+        """Internal helper to get history from short or long endpoint."""
+        if fields is None:
+            fields = self._history_fields
+
+        filters = [f"tenant eq {self._tenant_key}"]
+
+        # Convert datetime to epoch if needed
+        if since is not None:
+            since_epoch = int(since.timestamp()) if isinstance(since, datetime) else int(since)
+            filters.append(f"timestamp ge {since_epoch}")
+
+        if until is not None:
+            until_epoch = int(until.timestamp()) if isinstance(until, datetime) else int(until)
+            filters.append(f"timestamp le {until_epoch}")
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [self._to_history_model(item) for item in response]
+
+        return [self._to_history_model(response)]
+
+
+# =============================================================================
+# Tenant Logs
+# =============================================================================
+
+
+class TenantLog(ResourceObject):
+    """Tenant log entry resource object."""
+
+    @property
+    def tenant_key(self) -> int:
+        """Parent tenant key."""
+        return int(self.get("tenant", 0))
+
+    @property
+    def tenant_name(self) -> str:
+        """Parent tenant name."""
+        return str(self.get("tenant_name", ""))
+
+    @property
+    def level(self) -> str:
+        """Log level (Audit, Message, Warning, Error, Critical)."""
+        raw = str(self.get("level", "message"))
+        return LOG_LEVEL_DISPLAY.get(raw, raw)
+
+    @property
+    def level_raw(self) -> str:
+        """Raw log level value."""
+        return str(self.get("level", "message"))
+
+    @property
+    def text(self) -> str:
+        """Log message text."""
+        return str(self.get("text", ""))
+
+    @property
+    def user(self) -> str:
+        """User who generated the log entry."""
+        return str(self.get("user", ""))
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Timestamp of log entry (microseconds precision)."""
+        ts = self.get("timestamp")
+        if ts:
+            # timestamp is in microseconds
+            return datetime.fromtimestamp(int(ts) / 1_000_000, tz=timezone.utc)
+        return None
+
+    @property
+    def timestamp_epoch_us(self) -> int:
+        """Timestamp as Unix epoch in microseconds."""
+        return int(self.get("timestamp", 0))
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error or critical log."""
+        return self.level_raw in ("error", "critical")
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning log."""
+        return self.level_raw == "warning"
+
+    @property
+    def is_audit(self) -> bool:
+        """Check if this is an audit log."""
+        return self.level_raw == "audit"
+
+    def __repr__(self) -> str:
+        ts = self.timestamp.isoformat() if self.timestamp else "?"
+        text_preview = self.text[:40] + "..." if len(self.text) > 40 else self.text
+        return f"<TenantLog [{self.level}] {ts}: {text_preview!r}>"
+
+
+class TenantLogManager(ResourceManager[TenantLog]):
+    """Manager for tenant logs.
+
+    Provides access to log entries for a tenant.
+    Scoped to a specific tenant.
+
+    Example:
+        >>> # Get recent logs
+        >>> logs = manager.list(limit=20)
+
+        >>> # Get errors only
+        >>> errors = manager.list(level="error")
+
+        >>> # Get logs since a specific time
+        >>> logs = manager.list(since=datetime.now() - timedelta(hours=1))
+    """
+
+    _endpoint = "tenant_logs"
+
+    _default_fields = [
+        "$key",
+        "tenant",
+        "tenant#name as tenant_name",
+        "level",
+        "text",
+        "user",
+        "timestamp",
+    ]
+
+    def __init__(self, client: VergeClient, tenant: Tenant) -> None:
+        super().__init__(client)
+        self._tenant = tenant
+        self._tenant_key = tenant.key
+
+    def _to_model(self, data: dict[str, Any]) -> TenantLog:
+        return TenantLog(data, self)
+
+    def list(
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        level: Literal["audit", "message", "warning", "error", "critical", "summary", "debug"]
+        | None = None,
+        errors_only: bool = False,
+        warnings_only: bool = False,
+        since: datetime | int | None = None,
+        until: datetime | int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[TenantLog]:
+        """List tenant log entries.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            level: Filter by log level.
+            errors_only: Only return error and critical logs.
+            warnings_only: Only return warning logs.
+            since: Return logs after this time (datetime or epoch microseconds).
+            until: Return logs before this time (datetime or epoch microseconds).
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of TenantLog objects, sorted by timestamp descending.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        filters = [f"tenant eq {self._tenant_key}"]
+
+        if filter:
+            filters.append(filter)
+
+        if level is not None:
+            filters.append(f"level eq '{level}'")
+        elif errors_only:
+            filters.append("(level eq 'error' or level eq 'critical')")
+        elif warnings_only:
+            filters.append("level eq 'warning'")
+
+        # Convert datetime to microseconds if needed
+        if since is not None:
+            if isinstance(since, datetime):
+                since_us = int(since.timestamp() * 1_000_000)
+            else:
+                since_us = int(since)
+            filters.append(f"timestamp ge {since_us}")
+
+        if until is not None:
+            if isinstance(until, datetime):
+                until_us = int(until.timestamp() * 1_000_000)
+            else:
+                until_us = int(until)
+            filters.append(f"timestamp le {until_us}")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        params: dict[str, Any] = {
+            "filter": " and ".join(filters),
+            "fields": ",".join(fields),
+            "sort": "-timestamp",
+        }
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if isinstance(response, list):
+            return [self._to_model(item) for item in response]
+
+        return [self._to_model(response)]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> TenantLog:
+        """Get a specific log entry by key.
+
+        Args:
+            key: Log entry $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            TenantLog object.
+
+        Raises:
+            NotFoundError: If log entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("key must be provided")
+
+        if fields is None:
+            fields = self._default_fields
+
+        params: dict[str, Any] = {"fields": ",".join(fields)}
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+
+        if response is None:
+            raise NotFoundError(f"Log entry {key} not found")
+
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Log entry {key} returned invalid response")
+
+        return self._to_model(response)
+
+
+# =============================================================================
+# Tenant Dashboard
+# =============================================================================
+
+
+class TenantDashboard(ResourceObject):
+    """Tenant dashboard with aggregated metrics.
+
+    Provides a high-level overview of tenant status and resource utilization
+    across all tenants in the system.
+    """
+
+    # Tenant counts
+    @property
+    def tenants_count(self) -> int:
+        """Total number of tenants."""
+        return int(self.get("tenants_count", 0))
+
+    @property
+    def tenants_online(self) -> int:
+        """Number of online tenants."""
+        return int(self.get("tenants_online", 0))
+
+    @property
+    def tenants_warn(self) -> int:
+        """Number of tenants in warning state."""
+        return int(self.get("tenants_warn", 0))
+
+    @property
+    def tenants_error(self) -> int:
+        """Number of tenants in error state."""
+        return int(self.get("tenants_error", 0))
+
+    @property
+    def tenants_offline(self) -> int:
+        """Number of offline tenants."""
+        return self.tenants_count - self.tenants_online
+
+    # Storage counts
+    @property
+    def storage_count(self) -> int:
+        """Number of tenant storage allocations."""
+        return int(self.get("storage_count", 0))
+
+    # Snapshot counts
+    @property
+    def snapshots_count(self) -> int:
+        """Number of tenant snapshots."""
+        return int(self.get("snapshots_count", 0))
+
+    @property
+    def cloud_snapshots_count(self) -> int:
+        """Number of cloud snapshots."""
+        return int(self.get("cloud_snapshots_count", 0))
+
+    # Node counts
+    @property
+    def nodes_count(self) -> int:
+        """Total number of tenant nodes."""
+        return int(self.get("nodes_count", 0))
+
+    @property
+    def nodes_online(self) -> int:
+        """Number of online tenant nodes."""
+        return int(self.get("nodes_online", 0))
+
+    @property
+    def nodes_warn(self) -> int:
+        """Number of tenant nodes in warning state."""
+        return int(self.get("nodes_warn", 0))
+
+    @property
+    def nodes_error(self) -> int:
+        """Number of tenant nodes in error state."""
+        return int(self.get("nodes_error", 0))
+
+    # Recipe counts
+    @property
+    def tenant_recipes_count(self) -> int:
+        """Total number of tenant recipes."""
+        return int(self.get("tenant_recipes_count", 0))
+
+    @property
+    def tenant_recipes_online(self) -> int:
+        """Number of online tenant recipes."""
+        return int(self.get("tenant_recipes_online", 0))
+
+    @property
+    def tenant_recipes_warn(self) -> int:
+        """Number of tenant recipes in warning state."""
+        return int(self.get("tenant_recipes_warn", 0))
+
+    @property
+    def tenant_recipes_error(self) -> int:
+        """Number of tenant recipes in error state."""
+        return int(self.get("tenant_recipes_error", 0))
+
+    # Device counts
+    @property
+    def devices_count(self) -> int:
+        """Total number of tenant devices."""
+        return int(self.get("devices_count", 0))
+
+    @property
+    def devices_online(self) -> int:
+        """Number of online tenant devices."""
+        return int(self.get("devices_online", 0))
+
+    @property
+    def devices_warn(self) -> int:
+        """Number of tenant devices in warning state."""
+        return int(self.get("devices_warn", 0))
+
+    @property
+    def devices_error(self) -> int:
+        """Number of tenant devices in error state."""
+        return int(self.get("devices_error", 0))
+
+    # Top resource consumers (raw data access)
+    @property
+    def running_tenants_cores(self) -> builtins.list[dict[str, Any]]:
+        """Top running tenants by CPU cores."""
+        data = self.get("running_tenants_cores")
+        return data if isinstance(data, list) else []
+
+    @property
+    def tenant_storage(self) -> builtins.list[dict[str, Any]]:
+        """Top tenant storage by usage."""
+        data = self.get("tenant_storage")
+        return data if isinstance(data, list) else []
+
+    @property
+    def running_nodes_cpu(self) -> builtins.list[dict[str, Any]]:
+        """Top tenant nodes by CPU usage."""
+        data = self.get("running_nodes_cpu")
+        return data if isinstance(data, list) else []
+
+    @property
+    def running_nodes_ram(self) -> builtins.list[dict[str, Any]]:
+        """Top tenant nodes by RAM usage."""
+        data = self.get("running_nodes_ram")
+        return data if isinstance(data, list) else []
+
+    @property
+    def running_nodes_nic(self) -> builtins.list[dict[str, Any]]:
+        """Top tenant nodes by network bandwidth."""
+        data = self.get("running_nodes_nic")
+        return data if isinstance(data, list) else []
+
+    @property
+    def logs(self) -> builtins.list[dict[str, Any]]:
+        """Recent tenant-related logs."""
+        data = self.get("logs")
+        return data if isinstance(data, list) else []
+
+    @property
+    def tenant_snapshots(self) -> builtins.list[dict[str, Any]]:
+        """Tenant snapshot information."""
+        data = self.get("tenant_snapshots")
+        return data if isinstance(data, list) else []
+
+    def __repr__(self) -> str:
+        return (
+            f"<TenantDashboard tenants={self.tenants_online}/{self.tenants_count} "
+            f"nodes={self.nodes_online}/{self.nodes_count}>"
+        )
+
+
+class TenantDashboardManager(ResourceManager[TenantDashboard]):
+    """Manager for tenant dashboard.
+
+    Provides aggregated tenant metrics and status counts.
+
+    Example:
+        >>> dashboard = client.tenant_dashboard.get()
+        >>> print(f"Online: {dashboard.tenants_online}/{dashboard.tenants_count}")
+        >>> print(f"Errors: {dashboard.tenants_error}")
+    """
+
+    _endpoint = "tenant_dashboard"
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def _to_model(self, data: dict[str, Any]) -> TenantDashboard:
+        return TenantDashboard(data, self)
+
+    def get(self) -> TenantDashboard:  # type: ignore[override]
+        """Get tenant dashboard.
+
+        Returns:
+            TenantDashboard object with aggregated metrics.
+        """
+        response = self._client._request("GET", self._endpoint)
+
+        if response is None:
+            return self._to_model({})
+
+        if isinstance(response, list) and response:
+            return self._to_model(response[0])
+
+        if isinstance(response, dict):
+            return self._to_model(response)
+
+        return self._to_model({})

--- a/tests/integration/test_tenant_stats.py
+++ b/tests/integration/test_tenant_stats.py
@@ -1,0 +1,351 @@
+"""Integration tests for tenant stats and monitoring."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.resources.tenant_stats import (
+    TenantDashboard,
+    TenantLog,
+    TenantStats,
+    TenantStatsHistory,
+)
+
+
+@pytest.mark.integration
+class TestTenantStats:
+    """Integration tests for TenantStats."""
+
+    @pytest.fixture
+    def test_tenant(self, live_client: VergeClient):
+        """Get a tenant for testing, or skip if not available."""
+        tenants = live_client.tenants.list(limit=1)
+        if not tenants:
+            pytest.skip("No tenants available")
+        return tenants[0]
+
+    def test_get_tenant_stats(self, live_client: VergeClient, test_tenant) -> None:
+        """Test getting current tenant stats."""
+        stats = test_tenant.stats.get()
+
+        assert isinstance(stats, TenantStats)
+        assert stats.tenant_key == test_tenant.key
+
+        # Check RAM metrics
+        assert isinstance(stats.ram_used_mb, int)
+        assert stats.ram_used_mb >= 0
+
+        # Check last update
+        if stats.last_update:
+            assert isinstance(stats.last_update, datetime)
+
+    def test_get_tenant_stats_fields(self, live_client: VergeClient, test_tenant) -> None:
+        """Test getting tenant stats with specific fields."""
+        stats = test_tenant.stats.get(fields=["$key", "tenant", "ram_used"])
+
+        assert stats.tenant_key == test_tenant.key
+        assert isinstance(stats.ram_used_mb, int)
+
+    def test_tenant_stats_history_short(self, live_client: VergeClient, test_tenant) -> None:
+        """Test getting short-term stats history."""
+        history = test_tenant.stats.history_short(limit=10)
+
+        assert isinstance(history, list)
+        # History might be empty for inactive tenants
+        if history:
+            assert all(isinstance(h, TenantStatsHistory) for h in history)
+
+            # Check first record
+            record = history[0]
+            assert record.tenant_key == test_tenant.key
+            assert record.timestamp is not None
+            assert isinstance(record.timestamp, datetime)
+            assert isinstance(record.total_cpu, int)
+            assert isinstance(record.ram_used_mb, int)
+
+    def test_tenant_stats_history_long(self, live_client: VergeClient, test_tenant) -> None:
+        """Test getting long-term stats history."""
+        history = test_tenant.stats.history_long(limit=10)
+
+        assert isinstance(history, list)
+        if history:
+            assert all(isinstance(h, TenantStatsHistory) for h in history)
+
+            record = history[0]
+            assert record.tenant_key == test_tenant.key
+            assert record.timestamp is not None
+
+    def test_tenant_stats_history_since(self, live_client: VergeClient, test_tenant) -> None:
+        """Test getting stats history since a specific time."""
+        since = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        history = test_tenant.stats.history_short(limit=10, since=since)
+
+        assert isinstance(history, list)
+        # All records should be after 'since'
+        for record in history:
+            if record.timestamp:
+                assert record.timestamp >= since
+
+    def test_tenant_stats_storage_tiers(self, live_client: VergeClient, test_tenant) -> None:
+        """Test accessing storage tier stats."""
+        history = test_tenant.stats.history_short(limit=1)
+
+        if not history:
+            pytest.skip("No stats history available for tenant")
+
+        record = history[0]
+
+        # Test get_tier_stats helper for all tiers
+        for tier in range(6):
+            tier_stats = record.get_tier_stats(tier)
+            assert "provisioned" in tier_stats
+            assert "used" in tier_stats
+            assert "allocated" in tier_stats
+            assert "pct" in tier_stats
+
+            # All should be non-negative integers
+            assert tier_stats["provisioned"] >= 0
+            assert tier_stats["used"] >= 0
+            assert tier_stats["allocated"] >= 0
+            assert tier_stats["pct"] >= 0
+
+    def test_tenant_stats_total_storage(self, live_client: VergeClient, test_tenant) -> None:
+        """Test total storage calculation."""
+        history = test_tenant.stats.history_short(limit=1)
+
+        if not history:
+            pytest.skip("No stats history available for tenant")
+
+        record = history[0]
+        total_used = record.total_storage_used
+
+        # Should be the sum of all tier used values
+        expected = sum(getattr(record, f"tier{i}_used") for i in range(6))
+        assert total_used == expected
+
+
+@pytest.mark.integration
+class TestTenantLogs:
+    """Integration tests for TenantLog."""
+
+    @pytest.fixture
+    def test_tenant(self, live_client: VergeClient):
+        """Get a tenant for testing, or skip if not available."""
+        tenants = live_client.tenants.list(limit=1)
+        if not tenants:
+            pytest.skip("No tenants available")
+        return tenants[0]
+
+    def test_list_tenant_logs(self, live_client: VergeClient, test_tenant) -> None:
+        """Test listing tenant logs."""
+        logs = test_tenant.logs.list(limit=10)
+
+        assert isinstance(logs, list)
+        if logs:
+            assert all(isinstance(log, TenantLog) for log in logs)
+
+            # Check first log
+            log = logs[0]
+            assert log.tenant_key == test_tenant.key
+            assert isinstance(log.level, str)
+            assert isinstance(log.text, str)
+
+    def test_list_tenant_logs_with_level_filter(
+        self, live_client: VergeClient, test_tenant
+    ) -> None:
+        """Test listing tenant logs filtered by level."""
+        # Test message level
+        logs = test_tenant.logs.list(limit=5, level="message")
+        assert isinstance(logs, list)
+        for log in logs:
+            assert log.level_raw == "message"
+
+    def test_list_tenant_logs_errors_only(self, live_client: VergeClient, test_tenant) -> None:
+        """Test listing only error logs."""
+        logs = test_tenant.logs.list(limit=10, errors_only=True)
+
+        assert isinstance(logs, list)
+        for log in logs:
+            assert log.level_raw in ("error", "critical")
+            assert log.is_error is True
+
+    def test_list_tenant_logs_since(self, live_client: VergeClient, test_tenant) -> None:
+        """Test listing logs since a specific time."""
+        since = datetime.now(tz=timezone.utc) - timedelta(days=1)
+        logs = test_tenant.logs.list(limit=10, since=since)
+
+        assert isinstance(logs, list)
+        for log in logs:
+            if log.timestamp:
+                assert log.timestamp >= since
+
+    def test_tenant_log_properties(self, live_client: VergeClient, test_tenant) -> None:
+        """Test tenant log property accessors."""
+        logs = test_tenant.logs.list(limit=1)
+        if not logs:
+            pytest.skip("No logs available for test tenant")
+
+        log = logs[0]
+
+        # Test timestamp
+        assert log.timestamp is not None
+        assert isinstance(log.timestamp, datetime)
+
+        # Test level display vs raw
+        assert isinstance(log.level, str)
+        assert isinstance(log.level_raw, str)
+
+        # Test text
+        assert isinstance(log.text, str)
+
+        # Test boolean helpers
+        assert isinstance(log.is_error, bool)
+        assert isinstance(log.is_warning, bool)
+        assert isinstance(log.is_audit, bool)
+
+
+@pytest.mark.integration
+class TestTenantDashboard:
+    """Integration tests for TenantDashboard."""
+
+    def test_get_tenant_dashboard(self, live_client: VergeClient) -> None:
+        """Test getting tenant dashboard."""
+        dashboard = live_client.tenant_dashboard.get()
+
+        assert isinstance(dashboard, TenantDashboard)
+
+        # Check tenant counts
+        assert isinstance(dashboard.tenants_count, int)
+        assert dashboard.tenants_count >= 0
+        assert isinstance(dashboard.tenants_online, int)
+        assert dashboard.tenants_online >= 0
+        assert isinstance(dashboard.tenants_offline, int)
+        assert dashboard.tenants_offline >= 0
+
+        # Online + offline should not exceed total
+        assert dashboard.tenants_online + dashboard.tenants_offline <= dashboard.tenants_count
+
+    def test_tenant_dashboard_resource_counts(self, live_client: VergeClient) -> None:
+        """Test tenant dashboard resource counts."""
+        dashboard = live_client.tenant_dashboard.get()
+
+        # Check node and storage counts
+        assert isinstance(dashboard.nodes_count, int)
+        assert dashboard.nodes_count >= 0
+        assert isinstance(dashboard.storage_count, int)
+        assert dashboard.storage_count >= 0
+        assert isinstance(dashboard.snapshots_count, int)
+        assert dashboard.snapshots_count >= 0
+
+    def test_tenant_dashboard_top_consumers(self, live_client: VergeClient) -> None:
+        """Test tenant dashboard top consumers."""
+        dashboard = live_client.tenant_dashboard.get()
+
+        # running_tenants_cores should be a list
+        top_tenants = dashboard.running_tenants_cores
+        assert isinstance(top_tenants, list)
+
+        # running_nodes_cpu should be a list
+        top_cpu = dashboard.running_nodes_cpu
+        assert isinstance(top_cpu, list)
+
+        # running_nodes_ram should be a list
+        top_ram = dashboard.running_nodes_ram
+        assert isinstance(top_ram, list)
+
+        # tenant_storage should be a list
+        top_storage = dashboard.tenant_storage
+        assert isinstance(top_storage, list)
+
+    def test_tenant_dashboard_repr(self, live_client: VergeClient) -> None:
+        """Test dashboard repr."""
+        dashboard = live_client.tenant_dashboard.get()
+
+        # Repr should include tenant and node counts
+        repr_str = repr(dashboard)
+        assert "TenantDashboard" in repr_str
+        assert "tenants=" in repr_str
+        assert "nodes=" in repr_str
+
+
+@pytest.mark.integration
+class TestTenantStatsManagerScoping:
+    """Integration tests for TenantStatsManager scoping."""
+
+    def test_stats_manager_scoping(self, live_client: VergeClient) -> None:
+        """Test that stats managers are properly scoped to their tenant."""
+        tenants = live_client.tenants.list(limit=2)
+        if len(tenants) < 2:
+            pytest.skip("Need at least 2 tenants for this test")
+
+        tenant1, tenant2 = tenants[0], tenants[1]
+
+        # Get stats for each tenant
+        stats1 = tenant1.stats.get()
+        stats2 = tenant2.stats.get()
+
+        # Verify they are for different tenants
+        assert stats1.tenant_key == tenant1.key
+        assert stats2.tenant_key == tenant2.key
+
+        if tenant1.key != tenant2.key:
+            # The stats should be for different tenants
+            assert stats1.tenant_key != stats2.tenant_key
+
+    def test_logs_manager_scoping(self, live_client: VergeClient) -> None:
+        """Test that log managers are properly scoped to their tenant."""
+        tenants = live_client.tenants.list(limit=2)
+        if len(tenants) < 2:
+            pytest.skip("Need at least 2 tenants for this test")
+
+        tenant1, tenant2 = tenants[0], tenants[1]
+
+        # Get logs for each tenant
+        logs1 = tenant1.logs.list(limit=5)
+        logs2 = tenant2.logs.list(limit=5)
+
+        # Logs should be scoped to their respective tenants
+        for log in logs1:
+            assert log.tenant_key == tenant1.key
+
+        for log in logs2:
+            assert log.tenant_key == tenant2.key
+
+    def test_stats_manager_from_tenant_property(self, live_client: VergeClient) -> None:
+        """Test accessing stats manager via tenant.stats property."""
+        tenants = live_client.tenants.list(limit=1)
+        if not tenants:
+            pytest.skip("No tenants available")
+
+        tenant = tenants[0]
+
+        # Access stats property
+        stats_manager = tenant.stats
+
+        # Get stats using the manager
+        stats = stats_manager.get()
+        assert stats.tenant_key == tenant.key
+
+        # Get history
+        history = stats_manager.history_short(limit=5)
+        assert isinstance(history, list)
+        for record in history:
+            assert record.tenant_key == tenant.key
+
+    def test_logs_manager_from_tenant_property(self, live_client: VergeClient) -> None:
+        """Test accessing logs manager via tenant.logs property."""
+        tenants = live_client.tenants.list(limit=1)
+        if not tenants:
+            pytest.skip("No tenants available")
+
+        tenant = tenants[0]
+
+        # Access logs property
+        logs_manager = tenant.logs
+
+        # Get logs using the manager
+        logs = logs_manager.list(limit=5)
+        assert isinstance(logs, list)
+        for log in logs:
+            assert log.tenant_key == tenant.key

--- a/tests/unit/test_tenant_stats.py
+++ b/tests/unit/test_tenant_stats.py
@@ -1,0 +1,834 @@
+"""Unit tests for tenant stats and monitoring managers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.tenant_stats import (
+    TenantDashboard,
+    TenantDashboardManager,
+    TenantLog,
+    TenantLogManager,
+    TenantStats,
+    TenantStatsHistory,
+    TenantStatsManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def mock_tenant() -> MagicMock:
+    """Create a mock Tenant object."""
+    tenant = MagicMock()
+    tenant.key = 123
+    tenant.name = "test-tenant"
+    return tenant
+
+
+# =============================================================================
+# Sample Data Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_stats_data() -> dict[str, Any]:
+    """Sample tenant stats data from API."""
+    return {
+        "$key": 1,
+        "tenant": 123,
+        "ram_used": 8192,
+        "last_update": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_stats_history_data() -> dict[str, Any]:
+    """Sample tenant stats history data from API."""
+    return {
+        "$key": 1,
+        "tenant": 123,
+        "timestamp": 1704067200,
+        "total_cpu": 45,
+        "core_count": 8,
+        "ram_used": 8192,
+        "vram_used": 4096,
+        "ram_allocated": 16384,
+        "ram_pct": 50,
+        "ip_count": 5,
+        "tier0_provisioned": 107374182400,  # 100GB
+        "tier0_used": 53687091200,  # 50GB
+        "tier0_allocated": 107374182400,
+        "tier0_pct": 50,
+        "tier1_provisioned": 0,
+        "tier1_used": 0,
+        "tier1_allocated": 0,
+        "tier1_pct": 0,
+        "tier2_provisioned": 0,
+        "tier2_used": 0,
+        "tier2_allocated": 0,
+        "tier2_pct": 0,
+        "tier3_provisioned": 0,
+        "tier3_used": 0,
+        "tier3_allocated": 0,
+        "tier3_pct": 0,
+        "tier4_provisioned": 0,
+        "tier4_used": 0,
+        "tier4_allocated": 0,
+        "tier4_pct": 0,
+        "tier5_provisioned": 0,
+        "tier5_used": 0,
+        "tier5_allocated": 0,
+        "tier5_pct": 0,
+        "gpus_used": 1,
+        "gpus_total": 2,
+        "gpus_pct": 50,
+        "vgpus_used": 2,
+        "vgpus_total": 4,
+        "vgpus_pct": 50,
+    }
+
+
+@pytest.fixture
+def sample_log_data() -> dict[str, Any]:
+    """Sample tenant log data from API."""
+    return {
+        "$key": 1,
+        "tenant": 123,
+        "tenant_name": "test-tenant",
+        "level": "message",
+        "text": "Tenant powered on successfully",
+        "user": "admin",
+        "timestamp": 1704067200000000,  # microseconds
+    }
+
+
+@pytest.fixture
+def sample_log_list() -> list[dict[str, Any]]:
+    """Sample list of tenant logs."""
+    return [
+        {
+            "$key": 1,
+            "tenant": 123,
+            "tenant_name": "test-tenant",
+            "level": "message",
+            "text": "Tenant powered on successfully",
+            "user": "admin",
+            "timestamp": 1704067200000000,
+        },
+        {
+            "$key": 2,
+            "tenant": 123,
+            "tenant_name": "test-tenant",
+            "level": "error",
+            "text": "Storage allocation failed",
+            "user": "system",
+            "timestamp": 1704067201000000,
+        },
+        {
+            "$key": 3,
+            "tenant": 123,
+            "tenant_name": "test-tenant",
+            "level": "warning",
+            "text": "High resource usage detected",
+            "user": "system",
+            "timestamp": 1704067202000000,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_dashboard_data() -> dict[str, Any]:
+    """Sample tenant dashboard data from API."""
+    return {
+        "tenants_count": 10,
+        "tenants_online": 8,
+        "tenants_warn": 1,
+        "tenants_error": 1,
+        "storage_count": 15,
+        "snapshots_count": 20,
+        "cloud_snapshots_count": 5,
+        "nodes_count": 25,
+        "nodes_online": 22,
+        "nodes_warn": 2,
+        "nodes_error": 1,
+        "tenant_recipes_count": 5,
+        "tenant_recipes_online": 4,
+        "tenant_recipes_warn": 1,
+        "tenant_recipes_error": 0,
+        "devices_count": 10,
+        "devices_online": 9,
+        "devices_warn": 1,
+        "devices_error": 0,
+        "running_tenants_cores": [
+            {"$key": 1, "name": "tenant-a", "total_cores": 16},
+            {"$key": 2, "name": "tenant-b", "total_cores": 8},
+        ],
+        "tenant_storage": [
+            {"$key": 1, "tenant_name": "tenant-a", "used": 53687091200},
+        ],
+        "running_nodes_cpu": [],
+        "running_nodes_ram": [],
+        "running_nodes_nic": [],
+        "logs": [],
+        "tenant_snapshots": [],
+    }
+
+
+# =============================================================================
+# TenantStats Model Tests
+# =============================================================================
+
+
+class TestTenantStats:
+    """Tests for TenantStats model."""
+
+    def test_stats_properties(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test stats properties."""
+        manager = MagicMock()
+        stats = TenantStats(sample_stats_data, manager)
+
+        assert stats.tenant_key == 123
+        assert stats.ram_used_mb == 8192
+
+    def test_stats_last_update(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test last update timestamp."""
+        manager = MagicMock()
+        stats = TenantStats(sample_stats_data, manager)
+
+        assert stats.last_update is not None
+        assert stats.last_update.year == 2024
+        assert stats.last_update.tzinfo == timezone.utc
+
+    def test_stats_last_update_none(self) -> None:
+        """Test last update when not set."""
+        manager = MagicMock()
+        stats = TenantStats({"$key": 1, "tenant": 123}, manager)
+
+        assert stats.last_update is None
+
+    def test_stats_repr(self, sample_stats_data: dict[str, Any]) -> None:
+        """Test stats repr."""
+        manager = MagicMock()
+        stats = TenantStats(sample_stats_data, manager)
+
+        assert "TenantStats" in repr(stats)
+        assert "tenant=123" in repr(stats)
+        assert "ram=8192MB" in repr(stats)
+
+
+# =============================================================================
+# TenantStatsHistory Model Tests
+# =============================================================================
+
+
+class TestTenantStatsHistory:
+    """Tests for TenantStatsHistory model."""
+
+    def test_history_properties(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test history properties."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert history.tenant_key == 123
+        assert history.timestamp_epoch == 1704067200
+        assert history.total_cpu == 45
+        assert history.core_count == 8
+        assert history.ram_used_mb == 8192
+        assert history.vram_used_mb == 4096
+        assert history.ram_allocated_mb == 16384
+        assert history.ram_pct == 50
+        assert history.ip_count == 5
+
+    def test_history_timestamp(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test timestamp property."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert history.timestamp is not None
+        assert history.timestamp.year == 2024
+        assert history.timestamp.tzinfo == timezone.utc
+
+    def test_history_storage_tier0(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test tier 0 storage properties."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert history.tier0_provisioned == 107374182400
+        assert history.tier0_used == 53687091200
+        assert history.tier0_allocated == 107374182400
+        assert history.tier0_pct == 50
+
+    def test_history_gpu_metrics(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test GPU metrics."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert history.gpus_used == 1
+        assert history.gpus_total == 2
+        assert history.gpus_pct == 50
+        assert history.vgpus_used == 2
+        assert history.vgpus_total == 4
+        assert history.vgpus_pct == 50
+
+    def test_history_get_tier_stats(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test get_tier_stats helper."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        tier0 = history.get_tier_stats(0)
+        assert tier0["provisioned"] == 107374182400
+        assert tier0["used"] == 53687091200
+        assert tier0["pct"] == 50
+
+        tier1 = history.get_tier_stats(1)
+        assert tier1["provisioned"] == 0
+        assert tier1["used"] == 0
+
+    def test_history_get_tier_stats_invalid(
+        self, sample_stats_history_data: dict[str, Any]
+    ) -> None:
+        """Test get_tier_stats with invalid tier."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        with pytest.raises(ValueError, match="Tier must be 0-5"):
+            history.get_tier_stats(6)
+
+        with pytest.raises(ValueError, match="Tier must be 0-5"):
+            history.get_tier_stats(-1)
+
+    def test_history_total_storage(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test total storage helpers."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert history.total_storage_used == 53687091200
+        assert history.total_storage_provisioned == 107374182400
+        assert history.total_storage_allocated == 107374182400
+
+    def test_history_repr(self, sample_stats_history_data: dict[str, Any]) -> None:
+        """Test history repr."""
+        manager = MagicMock()
+        history = TenantStatsHistory(sample_stats_history_data, manager)
+
+        assert "TenantStatsHistory" in repr(history)
+        assert "cpu=45%" in repr(history)
+        assert "ram=8192MB" in repr(history)
+        assert "cores=8" in repr(history)
+
+
+# =============================================================================
+# TenantStatsManager Tests
+# =============================================================================
+
+
+class TestTenantStatsManager:
+    """Tests for TenantStatsManager."""
+
+    def test_get_stats(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_stats_data: dict[str, Any],
+    ) -> None:
+        """Test getting current stats."""
+        mock_client._request.return_value = [sample_stats_data]
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        stats = manager.get()
+
+        assert stats.ram_used_mb == 8192
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "tenant_stats"
+        assert "tenant eq 123" in call_args[1]["params"]["filter"]
+
+    def test_get_stats_not_found(self, mock_client: MagicMock, mock_tenant: MagicMock) -> None:
+        """Test getting stats when not found."""
+        mock_client._request.return_value = []
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+    def test_history_short(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test getting short history."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        history = manager.history_short(limit=100)
+
+        assert len(history) == 1
+        assert history[0].total_cpu == 45
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "tenant_stats_history_short" in call_args[0][1]
+
+    def test_history_long(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test getting long history."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        history = manager.history_long(limit=100)
+
+        assert len(history) == 1
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert "tenant_stats_history_long" in call_args[0][1]
+
+    def test_history_with_datetime_filter(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test history with datetime filter."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        history = manager.history_short(since=since)
+
+        assert len(history) == 1
+        call_args = mock_client._request.call_args
+        assert "timestamp ge" in call_args[1]["params"]["filter"]
+
+    def test_history_with_epoch_filter(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_stats_history_data: dict[str, Any],
+    ) -> None:
+        """Test history with epoch timestamp filter."""
+        mock_client._request.return_value = [sample_stats_history_data]
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        history = manager.history_short(since=1704067200, until=1704153600)
+
+        assert len(history) == 1
+        call_args = mock_client._request.call_args
+        assert "timestamp ge 1704067200" in call_args[1]["params"]["filter"]
+        assert "timestamp le 1704153600" in call_args[1]["params"]["filter"]
+
+    def test_history_empty_response(self, mock_client: MagicMock, mock_tenant: MagicMock) -> None:
+        """Test history with empty response."""
+        mock_client._request.return_value = None
+        manager = TenantStatsManager(mock_client, mock_tenant)
+
+        history = manager.history_short()
+
+        assert history == []
+
+
+# =============================================================================
+# TenantLog Model Tests
+# =============================================================================
+
+
+class TestTenantLog:
+    """Tests for TenantLog model."""
+
+    def test_log_properties(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log properties."""
+        manager = MagicMock()
+        log = TenantLog(sample_log_data, manager)
+
+        assert log.tenant_key == 123
+        assert log.tenant_name == "test-tenant"
+        assert log.level == "Message"
+        assert log.level_raw == "message"
+        assert log.text == "Tenant powered on successfully"
+        assert log.user == "admin"
+
+    def test_log_timestamp(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log timestamp (microsecond precision)."""
+        manager = MagicMock()
+        log = TenantLog(sample_log_data, manager)
+
+        assert log.timestamp is not None
+        assert log.timestamp_epoch_us == 1704067200000000
+
+    def test_log_level_checks(self, sample_log_list: list[dict[str, Any]]) -> None:
+        """Test log level helper properties."""
+        manager = MagicMock()
+
+        message_log = TenantLog(sample_log_list[0], manager)
+        error_log = TenantLog(sample_log_list[1], manager)
+        warning_log = TenantLog(sample_log_list[2], manager)
+
+        assert message_log.is_error is False
+        assert message_log.is_warning is False
+        assert message_log.is_audit is False
+
+        assert error_log.is_error is True
+        assert error_log.is_warning is False
+
+        assert warning_log.is_warning is True
+        assert warning_log.is_error is False
+
+    def test_log_repr(self, sample_log_data: dict[str, Any]) -> None:
+        """Test log repr."""
+        manager = MagicMock()
+        log = TenantLog(sample_log_data, manager)
+
+        assert "TenantLog" in repr(log)
+        assert "Message" in repr(log)
+
+
+# =============================================================================
+# TenantLogManager Tests
+# =============================================================================
+
+
+class TestTenantLogManager:
+    """Tests for TenantLogManager."""
+
+    def test_list_logs(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs."""
+        mock_client._request.return_value = sample_log_list
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list()
+
+        assert len(logs) == 3
+        mock_client._request.assert_called_once()
+
+    def test_list_logs_by_level(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs filtered by level."""
+        mock_client._request.return_value = [sample_log_list[1]]
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list(level="error")
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'error'" in call_args[1]["params"]["filter"]
+
+    def test_list_errors_only(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing errors only."""
+        mock_client._request.return_value = [sample_log_list[1]]
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list(errors_only=True)
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'error' or level eq 'critical'" in call_args[1]["params"]["filter"]
+
+    def test_list_warnings_only(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing warnings only."""
+        mock_client._request.return_value = [sample_log_list[2]]
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list(warnings_only=True)
+
+        assert len(logs) == 1
+        call_args = mock_client._request.call_args
+        assert "level eq 'warning'" in call_args[1]["params"]["filter"]
+
+    def test_list_logs_with_time_filter(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs with time filter."""
+        mock_client._request.return_value = sample_log_list
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        logs = manager.list(since=since)
+
+        assert len(logs) == 3
+        call_args = mock_client._request.call_args
+        assert "timestamp ge" in call_args[1]["params"]["filter"]
+
+    def test_list_logs_with_epoch_time_filter(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_list: list[dict[str, Any]],
+    ) -> None:
+        """Test listing logs with epoch time filter."""
+        mock_client._request.return_value = sample_log_list
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list(since=1704067200000000, until=1704067210000000)
+
+        assert len(logs) == 3
+        call_args = mock_client._request.call_args
+        assert "timestamp ge 1704067200000000" in call_args[1]["params"]["filter"]
+        assert "timestamp le 1704067210000000" in call_args[1]["params"]["filter"]
+
+    def test_get_log(
+        self,
+        mock_client: MagicMock,
+        mock_tenant: MagicMock,
+        sample_log_data: dict[str, Any],
+    ) -> None:
+        """Test getting a specific log."""
+        mock_client._request.return_value = sample_log_data
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        log = manager.get(key=1)
+
+        assert log.text == "Tenant powered on successfully"
+
+    def test_get_log_not_found(self, mock_client: MagicMock, mock_tenant: MagicMock) -> None:
+        """Test getting a log that doesn't exist."""
+        mock_client._request.return_value = None
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        with pytest.raises(NotFoundError):
+            manager.get(key=999)
+
+    def test_get_log_key_required(self, mock_client: MagicMock, mock_tenant: MagicMock) -> None:
+        """Test that key is required for get."""
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        with pytest.raises(ValueError, match="key must be provided"):
+            manager.get()
+
+    def test_list_logs_empty_response(self, mock_client: MagicMock, mock_tenant: MagicMock) -> None:
+        """Test listing logs with empty response."""
+        mock_client._request.return_value = None
+        manager = TenantLogManager(mock_client, mock_tenant)
+
+        logs = manager.list()
+
+        assert logs == []
+
+
+# =============================================================================
+# TenantDashboard Model Tests
+# =============================================================================
+
+
+class TestTenantDashboard:
+    """Tests for TenantDashboard model."""
+
+    def test_dashboard_tenant_counts(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard tenant counts."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert dashboard.tenants_count == 10
+        assert dashboard.tenants_online == 8
+        assert dashboard.tenants_warn == 1
+        assert dashboard.tenants_error == 1
+        assert dashboard.tenants_offline == 2  # 10 - 8
+
+    def test_dashboard_storage_counts(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard storage counts."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert dashboard.storage_count == 15
+        assert dashboard.snapshots_count == 20
+        assert dashboard.cloud_snapshots_count == 5
+
+    def test_dashboard_node_counts(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard node counts."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert dashboard.nodes_count == 25
+        assert dashboard.nodes_online == 22
+        assert dashboard.nodes_warn == 2
+        assert dashboard.nodes_error == 1
+
+    def test_dashboard_recipe_counts(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard recipe counts."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert dashboard.tenant_recipes_count == 5
+        assert dashboard.tenant_recipes_online == 4
+        assert dashboard.tenant_recipes_warn == 1
+        assert dashboard.tenant_recipes_error == 0
+
+    def test_dashboard_device_counts(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard device counts."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert dashboard.devices_count == 10
+        assert dashboard.devices_online == 9
+        assert dashboard.devices_warn == 1
+        assert dashboard.devices_error == 0
+
+    def test_dashboard_top_tenants(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard top tenants lists."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert len(dashboard.running_tenants_cores) == 2
+        assert dashboard.running_tenants_cores[0]["name"] == "tenant-a"
+        assert len(dashboard.tenant_storage) == 1
+
+    def test_dashboard_empty_lists(self) -> None:
+        """Test dashboard with missing/empty lists."""
+        manager = MagicMock()
+        dashboard = TenantDashboard({}, manager)
+
+        assert dashboard.running_tenants_cores == []
+        assert dashboard.tenant_storage == []
+        assert dashboard.running_nodes_cpu == []
+        assert dashboard.logs == []
+
+    def test_dashboard_repr(self, sample_dashboard_data: dict[str, Any]) -> None:
+        """Test dashboard repr."""
+        manager = MagicMock()
+        dashboard = TenantDashboard(sample_dashboard_data, manager)
+
+        assert "TenantDashboard" in repr(dashboard)
+        assert "tenants=8/10" in repr(dashboard)
+        assert "nodes=22/25" in repr(dashboard)
+
+
+# =============================================================================
+# TenantDashboardManager Tests
+# =============================================================================
+
+
+class TestTenantDashboardManager:
+    """Tests for TenantDashboardManager."""
+
+    def test_get_dashboard(
+        self,
+        mock_client: MagicMock,
+        sample_dashboard_data: dict[str, Any],
+    ) -> None:
+        """Test getting dashboard."""
+        mock_client._request.return_value = sample_dashboard_data
+        manager = TenantDashboardManager(mock_client)
+
+        dashboard = manager.get()
+
+        assert dashboard.tenants_count == 10
+        mock_client._request.assert_called_once()
+        call_args = mock_client._request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "tenant_dashboard"
+
+    def test_get_dashboard_empty_response(self, mock_client: MagicMock) -> None:
+        """Test getting dashboard with empty response."""
+        mock_client._request.return_value = None
+        manager = TenantDashboardManager(mock_client)
+
+        dashboard = manager.get()
+
+        assert dashboard.tenants_count == 0
+
+    def test_get_dashboard_list_response(
+        self,
+        mock_client: MagicMock,
+        sample_dashboard_data: dict[str, Any],
+    ) -> None:
+        """Test getting dashboard when API returns a list."""
+        mock_client._request.return_value = [sample_dashboard_data]
+        manager = TenantDashboardManager(mock_client)
+
+        dashboard = manager.get()
+
+        assert dashboard.tenants_count == 10
+
+
+# =============================================================================
+# Integration Tests with Tenant
+# =============================================================================
+
+
+class TestTenantIntegration:
+    """Tests for Tenant integration with stats/logs."""
+
+    def test_tenant_has_stats_property(self, mock_client: MagicMock) -> None:
+        """Test that Tenant has stats property."""
+        from pyvergeos.resources.tenant_manager import Tenant
+
+        tenant_data = {
+            "$key": 123,
+            "name": "test-tenant",
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        tenant = Tenant(tenant_data, manager)
+
+        stats_manager = tenant.stats
+        assert isinstance(stats_manager, TenantStatsManager)
+        assert stats_manager._tenant_key == 123
+
+    def test_tenant_has_logs_property(self, mock_client: MagicMock) -> None:
+        """Test that Tenant has logs property."""
+        from pyvergeos.resources.tenant_manager import Tenant
+
+        tenant_data = {
+            "$key": 123,
+            "name": "test-tenant",
+        }
+        manager = MagicMock()
+        manager._client = mock_client
+        tenant = Tenant(tenant_data, manager)
+
+        logs_manager = tenant.logs
+        assert isinstance(logs_manager, TenantLogManager)
+        assert logs_manager._tenant_key == 123
+
+
+# =============================================================================
+# Client Integration Tests
+# =============================================================================
+
+
+class TestClientIntegration:
+    """Tests for VergeClient integration with tenant dashboard."""
+
+    def test_client_has_tenant_dashboard_property(self, mock_client: MagicMock) -> None:
+        """Test that client has tenant_dashboard property after initialization."""
+        # This tests the pattern, not the actual client
+        # The actual client test would require more setup
+        manager = TenantDashboardManager(mock_client)
+        assert isinstance(manager, TenantDashboardManager)


### PR DESCRIPTION
## Summary

Implements section 3.4 (Tenant Stats & Monitoring) from the v1.0 release plan.

- Add `TenantStats` and `TenantStatsHistory` for current/historical performance metrics
- Add `TenantStatsManager` scoped via `tenant.stats` property
- Add `TenantLog` and `TenantLogManager` for tenant-specific logs via `tenant.logs`
- Add `TenantDashboard` with aggregated counts and top consumers
- Add `TenantDashboardManager` via `client.tenant_dashboard`

## Features

- Storage tier metrics (0-5) with helper methods like `get_tier_stats()` and `total_storage_used`
- GPU/vGPU metrics tracking
- Log level filtering (audit, message, warning, error, critical, summary, debug)
- Historical stats with short-term (high resolution) and long-term (lower resolution) endpoints
- Dashboard with tenant/node counts and top resource consumers

## Usage

```python
# Access tenant stats
tenant = client.tenants.get(name="customer-a")
stats = tenant.stats.get()
print(f"RAM: {stats.ram_used_mb}MB")

# Access stats history for billing/capacity planning
history = tenant.stats.history_short(limit=100)
for point in history:
    print(f"{point.timestamp}: CPU {point.total_cpu}%, RAM {point.ram_used_mb}MB")

# Access tenant-specific logs
logs = tenant.logs.list(level="error")
for log in logs:
    print(f"[{log.level}] {log.text}")

# Access dashboard summary
dashboard = client.tenant_dashboard.get()
print(f"Online: {dashboard.tenants_online}/{dashboard.tenants_count}")
```

## Test plan

- [x] Unit tests: 47 tests covering all models and managers
- [x] Integration tests: 18 tests against live VergeOS system
- [x] Ruff lint and format checks pass
- [x] mypy type checking passes
- [x] All 3062 unit tests pass