### PR TITLE
feat: add system enhancements (diagnostics, certificates, settings)

### DIFF
--- a/pyvergeos/resources/system.py
+++ b/pyvergeos/resources/system.py
@@ -1,4 +1,4 @@
-"""System management for VergeOS - settings, statistics, licenses, and inventory."""
+"""System management for VergeOS - settings, statistics, licenses, diagnostics, and inventory."""
 
 from __future__ import annotations
 
@@ -7,12 +7,29 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from pyvergeos.constants import POLL_INTERVAL, TASK_WAIT_TIMEOUT
 from pyvergeos.resources.base import ResourceManager, ResourceObject
 
 if TYPE_CHECKING:
     from pyvergeos.client import VergeClient
 
 logger = logging.getLogger(__name__)
+
+
+# Diagnostic status values
+DIAG_STATUS_INITIALIZING = "initializing"
+DIAG_STATUS_BUILDING = "building"
+DIAG_STATUS_UPLOADING = "uploading"
+DIAG_STATUS_COMPLETE = "complete"
+DIAG_STATUS_ERROR = "error"
+
+DIAG_STATUS_DISPLAY = {
+    DIAG_STATUS_INITIALIZING: "Initializing",
+    DIAG_STATUS_BUILDING: "Building",
+    DIAG_STATUS_UPLOADING: "Sending to Support",
+    DIAG_STATUS_COMPLETE: "Complete",
+    DIAG_STATUS_ERROR: "Error",
+}
 
 
 # =============================================================================
@@ -169,6 +186,97 @@ class SettingsManager(ResourceManager[SystemSetting]):
             raise NotFoundError(f"Setting '{key}' not found")
 
         return self._to_model(results[0])
+
+    def update(  # type: ignore[override]
+        self,
+        key: str,
+        value: str,
+    ) -> SystemSetting:
+        """Update a system setting value.
+
+        Args:
+            key: Setting key name (e.g., "max_connections").
+            value: New value for the setting.
+
+        Returns:
+            Updated SystemSetting object.
+
+        Raises:
+            NotFoundError: If setting not found.
+            ValueError: If key not provided.
+
+        Example:
+            >>> setting = client.system.settings.update("max_connections", "1000")
+            >>> print(f"New value: {setting.value}")
+        """
+        if not key:
+            raise ValueError("Setting key must be provided")
+
+        # Settings API uses the key as the identifier in the URL
+        body = {"value": value}
+
+        # First, we need to get the setting to find its row key
+        # Settings uses 'key' as the keyfield, so we filter by it
+        params: dict[str, Any] = {
+            "filter": f"key eq '{key}'",
+            "fields": "all",
+        }
+
+        response = self._client._request("GET", self._endpoint, params=params)
+        if not response:
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Setting '{key}' not found")
+
+        results = response if isinstance(response, list) else [response]
+        if not results:
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Setting '{key}' not found")
+
+        # Use the row identifier for PUT
+        row_key = results[0].get("$key") or results[0].get("key")
+
+        # For settings, we PUT with the key value in the body
+        body["key"] = key
+        self._client._request("PUT", f"{self._endpoint}/{row_key}", json_data=body)
+
+        # Fetch and return the updated setting
+        return self.get(key)
+
+    def reset(self, key: str) -> SystemSetting:
+        """Reset a system setting to its default value.
+
+        Args:
+            key: Setting key name.
+
+        Returns:
+            Updated SystemSetting object with default value.
+
+        Raises:
+            NotFoundError: If setting not found.
+
+        Example:
+            >>> setting = client.system.settings.reset("max_connections")
+            >>> print(f"Reset to: {setting.value}")
+        """
+        # Get the current setting to find the default value
+        current = self.get(key)
+        if current.default_value is not None:
+            return self.update(key, current.default_value)
+        return current
+
+    def list_modified(self) -> builtins.list[SystemSetting]:
+        """List only settings that have been modified from defaults.
+
+        Returns:
+            List of modified SystemSetting objects.
+
+        Example:
+            >>> for setting in client.system.settings.list_modified():
+            ...     print(f"{setting.key}: {setting.value} (default: {setting.default_value})")
+        """
+        return [s for s in self.list() if s.is_modified]
 
 
 # =============================================================================
@@ -405,6 +513,87 @@ class LicenseManager(ResourceManager[License]):
             return results[0]
 
         raise ValueError("Either key or name must be provided")
+
+    def generate_payload(self) -> str:
+        """Generate a license request payload for air-gapped systems.
+
+        For systems without internet connectivity, this generates a payload
+        that can be sent to Verge.io support to obtain a license file.
+
+        Returns:
+            License request payload as a string.
+
+        Raises:
+            APIError: If payload generation fails.
+
+        Example:
+            >>> payload = client.system.licenses.generate_payload()
+            >>> # Save payload to a file and send to support
+            >>> with open("license_request.txt", "w") as f:
+            ...     f.write(payload)
+        """
+        response = self._client._request(
+            "POST",
+            "license_actions",
+            json_data={"action": "generate"},
+        )
+
+        if response is None:
+            from pyvergeos.exceptions import APIError
+
+            raise APIError("License payload generation returned no response")
+
+        # Response may contain the payload directly or wrapped
+        if isinstance(response, dict):
+            # Try common response fields
+            payload = response.get("payload") or response.get("result") or response.get("data")
+            if payload:
+                return str(payload)
+            # If no specific field, return the whole response as JSON
+            import json
+
+            return json.dumps(response)
+
+        return str(response)
+
+    def add(self, license_text: str) -> License:
+        """Add a new license to the system.
+
+        Args:
+            license_text: The license text/key provided by Verge.io.
+
+        Returns:
+            The newly added License object.
+
+        Raises:
+            ValidationError: If the license is invalid.
+            ConflictError: If the license already exists.
+
+        Example:
+            >>> license_data = open("license.txt").read()
+            >>> lic = client.system.licenses.add(license_data)
+            >>> print(f"Added license: {lic.name}")
+        """
+        response = self._client._request(
+            "POST",
+            self._endpoint,
+            json_data={"license": license_text},
+        )
+
+        if response is None:
+            from pyvergeos.exceptions import APIError
+
+            raise APIError("License add returned no response")
+
+        if isinstance(response, dict):
+            key = response.get("$key")
+            if key is not None:
+                return self.get(int(key))
+            return self._to_model(response)
+
+        from pyvergeos.exceptions import APIError
+
+        raise APIError("Unexpected response format from license add")
 
 
 # =============================================================================
@@ -1021,6 +1210,695 @@ class SystemInventory:
 
 
 # =============================================================================
+# System Diagnostics
+# =============================================================================
+
+
+class SystemDiagnostic(ResourceObject):
+    """Represents a system diagnostic report in VergeOS.
+
+    System diagnostics capture comprehensive system information including logs,
+    configuration, network state, and other metrics useful for troubleshooting.
+
+    Properties:
+        name: Diagnostic report name.
+        description: Report description.
+        status: Current status (initializing, building, uploading, complete, error).
+        status_display: Human-readable status.
+        status_info: Additional status information (e.g., current node being processed).
+        file_key: Associated file $key for download.
+        is_complete: Whether the diagnostic build is complete.
+        is_building: Whether the diagnostic is currently building.
+        has_error: Whether the diagnostic encountered an error.
+        created_at: When the diagnostic was created.
+    """
+
+    @property
+    def name(self) -> str:
+        """Diagnostic report name."""
+        return str(self.get("name", ""))
+
+    @property
+    def description(self) -> str:
+        """Report description."""
+        return str(self.get("description", ""))
+
+    @property
+    def status(self) -> str:
+        """Current status (API value)."""
+        return str(self.get("status", DIAG_STATUS_INITIALIZING))
+
+    @property
+    def status_display(self) -> str:
+        """Human-readable status."""
+        return DIAG_STATUS_DISPLAY.get(self.status, self.status)
+
+    @property
+    def status_info(self) -> str:
+        """Additional status information."""
+        return str(self.get("status_info", ""))
+
+    @property
+    def file_key(self) -> int | None:
+        """Associated file $key for download."""
+        val = self.get("file")
+        return int(val) if val else None
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the diagnostic build is complete."""
+        return self.status == DIAG_STATUS_COMPLETE
+
+    @property
+    def is_building(self) -> bool:
+        """Whether the diagnostic is currently building."""
+        return self.status in (DIAG_STATUS_INITIALIZING, DIAG_STATUS_BUILDING)
+
+    @property
+    def has_error(self) -> bool:
+        """Whether the diagnostic encountered an error."""
+        return self.status == DIAG_STATUS_ERROR
+
+    @property
+    def created_at(self) -> datetime | None:
+        """When the diagnostic was created."""
+        ts = self.get("timestamp")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def refresh(self) -> SystemDiagnostic:
+        """Refresh diagnostic data from API.
+
+        Returns:
+            Updated SystemDiagnostic object.
+        """
+        from typing import cast
+
+        manager = cast("SystemDiagnosticManager", self._manager)
+        return manager.get(self.key)
+
+    def send_to_support(self) -> None:
+        """Send this diagnostic report to Verge.io support.
+
+        Requires the diagnostic to be complete.
+
+        Raises:
+            ValueError: If diagnostic is not complete.
+        """
+        from typing import cast
+
+        if not self.is_complete:
+            raise ValueError("Diagnostic must be complete before sending to support")
+
+        manager = cast("SystemDiagnosticManager", self._manager)
+        manager.send_to_support(self.key)
+
+    def wait_for_completion(
+        self,
+        timeout: float = TASK_WAIT_TIMEOUT,
+        poll_interval: float = POLL_INTERVAL,
+    ) -> SystemDiagnostic:
+        """Wait for the diagnostic build to complete.
+
+        Args:
+            timeout: Maximum time to wait in seconds.
+            poll_interval: Time between status checks in seconds.
+
+        Returns:
+            The completed SystemDiagnostic object.
+
+        Raises:
+            TaskTimeoutError: If timeout is reached before completion.
+        """
+        import time
+
+        from pyvergeos.exceptions import TaskTimeoutError
+
+        start_time = time.time()
+        while True:
+            current = self.refresh()
+            if current.is_complete or current.has_error:
+                return current
+
+            elapsed = time.time() - start_time
+            if elapsed >= timeout:
+                raise TaskTimeoutError(
+                    f"Diagnostic build did not complete within {timeout} seconds"
+                )
+
+            time.sleep(poll_interval)
+
+    def delete(self) -> None:
+        """Delete this diagnostic report."""
+        from typing import cast
+
+        manager = cast("SystemDiagnosticManager", self._manager)
+        manager.delete(self.key)
+
+    def __repr__(self) -> str:
+        return (
+            f"<SystemDiagnostic key={self.key} name={self.name!r} status={self.status_display!r}>"
+        )
+
+
+class SystemDiagnosticManager(ResourceManager[SystemDiagnostic]):
+    """Manages system diagnostic reports in VergeOS.
+
+    System diagnostics capture comprehensive system information for
+    troubleshooting and support purposes.
+
+    Example:
+        >>> # Build a new diagnostic report
+        >>> diag = client.system.diagnostics.build(
+        ...     name="Support Case #12345",
+        ...     description="Network connectivity issue",
+        ...     send_to_support=True
+        ... )
+        >>>
+        >>> # Wait for completion
+        >>> diag = diag.wait_for_completion()
+        >>> print(f"Status: {diag.status_display}")
+        >>>
+        >>> # List all diagnostics
+        >>> for d in client.system.diagnostics.list():
+        ...     print(f"{d.name}: {d.status_display}")
+    """
+
+    _endpoint = "system_diagnostics"
+
+    def _to_model(self, data: dict[str, Any]) -> SystemDiagnostic:
+        return SystemDiagnostic(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        status: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[SystemDiagnostic]:
+        """List system diagnostic reports.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            status: Filter by status (initializing, building, complete, error).
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of SystemDiagnostic objects.
+
+        Example:
+            >>> # List all diagnostics
+            >>> diagnostics = client.system.diagnostics.list()
+            >>>
+            >>> # List completed diagnostics only
+            >>> completed = client.system.diagnostics.list(status="complete")
+        """
+        if fields is None:
+            fields = [
+                "$key",
+                "name",
+                "description",
+                "status",
+                "status_info",
+                "file",
+                "timestamp",
+            ]
+
+        filters = []
+        if filter:
+            filters.append(filter)
+        if status:
+            filters.append(f"status eq '{status}'")
+
+        combined_filter = " and ".join(filters) if filters else None
+
+        return super().list(
+            filter=combined_filter,
+            fields=fields,
+            limit=limit,
+            offset=offset,
+            **filter_kwargs,
+        )
+
+    def get(  # type: ignore[override]
+        self, key: int, *, fields: builtins.list[str] | None = None
+    ) -> SystemDiagnostic:
+        """Get a diagnostic report by key.
+
+        Args:
+            key: Diagnostic $key.
+            fields: List of fields to return.
+
+        Returns:
+            SystemDiagnostic object.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+        """
+        if fields is None:
+            fields = [
+                "$key",
+                "name",
+                "description",
+                "status",
+                "status_info",
+                "file",
+                "timestamp",
+            ]
+
+        return super().get(key, fields=fields)
+
+    def build(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        *,
+        send_to_support: bool = False,
+    ) -> SystemDiagnostic:
+        """Build a new system diagnostic report.
+
+        Triggers collection of comprehensive system information from all nodes.
+        This operation may take several minutes depending on system size.
+
+        Args:
+            name: Report name. If not provided, auto-generated with timestamp.
+            description: Report description.
+            send_to_support: If True, automatically send to Verge.io support
+                when complete (requires internet connectivity).
+
+        Returns:
+            The new SystemDiagnostic object (initially in 'initializing' status).
+
+        Example:
+            >>> # Build diagnostic for support case
+            >>> diag = client.system.diagnostics.build(
+            ...     name="Support-12345",
+            ...     description="High CPU usage investigation",
+            ...     send_to_support=True
+            ... )
+            >>> diag = diag.wait_for_completion()
+        """
+        body: dict[str, Any] = {}
+
+        if name:
+            body["name"] = name
+        if description:
+            body["description"] = description
+        if send_to_support:
+            body["send2support"] = True
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response is None:
+            from pyvergeos.exceptions import APIError
+
+            raise APIError("Diagnostic build returned no response")
+
+        if isinstance(response, dict):
+            key = response.get("$key")
+            if key is not None:
+                return self.get(int(key))
+            return self._to_model(response)
+
+        from pyvergeos.exceptions import APIError
+
+        raise APIError("Unexpected response format from diagnostic build")
+
+    def send_to_support(self, key: int) -> None:
+        """Send a diagnostic report to Verge.io support.
+
+        The diagnostic must be complete before sending.
+
+        Args:
+            key: Diagnostic $key.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+            ValueError: If diagnostic is not complete.
+        """
+        # First verify the diagnostic exists and is complete
+        diag = self.get(key)
+        if not diag.is_complete:
+            raise ValueError("Diagnostic must be complete before sending to support")
+
+        # Use the actions endpoint
+        self._client._request(
+            "POST",
+            "system_diagnostic_actions",
+            json_data={
+                "system_diagnostic": key,
+                "action": "send2support",
+            },
+        )
+
+    def delete(self, key: int) -> None:
+        """Delete a diagnostic report.
+
+        Args:
+            key: Diagnostic $key.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> SystemDiagnostic:
+        """Update a diagnostic report's name or description.
+
+        Args:
+            key: Diagnostic $key.
+            name: New name.
+            description: New description.
+
+        Returns:
+            Updated SystemDiagnostic object.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def get_download_url(self, key: int) -> str | None:
+        """Get the download URL for a completed diagnostic file.
+
+        Args:
+            key: Diagnostic $key.
+
+        Returns:
+            Download URL string, or None if file not available.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+            ValueError: If diagnostic is not complete.
+        """
+        diag = self.get(key)
+        if not diag.is_complete:
+            raise ValueError("Diagnostic must be complete to download")
+
+        if diag.file_key is None:
+            return None
+
+        # Get the file information
+        file_response = self._client._request(
+            "GET",
+            f"files/{diag.file_key}",
+            params={"fields": "$key,name,path"},
+        )
+
+        if file_response and isinstance(file_response, dict):
+            path = file_response.get("path")
+            if path:
+                return f"https://{self._client.host}/files/{path}"
+
+        return None
+
+
+# =============================================================================
+# Root Certificates (Trusted CAs)
+# =============================================================================
+
+
+class RootCertificate(ResourceObject):
+    """Represents a trusted root certificate authority in VergeOS.
+
+    Root certificates are added to the system's trust store to enable
+    secure connections to systems using private/internal CA certificates.
+
+    Properties:
+        subject: Certificate subject (common name, organization, etc.).
+        issuer: Certificate issuer.
+        fingerprint: Certificate fingerprint (SHA-256).
+        start_date: Certificate validity start date.
+        end_date: Certificate validity end date.
+        cert_pem: Certificate in PEM format.
+        modified_at: When the certificate was last modified.
+    """
+
+    @property
+    def subject(self) -> str:
+        """Certificate subject."""
+        return str(self.get("subject", ""))
+
+    @property
+    def issuer(self) -> str:
+        """Certificate issuer."""
+        return str(self.get("issuer", ""))
+
+    @property
+    def fingerprint(self) -> str:
+        """Certificate fingerprint."""
+        return str(self.get("fingerprint", ""))
+
+    @property
+    def start_date(self) -> str:
+        """Certificate validity start date."""
+        return str(self.get("startdate", ""))
+
+    @property
+    def end_date(self) -> str:
+        """Certificate validity end date."""
+        return str(self.get("enddate", ""))
+
+    @property
+    def cert_pem(self) -> str:
+        """Certificate in PEM format."""
+        return str(self.get("cert", ""))
+
+    @property
+    def modified_at(self) -> datetime | None:
+        """When the certificate was last modified."""
+        ts = self.get("modified")
+        if ts:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    def delete(self) -> None:
+        """Delete this root certificate."""
+        from typing import cast
+
+        manager = cast("RootCertificateManager", self._manager)
+        manager.delete(self.key)
+
+    def __repr__(self) -> str:
+        return f"<RootCertificate key={self.key} subject={self.subject!r}>"
+
+
+class RootCertificateManager(ResourceManager[RootCertificate]):
+    """Manages trusted root certificates in VergeOS.
+
+    Root certificates allow adding custom Certificate Authorities to the
+    system's trust store, enabling secure connections to systems using
+    private/enterprise CA certificates.
+
+    Common use cases:
+    - Enabling secure site syncs with internal CA certificates
+    - Trusting enterprise PKI for LDAP/AD connections
+    - Development environments with self-signed CAs
+
+    Example:
+        >>> # Add a root CA
+        >>> ca_cert = open("enterprise-ca.pem").read()
+        >>> root_ca = client.system.root_certificates.create(cert=ca_cert)
+        >>> print(f"Added CA: {root_ca.subject}")
+        >>>
+        >>> # List trusted CAs
+        >>> for ca in client.system.root_certificates.list():
+        ...     print(f"{ca.subject} (expires: {ca.end_date})")
+    """
+
+    _endpoint = "root_certificates"
+
+    def _to_model(self, data: dict[str, Any]) -> RootCertificate:
+        return RootCertificate(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[RootCertificate]:
+        """List trusted root certificates.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of RootCertificate objects.
+
+        Example:
+            >>> # List all trusted CAs
+            >>> for ca in client.system.root_certificates.list():
+            ...     print(f"{ca.subject}")
+        """
+        if fields is None:
+            fields = [
+                "$key",
+                "subject",
+                "issuer",
+                "fingerprint",
+                "startdate",
+                "enddate",
+                "modified",
+            ]
+
+        return super().list(
+            filter=filter,
+            fields=fields,
+            limit=limit,
+            offset=offset,
+            **filter_kwargs,
+        )
+
+    def get(  # type: ignore[override]
+        self, key: int, *, fields: builtins.list[str] | None = None
+    ) -> RootCertificate:
+        """Get a root certificate by key.
+
+        Args:
+            key: Certificate $key.
+            fields: List of fields to return.
+
+        Returns:
+            RootCertificate object.
+
+        Raises:
+            NotFoundError: If certificate not found.
+        """
+        if fields is None:
+            fields = [
+                "$key",
+                "cert",
+                "subject",
+                "issuer",
+                "fingerprint",
+                "startdate",
+                "enddate",
+                "modified",
+            ]
+
+        return super().get(key, fields=fields)
+
+    def get_by_subject(self, subject: str) -> RootCertificate:
+        """Get a root certificate by subject.
+
+        Args:
+            subject: Certificate subject (partial match supported).
+
+        Returns:
+            RootCertificate object.
+
+        Raises:
+            NotFoundError: If certificate not found.
+        """
+        results = self.list(filter=f"subject ct '{subject}'", limit=1)
+        if not results:
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Root certificate with subject containing '{subject}' not found")
+        return results[0]
+
+    def get_by_fingerprint(self, fingerprint: str) -> RootCertificate:
+        """Get a root certificate by fingerprint.
+
+        Args:
+            fingerprint: Certificate fingerprint.
+
+        Returns:
+            RootCertificate object.
+
+        Raises:
+            NotFoundError: If certificate not found.
+        """
+        results = self.list(filter=f"fingerprint eq '{fingerprint}'", limit=1)
+        if not results:
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Root certificate with fingerprint '{fingerprint}' not found")
+        return results[0]
+
+    def create(self, cert: str) -> RootCertificate:  # type: ignore[override]
+        """Add a new trusted root certificate.
+
+        Args:
+            cert: Certificate in PEM format.
+
+        Returns:
+            The new RootCertificate object.
+
+        Raises:
+            ValidationError: If the certificate is invalid.
+            ConflictError: If the certificate already exists.
+
+        Example:
+            >>> ca_cert = '''-----BEGIN CERTIFICATE-----
+            ... MIIDXTCCAkWgAwIBAgIJAJC1...
+            ... -----END CERTIFICATE-----'''
+            >>> root_ca = client.system.root_certificates.create(cert=ca_cert)
+        """
+        response = self._client._request(
+            "POST",
+            self._endpoint,
+            json_data={"cert": cert},
+        )
+
+        if response is None:
+            from pyvergeos.exceptions import APIError
+
+            raise APIError("Root certificate creation returned no response")
+
+        if isinstance(response, dict):
+            key = response.get("$key")
+            if key is not None:
+                return self.get(int(key))
+            return self._to_model(response)
+
+        from pyvergeos.exceptions import APIError
+
+        raise APIError("Unexpected response format from root certificate creation")
+
+    def delete(self, key: int) -> None:
+        """Delete a root certificate.
+
+        Args:
+            key: Certificate $key.
+
+        Raises:
+            NotFoundError: If certificate not found.
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+
+# =============================================================================
 # System Manager
 # =============================================================================
 
@@ -1028,7 +1906,8 @@ class SystemInventory:
 class SystemManager:
     """Provides system-level operations in VergeOS.
 
-    Includes access to settings, statistics, licenses, and inventory.
+    Includes access to settings, statistics, licenses, diagnostics,
+    root certificates, and inventory.
 
     Example:
         >>> # Get system statistics
@@ -1043,6 +1922,18 @@ class SystemManager:
         >>> setting = client.system.settings.get("max_connections")
         >>> print(f"Max connections: {setting.value}")
 
+        >>> # Update a setting
+        >>> setting = client.system.settings.update("max_connections", "1000")
+
+        >>> # Build system diagnostics
+        >>> diag = client.system.diagnostics.build(
+        ...     name="Support Case",
+        ...     send_to_support=True
+        ... )
+
+        >>> # Add a trusted root CA
+        >>> root_ca = client.system.root_certificates.create(cert=pem_text)
+
         >>> # Get full inventory
         >>> inventory = client.system.inventory()
         >>> print(inventory.summary)
@@ -1052,20 +1943,94 @@ class SystemManager:
         self._client = client
         self._settings: SettingsManager | None = None
         self._licenses: LicenseManager | None = None
+        self._diagnostics: SystemDiagnosticManager | None = None
+        self._root_certificates: RootCertificateManager | None = None
 
     @property
     def settings(self) -> SettingsManager:
-        """Access system settings."""
+        """Access system settings.
+
+        System settings control various aspects of VergeOS behavior
+        including connection limits, API rate limits, and more.
+
+        Example:
+            >>> # List all settings
+            >>> for s in client.system.settings.list():
+            ...     print(f"{s.key}: {s.value}")
+
+            >>> # Update a setting
+            >>> client.system.settings.update("max_connections", "1000")
+
+            >>> # List modified settings
+            >>> for s in client.system.settings.list_modified():
+            ...     print(f"{s.key}: {s.value} (default: {s.default_value})")
+        """
         if self._settings is None:
             self._settings = SettingsManager(self._client)
         return self._settings
 
     @property
     def licenses(self) -> LicenseManager:
-        """Access license management."""
+        """Access license management.
+
+        Licenses control which features are available and the
+        capabilities of the VergeOS system.
+
+        Example:
+            >>> # List licenses
+            >>> for lic in client.system.licenses.list():
+            ...     print(f"{lic.name}: {'valid' if lic.is_valid else 'invalid'}")
+
+            >>> # Generate payload for air-gapped licensing
+            >>> payload = client.system.licenses.generate_payload()
+        """
         if self._licenses is None:
             self._licenses = LicenseManager(self._client)
         return self._licenses
+
+    @property
+    def diagnostics(self) -> SystemDiagnosticManager:
+        """Access system diagnostics.
+
+        System diagnostics capture comprehensive system information
+        for troubleshooting and support purposes.
+
+        Example:
+            >>> # Build a diagnostic report
+            >>> diag = client.system.diagnostics.build(
+            ...     name="Support-12345",
+            ...     description="Network issue",
+            ...     send_to_support=True
+            ... )
+            >>> diag = diag.wait_for_completion()
+
+            >>> # List diagnostics
+            >>> for d in client.system.diagnostics.list():
+            ...     print(f"{d.name}: {d.status_display}")
+        """
+        if self._diagnostics is None:
+            self._diagnostics = SystemDiagnosticManager(self._client)
+        return self._diagnostics
+
+    @property
+    def root_certificates(self) -> RootCertificateManager:
+        """Access root certificate (trusted CA) management.
+
+        Root certificates allow adding custom Certificate Authorities
+        to the system's trust store for secure connections.
+
+        Example:
+            >>> # Add a trusted CA
+            >>> ca_pem = open("enterprise-ca.pem").read()
+            >>> ca = client.system.root_certificates.create(cert=ca_pem)
+
+            >>> # List trusted CAs
+            >>> for ca in client.system.root_certificates.list():
+            ...     print(f"{ca.subject}")
+        """
+        if self._root_certificates is None:
+            self._root_certificates = RootCertificateManager(self._client)
+        return self._root_certificates
 
     def statistics(self) -> SystemStatistics:
         """Get system dashboard statistics.


### PR DESCRIPTION
## Summary

Implements section 4.4 System Enhancements from the v1.0 release plan, adding comprehensive system management functionality:

- **System Diagnostics** (`SystemDiagnosticManager`, `SystemDiagnostic`)
  - Build diagnostic reports with progress tracking
  - Wait for completion with configurable timeout
  - Send to Verge.io support automatically or on-demand
  - Get download URL for completed diagnostics

- **Root Certificates** (`RootCertificateManager`, `RootCertificate`)
  - Add trusted Certificate Authorities to the system trust store
  - List, get, and delete certificates
  - Lookup by subject (partial match) or fingerprint

- **License Enhancements**
  - `generate_payload()` - Generate license request for air-gapped systems
  - `add()` - Add new licenses to the system

- **Settings Enhancements**
  - `update(key, value)` - Update setting values
  - `reset(key)` - Reset settings to defaults
  - `list_modified()` - List only settings that differ from defaults

## Changes

- `pyvergeos/resources/system.py` - Added ~600 lines of new functionality
- `tests/unit/test_system.py` - Added 38 new unit tests (78 total)
- `tests/integration/test_system.py` - Added 15 new integration tests

## Test plan

- [x] All 78 unit tests passing
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [ ] Integration tests against live system (marked with `@pytest.mark.integration`)