### PR TITLE
feat: add authentication sources and OIDC application management

### DIFF
--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -1,6 +1,12 @@
 """Resource managers for VergeOS API resources."""
 
 from pyvergeos.resources.api_keys import APIKey, APIKeyCreated, APIKeyManager
+from pyvergeos.resources.auth_sources import (
+    AuthSource,
+    AuthSourceManager,
+    AuthSourceState,
+    AuthSourceStateManager,
+)
 from pyvergeos.resources.base import ResourceManager, ResourceObject
 from pyvergeos.resources.billing import BillingManager, BillingRecord
 from pyvergeos.resources.certificates import Certificate, CertificateManager
@@ -88,6 +94,16 @@ from pyvergeos.resources.nodes import (
     NodeUSBDevice,
     NodeUSBDeviceManager,
 )
+from pyvergeos.resources.oidc_applications import (
+    OidcApplication,
+    OidcApplicationGroup,
+    OidcApplicationGroupManager,
+    OidcApplicationLog,
+    OidcApplicationLogManager,
+    OidcApplicationManager,
+    OidcApplicationUser,
+    OidcApplicationUserManager,
+)
 from pyvergeos.resources.permissions import Permission, PermissionManager
 from pyvergeos.resources.recipe_common import (
     RecipeQuestion,
@@ -168,6 +184,10 @@ __all__ = [
     "APIKey",
     "APIKeyCreated",
     "APIKeyManager",
+    "AuthSource",
+    "AuthSourceManager",
+    "AuthSourceState",
+    "AuthSourceStateManager",
     "BillingManager",
     "BillingRecord",
     "Certificate",
@@ -245,6 +265,14 @@ __all__ = [
     "NASVolumeSync",
     "NASVolumeSyncManager",
     "NFSSettings",
+    "OidcApplication",
+    "OidcApplicationGroup",
+    "OidcApplicationGroupManager",
+    "OidcApplicationLog",
+    "OidcApplicationLogManager",
+    "OidcApplicationManager",
+    "OidcApplicationUser",
+    "OidcApplicationUserManager",
     "Permission",
     "PermissionManager",
     "ResourceGroup",

--- a/pyvergeos/resources/auth_sources.py
+++ b/pyvergeos/resources/auth_sources.py
@@ -1,0 +1,827 @@
+"""Authentication source management for external identity providers.
+
+Authentication sources enable SSO and federated login via OAuth2/OIDC providers
+such as Azure AD, Google, GitLab, Okta, and generic OpenID Connect.
+
+Key concepts:
+    - **Auth Source**: Configuration for an external identity provider
+    - **Driver**: The type of provider (azure, google, gitlab, okta, openid, etc.)
+    - **Settings**: Driver-specific configuration stored as JSON
+    - **States**: Ephemeral OAuth state tokens during authentication flow
+
+Supported drivers:
+    - azure: Azure Active Directory
+    - google: Google OAuth
+    - gitlab: GitLab (OpenID)
+    - okta: Okta
+    - openid: Generic OpenID Connect
+    - openid-well-known: OpenID with well-known configuration discovery
+    - oauth2: Generic OAuth2
+    - verge.io: Verge.io parent system authentication
+
+Example:
+    >>> # List all authentication sources
+    >>> for source in client.auth_sources.list():
+    ...     print(f"{source.name} ({source.driver})")
+
+    >>> # Get a specific auth source
+    >>> azure = client.auth_sources.get(name="Azure AD")
+
+    >>> # Create an Azure AD auth source
+    >>> source = client.auth_sources.create(
+    ...     name="Corporate Azure",
+    ...     driver="azure",
+    ...     settings={
+    ...         "tenant_id": "your-tenant-id",
+    ...         "client_id": "your-client-id",
+    ...         "client_secret": "your-client-secret",
+    ...         "scope": "openid profile email",
+    ...     }
+    ... )
+
+    >>> # Enable debug mode for troubleshooting
+    >>> source.enable_debug()
+
+    >>> # List users using this auth source
+    >>> for user in client.users.list(auth_source=source.key):
+    ...     print(f"  {user.name}")
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+# =============================================================================
+# Auth Source State (OAuth State Tokens)
+# =============================================================================
+
+
+class AuthSourceState(ResourceObject):
+    """OAuth state token for authentication flow.
+
+    Auth source states are ephemeral tokens created during the OAuth
+    authentication flow. They expire after 15 minutes.
+
+    Attributes:
+        key: State key (40-character hex string).
+        auth_source: Parent auth source key.
+        meta: State metadata (JSON).
+        timestamp: Creation timestamp (microseconds).
+    """
+
+    @property
+    def key(self) -> str:  # type: ignore[override]
+        """State key (40-character hex string).
+
+        Raises:
+            ValueError: If state has no key.
+        """
+        state = self.get("state")
+        if state is None:
+            state = self.get("$key")
+        if state is None:
+            raise ValueError("State has no key")
+        return str(state)
+
+    @property
+    def auth_source_key(self) -> int | None:
+        """Get the parent auth source key."""
+        source = self.get("auth_source")
+        return int(source) if source is not None else None
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if state has expired (>15 minutes old).
+
+        States expire 15 minutes (900 seconds) after creation.
+        """
+        import time
+
+        timestamp = self.get("timestamp", 0)
+        if not timestamp:
+            return True
+        # timestamp is in microseconds, convert to seconds
+        created_at = int(timestamp) / 1_000_000
+        return bool(time.time() - created_at > 900)
+
+
+class AuthSourceStateManager(ResourceManager["AuthSourceState"]):
+    """Manager for authentication source state operations.
+
+    States are read-only and automatically created/deleted during OAuth flow.
+
+    Example:
+        >>> # List states for an auth source
+        >>> for state in client.auth_source_states.list(auth_source=1):
+        ...     print(f"{state.key}: expired={state.is_expired}")
+    """
+
+    _endpoint = "auth_source_states"
+
+    _default_fields = [
+        "$key",
+        "state",
+        "auth_source",
+        "meta",
+        "timestamp",
+    ]
+
+    def __init__(self, client: VergeClient, *, auth_source_key: int | None = None) -> None:
+        super().__init__(client)
+        self._auth_source_key = auth_source_key
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        auth_source: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[AuthSourceState]:
+        """List auth source states with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            auth_source: Filter by auth source key. Ignored if manager is scoped.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of AuthSourceState objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add auth_source filter (from scope or parameter)
+        source_key = self._auth_source_key
+        if source_key is None and auth_source is not None:
+            source_key = auth_source
+
+        if source_key is not None:
+            filters.append(f"auth_source eq {source_key}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        # Sort by timestamp descending
+        params["sort"] = "-timestamp"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: str | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> AuthSourceState:
+        """Get a single state by key.
+
+        Args:
+            key: State key (40-character hex string).
+            fields: List of fields to return.
+
+        Returns:
+            AuthSourceState object.
+
+        Raises:
+            NotFoundError: If state not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {
+            "filter": f"state eq '{key}'",
+        }
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            raise NotFoundError(f"Auth source state with key {key} not found")
+        if isinstance(response, list):
+            if not response:
+                raise NotFoundError(f"Auth source state with key {key} not found")
+            response = response[0]
+        if not isinstance(response, dict):
+            raise NotFoundError(f"Auth source state with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def _to_model(self, data: dict[str, Any]) -> AuthSourceState:
+        """Convert API response to AuthSourceState object."""
+        return AuthSourceState(data, self)
+
+
+# =============================================================================
+# Auth Source
+# =============================================================================
+
+
+class AuthSource(ResourceObject):
+    """Authentication source resource object.
+
+    Represents an external identity provider configuration.
+
+    Attributes:
+        key: Auth source $key (row ID).
+        name: Display name shown on login button.
+        driver: Provider type (azure, google, gitlab, okta, openid, etc.).
+        settings: Driver-specific configuration (JSON).
+        menu: Whether to show in dropdown menu.
+        debug: Debug logging enabled.
+        debug_ts: Debug mode timestamp.
+        button_background_color: Login button background color (CSS).
+        button_color: Login button text color (CSS).
+        button_fa_icon: Login button Font Awesome icon class.
+        icon_color: Login button icon color (CSS).
+    """
+
+    @property
+    def driver(self) -> str:
+        """Get the auth provider driver type."""
+        return str(self.get("driver", ""))
+
+    @property
+    def is_azure(self) -> bool:
+        """Check if this is an Azure AD source."""
+        return self.driver == "azure"
+
+    @property
+    def is_google(self) -> bool:
+        """Check if this is a Google source."""
+        return self.driver == "google"
+
+    @property
+    def is_gitlab(self) -> bool:
+        """Check if this is a GitLab source."""
+        return self.driver == "gitlab"
+
+    @property
+    def is_okta(self) -> bool:
+        """Check if this is an Okta source."""
+        return self.driver == "okta"
+
+    @property
+    def is_openid(self) -> bool:
+        """Check if this is an OpenID source (any variant)."""
+        driver = self.driver
+        return driver in ("openid", "openid-well-known")
+
+    @property
+    def is_oauth2(self) -> bool:
+        """Check if this is a generic OAuth2 source."""
+        return self.driver == "oauth2"
+
+    @property
+    def is_vergeos(self) -> bool:
+        """Check if this is a Verge.io parent source."""
+        return self.driver == "verge.io"
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        """Get driver-specific settings.
+
+        Settings vary by driver but commonly include:
+        - client_id: OAuth client ID
+        - client_secret: OAuth client secret
+        - tenant_id: Azure tenant ID (Azure only)
+        - scope: OAuth scopes to request
+        - redirect_uri: OAuth redirect URI
+        - remote_user_fields: Fields to match users
+        """
+        settings = self.get("settings")
+        if isinstance(settings, dict):
+            return settings
+        return {}
+
+    @property
+    def is_debug_enabled(self) -> bool:
+        """Check if debug logging is enabled."""
+        return bool(self.get("debug", False))
+
+    @property
+    def is_menu(self) -> bool:
+        """Check if shown in dropdown menu."""
+        return bool(self.get("menu", False))
+
+    @property
+    def button_style(self) -> dict[str, str | None]:
+        """Get login button styling properties.
+
+        Returns:
+            Dict with background_color, text_color, icon, icon_color.
+        """
+        return {
+            "background_color": self.get("button_background_color"),
+            "text_color": self.get("button_color"),
+            "icon": self.get("button_fa_icon"),
+            "icon_color": self.get("icon_color"),
+        }
+
+    @property
+    def states(self) -> AuthSourceStateManager:
+        """Get a state manager scoped to this auth source.
+
+        Returns:
+            AuthSourceStateManager for this auth source.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        return AuthSourceStateManager(manager._client, auth_source_key=self.key)
+
+    def enable_debug(self) -> AuthSource:
+        """Enable debug logging for this auth source.
+
+        Debug mode automatically disables after 1 hour.
+
+        Returns:
+            Updated AuthSource object.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        return manager.update(self.key, debug=True)
+
+    def disable_debug(self) -> AuthSource:
+        """Disable debug logging for this auth source.
+
+        Returns:
+            Updated AuthSource object.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        return manager.update(self.key, debug=False)
+
+    def refresh(self) -> AuthSource:
+        """Refresh resource data from API.
+
+        Returns:
+            Updated AuthSource object.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        return manager.get(self.key)
+
+    def save(self, **kwargs: Any) -> AuthSource:
+        """Save changes to resource.
+
+        Args:
+            **kwargs: Fields to update.
+
+        Returns:
+            Updated AuthSource object.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        return manager.update(self.key, **kwargs)
+
+    def delete(self) -> None:
+        """Delete this auth source.
+
+        This will fail if users or OIDC applications are using this source.
+        """
+        from typing import cast
+
+        manager = cast("AuthSourceManager", self._manager)
+        manager.delete(self.key)
+
+
+class AuthSourceManager(ResourceManager["AuthSource"]):
+    """Manager for authentication source operations.
+
+    Authentication sources enable SSO via external identity providers.
+
+    Example:
+        >>> # List all auth sources
+        >>> for source in client.auth_sources.list():
+        ...     print(f"{source.name} ({source.driver})")
+
+        >>> # Get a specific source
+        >>> source = client.auth_sources.get(name="Azure AD")
+
+        >>> # Create an auth source
+        >>> source = client.auth_sources.create(
+        ...     name="Google",
+        ...     driver="google",
+        ...     settings={
+        ...         "client_id": "your-client-id",
+        ...         "client_secret": "your-secret",
+        ...     }
+        ... )
+
+        >>> # Update settings
+        >>> source = client.auth_sources.update(
+        ...     source.key,
+        ...     settings={"scope": "openid profile email groups"}
+        ... )
+
+        >>> # Delete an auth source
+        >>> client.auth_sources.delete(source.key)
+    """
+
+    _endpoint = "auth_sources"
+
+    _default_fields = [
+        "$key",
+        "name",
+        "driver",
+        "menu",
+        "debug",
+        "debug_ts",
+        "button_background_color",
+        "button_color",
+        "button_fa_icon",
+        "icon_color",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        driver: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[AuthSource]:
+        """List auth sources with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            driver: Filter by driver type (azure, google, gitlab, etc.).
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of AuthSource objects.
+
+        Example:
+            >>> # List all sources
+            >>> sources = client.auth_sources.list()
+
+            >>> # List Azure sources only
+            >>> sources = client.auth_sources.list(driver="azure")
+
+            >>> # Filter by name pattern
+            >>> sources = client.auth_sources.list(name="Corporate*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add driver filter
+        if driver is not None:
+            filters.append(f"driver eq '{driver}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+        include_settings: bool = False,
+    ) -> AuthSource:
+        """Get a single auth source by key or name.
+
+        Args:
+            key: Auth source $key (row ID).
+            name: Auth source name.
+            fields: List of fields to return.
+            include_settings: Include settings JSON in response.
+
+        Returns:
+            AuthSource object.
+
+        Raises:
+            NotFoundError: If source not found.
+            ValueError: If no identifier provided.
+
+        Example:
+            >>> # Get by key
+            >>> source = client.auth_sources.get(1)
+
+            >>> # Get by name
+            >>> source = client.auth_sources.get(name="Azure AD")
+
+            >>> # Include settings
+            >>> source = client.auth_sources.get(1, include_settings=True)
+            >>> print(source.settings)
+        """
+        # Determine which fields to request
+        request_fields = list(fields) if fields else list(self._default_fields)
+        if include_settings and "settings" not in request_fields:
+            request_fields.append("settings")
+
+        if key is not None:
+            params: dict[str, Any] = {
+                "fields": ",".join(request_fields),
+            }
+
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"Auth source with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Auth source with key {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=request_fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Auth source with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        *,
+        driver: str,
+        settings: dict[str, Any] | None = None,
+        menu: bool = False,
+        button_background_color: str | None = None,
+        button_color: str | None = None,
+        button_fa_icon: str | None = None,
+        icon_color: str | None = None,
+    ) -> AuthSource:
+        """Create a new authentication source.
+
+        Args:
+            name: Display name for the auth source (appears on login button).
+            driver: Provider type. One of:
+                - azure: Azure Active Directory
+                - google: Google OAuth
+                - gitlab: GitLab (OpenID)
+                - okta: Okta
+                - openid: Generic OpenID Connect
+                - openid-well-known: OpenID with well-known discovery
+                - oauth2: Generic OAuth2
+                - verge.io: Verge.io parent system
+            settings: Driver-specific configuration. Common fields:
+                - client_id: OAuth client ID
+                - client_secret: OAuth client secret
+                - tenant_id: Azure tenant ID (Azure only)
+                - scope: OAuth scopes (default: "openid profile email")
+                - remote_user_fields: Fields to match users
+                - auto_create_users: Pattern for auto-creating users
+                - update_remote_user: Update remote user ID after login
+                - update_user_email: Update user email from provider
+                - update_user_display_name: Update display name from provider
+                - update_group_membership: Sync group membership
+            menu: Show in dropdown menu instead of buttons.
+            button_background_color: Button background color (CSS value).
+            button_color: Button text color (CSS value).
+            button_fa_icon: Button icon (Bootstrap Icon class, e.g. "bi-google").
+            icon_color: Button icon color (CSS value).
+
+        Returns:
+            Created AuthSource object.
+
+        Example:
+            >>> # Create Azure AD source
+            >>> source = client.auth_sources.create(
+            ...     name="Corporate Azure",
+            ...     driver="azure",
+            ...     settings={
+            ...         "tenant_id": "your-tenant-id",
+            ...         "client_id": "your-client-id",
+            ...         "client_secret": "your-client-secret",
+            ...         "scope": "openid profile email",
+            ...         "update_remote_user": True,
+            ...         "update_user_email": True,
+            ...     }
+            ... )
+
+            >>> # Create Google source with custom styling
+            >>> source = client.auth_sources.create(
+            ...     name="Sign in with Google",
+            ...     driver="google",
+            ...     settings={
+            ...         "client_id": "your-client-id",
+            ...         "client_secret": "your-secret",
+            ...     },
+            ...     button_background_color="#4285F4",
+            ...     button_color="#ffffff",
+            ...     button_fa_icon="bi-google",
+            ... )
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "driver": driver,
+        }
+
+        if settings is not None:
+            body["settings"] = settings
+
+        if menu:
+            body["menu"] = menu
+
+        if button_background_color is not None:
+            body["button_background_color"] = button_background_color
+
+        if button_color is not None:
+            body["button_color"] = button_color
+
+        if button_fa_icon is not None:
+            body["button_fa_icon"] = button_fa_icon
+
+        if icon_color is not None:
+            body["icon_color"] = icon_color
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created source
+        if response and isinstance(response, dict):
+            source_key = response.get("$key")
+            if source_key:
+                return self.get(key=int(source_key))
+
+        # Fallback: search by name
+        return self.get(name=name)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        settings: dict[str, Any] | None = None,
+        menu: bool | None = None,
+        debug: bool | None = None,
+        button_background_color: str | None = None,
+        button_color: str | None = None,
+        button_fa_icon: str | None = None,
+        icon_color: str | None = None,
+    ) -> AuthSource:
+        """Update an authentication source.
+
+        Note: The driver cannot be changed after creation.
+
+        Args:
+            key: Auth source $key (row ID).
+            name: New display name.
+            settings: Updated settings (merged with existing).
+            menu: Show in dropdown menu.
+            debug: Enable/disable debug logging.
+            button_background_color: Button background color.
+            button_color: Button text color.
+            button_fa_icon: Button icon class.
+            icon_color: Button icon color.
+
+        Returns:
+            Updated AuthSource object.
+
+        Example:
+            >>> # Update settings
+            >>> source = client.auth_sources.update(
+            ...     source.key,
+            ...     settings={"scope": "openid profile email groups"}
+            ... )
+
+            >>> # Enable debug mode
+            >>> source = client.auth_sources.update(source.key, debug=True)
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+
+        if settings is not None:
+            body["settings"] = settings
+
+        if menu is not None:
+            body["menu"] = menu
+
+        if debug is not None:
+            body["debug"] = debug
+
+        if button_background_color is not None:
+            body["button_background_color"] = button_background_color
+
+        if button_color is not None:
+            body["button_color"] = button_color
+
+        if button_fa_icon is not None:
+            body["button_fa_icon"] = button_fa_icon
+
+        if icon_color is not None:
+            body["icon_color"] = icon_color
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete an authentication source.
+
+        This operation will fail if:
+        - Users are assigned to this auth source
+        - OIDC applications reference this auth source
+
+        Args:
+            key: Auth source $key (row ID).
+
+        Raises:
+            NotFoundError: If source not found.
+            ConflictError: If source is in use by users or OIDC apps.
+
+        Example:
+            >>> client.auth_sources.delete(source.key)
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def states(self, key: int) -> AuthSourceStateManager:
+        """Get a state manager scoped to a specific auth source.
+
+        Args:
+            key: Auth source $key (row ID).
+
+        Returns:
+            AuthSourceStateManager for the auth source.
+        """
+        return AuthSourceStateManager(self._client, auth_source_key=key)
+
+    def _to_model(self, data: dict[str, Any]) -> AuthSource:
+        """Convert API response to AuthSource object."""
+        return AuthSource(data, self)

--- a/pyvergeos/resources/oidc_applications.py
+++ b/pyvergeos/resources/oidc_applications.py
@@ -1,0 +1,1298 @@
+"""OIDC application management for VergeOS as identity provider.
+
+OIDC applications enable VergeOS to act as an OpenID Connect identity provider,
+allowing other systems and tenants to authenticate through VergeOS.
+
+Key concepts:
+    - **OIDC Application**: Configuration for a client that authenticates via VergeOS
+    - **Client Credentials**: Auto-generated client_id and client_secret for OAuth2 flow
+    - **Redirect URIs**: Allowed callback URLs for the OAuth2 flow
+    - **Access Control**: User/group ACLs to restrict who can use the application
+
+Benefits:
+    - Central identity management across VergeOS systems and tenants
+    - Single sign-on (SSO) capabilities
+    - Can chain to upstream providers (Azure, Google, etc.)
+    - Reduces administrative burden for multi-system environments
+
+Example:
+    >>> # List all OIDC applications
+    >>> for app in client.oidc_applications.list():
+    ...     print(f"{app.name}: {app.client_id}")
+
+    >>> # Create an OIDC application
+    >>> app = client.oidc_applications.create(
+    ...     name="Tenant Portal",
+    ...     redirect_uri="https://tenant.example.com/callback",
+    ...     description="OIDC for tenant authentication",
+    ... )
+    >>> print(f"Client ID: {app.client_id}")
+    >>> print(f"Client Secret: {app.client_secret}")
+
+    >>> # Get well-known configuration URL
+    >>> print(f"Well-known: {app.well_known_configuration}")
+
+    >>> # Restrict access to specific users
+    >>> app = client.oidc_applications.update(app.key, restrict_access=True)
+    >>> app.allowed_users.add(user_key=123)
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+# =============================================================================
+# OIDC Application Users (ACL)
+# =============================================================================
+
+
+class OidcApplicationUser(ResourceObject):
+    """OIDC application user ACL entry.
+
+    Represents a user that is allowed to use an OIDC application
+    when restrict_access is enabled.
+
+    Attributes:
+        key: Entry $key (row ID).
+        oidc_application: Parent application key.
+        user: Allowed user key.
+    """
+
+    @property
+    def application_key(self) -> int | None:
+        """Get the parent OIDC application key."""
+        app = self.get("oidc_application")
+        return int(app) if app is not None else None
+
+    @property
+    def user_key(self) -> int | None:
+        """Get the allowed user key."""
+        user = self.get("user")
+        return int(user) if user is not None else None
+
+    @property
+    def user_display(self) -> str | None:
+        """Get the user display name."""
+        return self.get("user_display")
+
+    def delete(self) -> None:
+        """Remove this user from allowed users."""
+        from typing import cast
+
+        manager = cast("OidcApplicationUserManager", self._manager)
+        manager.delete(self.key)
+
+
+class OidcApplicationUserManager(ResourceManager["OidcApplicationUser"]):
+    """Manager for OIDC application user ACL operations.
+
+    Example:
+        >>> # List allowed users for an application
+        >>> for entry in app.allowed_users.list():
+        ...     print(f"{entry.user_display}")
+
+        >>> # Add a user
+        >>> app.allowed_users.add(user_key=123)
+
+        >>> # Remove a user
+        >>> entry.delete()
+    """
+
+    _endpoint = "oidc_application_users"
+
+    _default_fields = [
+        "$key",
+        "oidc_application",
+        "display(oidc_application) as oidc_application_display",
+        "user",
+        "display(user) as user_display",
+    ]
+
+    def __init__(self, client: VergeClient, *, application_key: int | None = None) -> None:
+        super().__init__(client)
+        self._application_key = application_key
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        oidc_application: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[OidcApplicationUser]:
+        """List allowed users with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            oidc_application: Filter by application key. Ignored if scoped.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of OidcApplicationUser objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add application filter
+        app_key = self._application_key
+        if app_key is None and oidc_application is not None:
+            app_key = oidc_application
+
+        if app_key is not None:
+            filters.append(f"oidc_application eq {app_key}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> OidcApplicationUser:
+        """Get a single user ACL entry by key.
+
+        Args:
+            key: Entry $key (row ID).
+            fields: List of fields to return.
+
+        Returns:
+            OidcApplicationUser object.
+
+        Raises:
+            NotFoundError: If entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+        if response is None:
+            raise NotFoundError(f"OIDC application user with key {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"OIDC application user with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def add(self, *, user_key: int) -> OidcApplicationUser:
+        """Add a user to allowed users.
+
+        Args:
+            user_key: User $key to add.
+
+        Returns:
+            Created OidcApplicationUser object.
+
+        Raises:
+            ValueError: If manager is not scoped to an application.
+        """
+        if self._application_key is None:
+            raise ValueError("Manager must be scoped to an application to add users")
+
+        body: dict[str, Any] = {
+            "oidc_application": self._application_key,
+            "user": user_key,
+        }
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response and isinstance(response, dict):
+            entry_key = response.get("$key")
+            if entry_key:
+                return self.get(key=int(entry_key))
+
+        # Fallback: search
+        results = self.list(limit=1)
+        if results:
+            return results[0]
+        raise NotFoundError("Failed to create user ACL entry")
+
+    def delete(self, key: int) -> None:
+        """Remove a user ACL entry.
+
+        Args:
+            key: Entry $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def _to_model(self, data: dict[str, Any]) -> OidcApplicationUser:
+        """Convert API response to OidcApplicationUser object."""
+        return OidcApplicationUser(data, self)
+
+
+# =============================================================================
+# OIDC Application Groups (ACL)
+# =============================================================================
+
+
+class OidcApplicationGroup(ResourceObject):
+    """OIDC application group ACL entry.
+
+    Represents a group whose members are allowed to use an OIDC application
+    when restrict_access is enabled.
+
+    Attributes:
+        key: Entry $key (row ID).
+        oidc_application: Parent application key.
+        group: Allowed group key.
+    """
+
+    @property
+    def application_key(self) -> int | None:
+        """Get the parent OIDC application key."""
+        app = self.get("oidc_application")
+        return int(app) if app is not None else None
+
+    @property
+    def group_key(self) -> int | None:
+        """Get the allowed group key."""
+        group = self.get("group")
+        return int(group) if group is not None else None
+
+    @property
+    def group_display(self) -> str | None:
+        """Get the group display name."""
+        return self.get("group_display")
+
+    def delete(self) -> None:
+        """Remove this group from allowed groups."""
+        from typing import cast
+
+        manager = cast("OidcApplicationGroupManager", self._manager)
+        manager.delete(self.key)
+
+
+class OidcApplicationGroupManager(ResourceManager["OidcApplicationGroup"]):
+    """Manager for OIDC application group ACL operations.
+
+    Example:
+        >>> # List allowed groups for an application
+        >>> for entry in app.allowed_groups.list():
+        ...     print(f"{entry.group_display}")
+
+        >>> # Add a group
+        >>> app.allowed_groups.add(group_key=456)
+
+        >>> # Remove a group
+        >>> entry.delete()
+    """
+
+    _endpoint = "oidc_application_groups"
+
+    _default_fields = [
+        "$key",
+        "oidc_application",
+        "display(oidc_application) as oidc_application_display",
+        "group",
+        "display(group) as group_display",
+    ]
+
+    def __init__(self, client: VergeClient, *, application_key: int | None = None) -> None:
+        super().__init__(client)
+        self._application_key = application_key
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        oidc_application: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[OidcApplicationGroup]:
+        """List allowed groups with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            oidc_application: Filter by application key. Ignored if scoped.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of OidcApplicationGroup objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add application filter
+        app_key = self._application_key
+        if app_key is None and oidc_application is not None:
+            app_key = oidc_application
+
+        if app_key is not None:
+            filters.append(f"oidc_application eq {app_key}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> OidcApplicationGroup:
+        """Get a single group ACL entry by key.
+
+        Args:
+            key: Entry $key (row ID).
+            fields: List of fields to return.
+
+        Returns:
+            OidcApplicationGroup object.
+
+        Raises:
+            NotFoundError: If entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+        if response is None:
+            raise NotFoundError(f"OIDC application group with key {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"OIDC application group with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def add(self, *, group_key: int) -> OidcApplicationGroup:
+        """Add a group to allowed groups.
+
+        Args:
+            group_key: Group $key to add.
+
+        Returns:
+            Created OidcApplicationGroup object.
+
+        Raises:
+            ValueError: If manager is not scoped to an application.
+        """
+        if self._application_key is None:
+            raise ValueError("Manager must be scoped to an application to add groups")
+
+        body: dict[str, Any] = {
+            "oidc_application": self._application_key,
+            "group": group_key,
+        }
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        if response and isinstance(response, dict):
+            entry_key = response.get("$key")
+            if entry_key:
+                return self.get(key=int(entry_key))
+
+        # Fallback: search
+        results = self.list(limit=1)
+        if results:
+            return results[0]
+        raise NotFoundError("Failed to create group ACL entry")
+
+    def delete(self, key: int) -> None:
+        """Remove a group ACL entry.
+
+        Args:
+            key: Entry $key (row ID).
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def _to_model(self, data: dict[str, Any]) -> OidcApplicationGroup:
+        """Convert API response to OidcApplicationGroup object."""
+        return OidcApplicationGroup(data, self)
+
+
+# =============================================================================
+# OIDC Application Logs
+# =============================================================================
+
+
+class OidcApplicationLog(ResourceObject):
+    """OIDC application log entry.
+
+    Represents an audit log entry for OIDC application operations.
+
+    Attributes:
+        key: Log entry $key (row ID).
+        oidc_application: Parent application key.
+        level: Log level (audit, message, warning, error, critical).
+        text: Log message text.
+        timestamp: Log timestamp (microseconds).
+        user: User who triggered the log.
+    """
+
+    @property
+    def application_key(self) -> int | None:
+        """Get the parent application key."""
+        app = self.get("oidc_application")
+        return int(app) if app is not None else None
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error log entry."""
+        level = self.get("level", "")
+        return level in ("error", "critical")
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning log entry."""
+        return self.get("level") == "warning"
+
+    @property
+    def is_audit(self) -> bool:
+        """Check if this is an audit log entry."""
+        return self.get("level") == "audit"
+
+
+class OidcApplicationLogManager(ResourceManager["OidcApplicationLog"]):
+    """Manager for OIDC application log operations.
+
+    Example:
+        >>> # List all logs for an application
+        >>> for log in app.logs.list():
+        ...     print(f"{log.level}: {log.text}")
+
+        >>> # List errors only
+        >>> errors = app.logs.list_errors()
+    """
+
+    _endpoint = "oidc_application_logs"
+
+    _default_fields = [
+        "$key",
+        "oidc_application",
+        "oidc_application#name as oidc_application_display",
+        "level",
+        "text",
+        "timestamp",
+        "user",
+    ]
+
+    def __init__(self, client: VergeClient, *, application_key: int | None = None) -> None:
+        super().__init__(client)
+        self._application_key = application_key
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        oidc_application: int | None = None,
+        level: str | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[OidcApplicationLog]:
+        """List logs with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            oidc_application: Filter by application key. Ignored if scoped.
+            level: Filter by log level.
+            **filter_kwargs: Shorthand filter arguments.
+
+        Returns:
+            List of OidcApplicationLog objects.
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add application filter
+        app_key = self._application_key
+        if app_key is None and oidc_application is not None:
+            app_key = oidc_application
+
+        if app_key is not None:
+            filters.append(f"oidc_application eq {app_key}")
+
+        # Add level filter
+        if level is not None:
+            filters.append(f"level eq '{level}'")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        # Sort by timestamp descending
+        params["sort"] = "-timestamp"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> OidcApplicationLog:
+        """Get a single log entry by key.
+
+        Args:
+            key: Log entry $key (row ID).
+            fields: List of fields to return.
+
+        Returns:
+            OidcApplicationLog object.
+
+        Raises:
+            NotFoundError: If entry not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("Key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+        if response is None:
+            raise NotFoundError(f"OIDC application log with key {key} not found")
+        if not isinstance(response, dict):
+            raise NotFoundError(f"OIDC application log with key {key} returned invalid response")
+        return self._to_model(response)
+
+    def list_errors(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[OidcApplicationLog]:
+        """List error and critical log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of error/critical log entries.
+        """
+        return self.list(
+            filter="(level eq 'error') or (level eq 'critical')",
+            limit=limit,
+        )
+
+    def list_warnings(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[OidcApplicationLog]:
+        """List warning log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of warning log entries.
+        """
+        return self.list(level="warning", limit=limit)
+
+    def list_audits(
+        self,
+        limit: int | None = None,
+    ) -> builtins.list[OidcApplicationLog]:
+        """List audit log entries.
+
+        Args:
+            limit: Maximum number of results.
+
+        Returns:
+            List of audit log entries.
+        """
+        return self.list(level="audit", limit=limit)
+
+    def _to_model(self, data: dict[str, Any]) -> OidcApplicationLog:
+        """Convert API response to OidcApplicationLog object."""
+        return OidcApplicationLog(data, self)
+
+
+# =============================================================================
+# OIDC Application
+# =============================================================================
+
+
+class OidcApplication(ResourceObject):
+    """OIDC application resource object.
+
+    Represents an OIDC client application configuration for VergeOS
+    acting as an identity provider.
+
+    Attributes:
+        key: Application $key (row ID).
+        name: Application name.
+        enabled: Whether the application is enabled.
+        created: Creation timestamp.
+        description: Application description.
+        redirect_uri: Allowed redirect URIs (newline-separated).
+        client_id: OAuth2 client ID (auto-generated).
+        client_secret: OAuth2 client secret (auto-generated).
+        force_auth_source: Auth source for auto-redirect.
+        restrict_access: Whether access is restricted to specific users/groups.
+        map_user: User to map all logins to.
+        scope_profile: Grant profile scope.
+        scope_email: Grant email scope.
+        scope_groups: Grant groups scope.
+        well_known_configuration: Well-known configuration URL.
+    """
+
+    @property
+    def client_id(self) -> str | None:
+        """Get the OAuth2 client ID."""
+        return self.get("client_id")
+
+    @property
+    def client_secret(self) -> str | None:
+        """Get the OAuth2 client secret.
+
+        Note: This is only available if fetched with include_secret=True.
+        """
+        return self.get("client_secret")
+
+    @property
+    def is_enabled(self) -> bool:
+        """Check if the application is enabled."""
+        return bool(self.get("enabled", True))
+
+    @property
+    def is_access_restricted(self) -> bool:
+        """Check if access is restricted to specific users/groups."""
+        return bool(self.get("restrict_access", False))
+
+    @property
+    def redirect_uris(self) -> builtins.list[str]:
+        """Get redirect URIs as a list.
+
+        Redirect URIs are stored as newline-separated values.
+        """
+        uri = self.get("redirect_uri", "")
+        if not uri:
+            return []
+        return [u.strip() for u in str(uri).split("\n") if u.strip()]
+
+    @property
+    def well_known_configuration(self) -> str | None:
+        """Get the OIDC well-known configuration URL."""
+        return self.get("well_known_configuration")
+
+    @property
+    def scopes(self) -> builtins.list[str]:
+        """Get enabled scopes as a list."""
+        scopes = ["openid"]  # Always included
+        if self.get("scope_profile", True):
+            scopes.append("profile")
+        if self.get("scope_email", True):
+            scopes.append("email")
+        if self.get("scope_groups", True):
+            scopes.append("groups")
+        return scopes
+
+    @property
+    def force_auth_source_key(self) -> int | None:
+        """Get the forced auth source key for auto-redirect."""
+        source = self.get("force_auth_source")
+        return int(source) if source is not None else None
+
+    @property
+    def map_user_key(self) -> int | None:
+        """Get the mapped user key."""
+        user = self.get("map_user")
+        return int(user) if user is not None else None
+
+    @property
+    def allowed_users(self) -> OidcApplicationUserManager:
+        """Get a user ACL manager scoped to this application.
+
+        Returns:
+            OidcApplicationUserManager for this application.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return OidcApplicationUserManager(manager._client, application_key=self.key)
+
+    @property
+    def allowed_groups(self) -> OidcApplicationGroupManager:
+        """Get a group ACL manager scoped to this application.
+
+        Returns:
+            OidcApplicationGroupManager for this application.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return OidcApplicationGroupManager(manager._client, application_key=self.key)
+
+    @property
+    def logs(self) -> OidcApplicationLogManager:
+        """Get a log manager scoped to this application.
+
+        Returns:
+            OidcApplicationLogManager for this application.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return OidcApplicationLogManager(manager._client, application_key=self.key)
+
+    def enable(self) -> OidcApplication:
+        """Enable this OIDC application.
+
+        Returns:
+            Updated OidcApplication object.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return manager.update(self.key, enabled=True)
+
+    def disable(self) -> OidcApplication:
+        """Disable this OIDC application.
+
+        Returns:
+            Updated OidcApplication object.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return manager.update(self.key, enabled=False)
+
+    def refresh(self) -> OidcApplication:
+        """Refresh resource data from API.
+
+        Returns:
+            Updated OidcApplication object.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return manager.get(self.key)
+
+    def save(self, **kwargs: Any) -> OidcApplication:
+        """Save changes to resource.
+
+        Args:
+            **kwargs: Fields to update.
+
+        Returns:
+            Updated OidcApplication object.
+        """
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        return manager.update(self.key, **kwargs)
+
+    def delete(self) -> None:
+        """Delete this OIDC application."""
+        from typing import cast
+
+        manager = cast("OidcApplicationManager", self._manager)
+        manager.delete(self.key)
+
+
+class OidcApplicationManager(ResourceManager["OidcApplication"]):
+    """Manager for OIDC application operations.
+
+    OIDC applications enable VergeOS to act as an identity provider.
+
+    Example:
+        >>> # List all OIDC applications
+        >>> for app in client.oidc_applications.list():
+        ...     print(f"{app.name}: {app.client_id}")
+
+        >>> # Get a specific application
+        >>> app = client.oidc_applications.get(name="Tenant Portal")
+
+        >>> # Create an application
+        >>> app = client.oidc_applications.create(
+        ...     name="Partner Portal",
+        ...     redirect_uri="https://partner.example.com/callback",
+        ...     description="OIDC for partner authentication",
+        ... )
+        >>> print(f"Client ID: {app.client_id}")
+        >>> print(f"Client Secret: {app.client_secret}")
+
+        >>> # Restrict access to specific users
+        >>> app = client.oidc_applications.update(app.key, restrict_access=True)
+        >>> app.allowed_users.add(user_key=123)
+
+        >>> # Delete an application
+        >>> client.oidc_applications.delete(app.key)
+    """
+
+    _endpoint = "oidc_applications"
+
+    _default_fields = [
+        "$key",
+        "name",
+        "enabled",
+        "created",
+        "description",
+        "redirect_uri",
+        "client_id",
+        "force_auth_source",
+        "restrict_access",
+        "map_user",
+        "scope_profile",
+        "scope_email",
+        "scope_groups",
+    ]
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        enabled: bool | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[OidcApplication]:
+        """List OIDC applications with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return (uses defaults if not specified).
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            enabled: Filter by enabled state.
+            **filter_kwargs: Shorthand filter arguments (name, etc.).
+
+        Returns:
+            List of OidcApplication objects.
+
+        Example:
+            >>> # List all applications
+            >>> apps = client.oidc_applications.list()
+
+            >>> # List enabled applications only
+            >>> apps = client.oidc_applications.list(enabled=True)
+
+            >>> # Filter by name pattern
+            >>> apps = client.oidc_applications.list(name="Tenant*")
+        """
+        params: dict[str, Any] = {}
+
+        # Build filter
+        filters: builtins.list[str] = []
+        if filter:
+            filters.append(filter)
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        # Add enabled filter
+        if enabled is not None:
+            filters.append(f"enabled eq {1 if enabled else 0}")
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        # Use default fields if not specified
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        # Pagination
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            response = [response]
+
+        return [self._to_model(item) for item in response if item]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+        include_secret: bool = False,
+        include_well_known: bool = False,
+    ) -> OidcApplication:
+        """Get a single OIDC application by key or name.
+
+        Args:
+            key: Application $key (row ID).
+            name: Application name.
+            fields: List of fields to return.
+            include_secret: Include client_secret in response.
+            include_well_known: Include well_known_configuration in response.
+
+        Returns:
+            OidcApplication object.
+
+        Raises:
+            NotFoundError: If application not found.
+            ValueError: If no identifier provided.
+
+        Example:
+            >>> # Get by key
+            >>> app = client.oidc_applications.get(1)
+
+            >>> # Get by name with secret
+            >>> app = client.oidc_applications.get(
+            ...     name="Tenant Portal",
+            ...     include_secret=True
+            ... )
+            >>> print(app.client_secret)
+        """
+        # Determine which fields to request
+        request_fields = list(fields) if fields else list(self._default_fields)
+        if include_secret and "client_secret" not in request_fields:
+            request_fields.append("client_secret")
+        if include_well_known and "well_known_configuration" not in request_fields:
+            request_fields.append("well_known_configuration")
+
+        if key is not None:
+            params: dict[str, Any] = {
+                "fields": ",".join(request_fields),
+            }
+
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"OIDC application with key {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"OIDC application with key {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=request_fields, limit=1)
+            if not results:
+                raise NotFoundError(f"OIDC application with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        *,
+        redirect_uri: str | builtins.list[str] | None = None,
+        description: str | None = None,
+        enabled: bool = True,
+        force_auth_source: int | None = None,
+        restrict_access: bool = False,
+        map_user: int | None = None,
+        scope_profile: bool = True,
+        scope_email: bool = True,
+        scope_groups: bool = True,
+    ) -> OidcApplication:
+        """Create a new OIDC application.
+
+        The client_id and client_secret are auto-generated and returned
+        in the created object.
+
+        Args:
+            name: Application name.
+            redirect_uri: Allowed redirect URIs (string or list of strings).
+                Wildcards are supported (e.g., "https://*.example.com").
+            description: Application description.
+            enabled: Whether the application is enabled.
+            force_auth_source: Auth source key for auto-redirect.
+            restrict_access: Restrict access to specific users/groups.
+            map_user: User key to map all logins to.
+            scope_profile: Grant profile scope (read user name).
+            scope_email: Grant email scope (read user email).
+            scope_groups: Grant groups scope (read group membership).
+
+        Returns:
+            Created OidcApplication object with client credentials.
+
+        Example:
+            >>> app = client.oidc_applications.create(
+            ...     name="Partner Portal",
+            ...     redirect_uri=[
+            ...         "https://portal.example.com/callback",
+            ...         "https://staging.example.com/callback",
+            ...     ],
+            ...     description="OIDC for partner authentication",
+            ... )
+            >>> print(f"Client ID: {app.client_id}")
+            >>> print(f"Client Secret: {app.client_secret}")
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "enabled": enabled,
+            "scope_profile": scope_profile,
+            "scope_email": scope_email,
+            "scope_groups": scope_groups,
+        }
+
+        # Handle redirect URIs
+        if redirect_uri is not None:
+            if isinstance(redirect_uri, list):
+                body["redirect_uri"] = "\n".join(redirect_uri)
+            else:
+                body["redirect_uri"] = redirect_uri
+
+        if description is not None:
+            body["description"] = description
+
+        if force_auth_source is not None:
+            body["force_auth_source"] = force_auth_source
+
+        if restrict_access:
+            body["restrict_access"] = restrict_access
+
+        if map_user is not None:
+            body["map_user"] = map_user
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+
+        # Get the created application with secret
+        if response and isinstance(response, dict):
+            app_key = response.get("$key")
+            if app_key:
+                return self.get(key=int(app_key), include_secret=True, include_well_known=True)
+
+        # Fallback: search by name (with secret)
+        return self.get(name=name, include_secret=True, include_well_known=True)
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        *,
+        name: str | None = None,
+        redirect_uri: str | builtins.list[str] | None = None,
+        description: str | None = None,
+        enabled: bool | None = None,
+        force_auth_source: int | None = None,
+        restrict_access: bool | None = None,
+        map_user: int | None = None,
+        scope_profile: bool | None = None,
+        scope_email: bool | None = None,
+        scope_groups: bool | None = None,
+    ) -> OidcApplication:
+        """Update an OIDC application.
+
+        Note: client_id and client_secret cannot be changed.
+
+        Args:
+            key: Application $key (row ID).
+            name: New application name.
+            redirect_uri: Updated redirect URIs.
+            description: New description.
+            enabled: Enable or disable.
+            force_auth_source: Auth source for auto-redirect.
+            restrict_access: Restrict to specific users/groups.
+            map_user: User to map all logins to.
+            scope_profile: Grant profile scope.
+            scope_email: Grant email scope.
+            scope_groups: Grant groups scope.
+
+        Returns:
+            Updated OidcApplication object.
+
+        Example:
+            >>> # Update redirect URIs
+            >>> app = client.oidc_applications.update(
+            ...     app.key,
+            ...     redirect_uri="https://new.example.com/callback"
+            ... )
+
+            >>> # Enable access restriction
+            >>> app = client.oidc_applications.update(
+            ...     app.key,
+            ...     restrict_access=True
+            ... )
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+
+        if redirect_uri is not None:
+            if isinstance(redirect_uri, list):
+                body["redirect_uri"] = "\n".join(redirect_uri)
+            else:
+                body["redirect_uri"] = redirect_uri
+
+        if description is not None:
+            body["description"] = description
+
+        if enabled is not None:
+            body["enabled"] = enabled
+
+        if force_auth_source is not None:
+            body["force_auth_source"] = force_auth_source
+
+        if restrict_access is not None:
+            body["restrict_access"] = restrict_access
+
+        if map_user is not None:
+            body["map_user"] = map_user
+
+        if scope_profile is not None:
+            body["scope_profile"] = scope_profile
+
+        if scope_email is not None:
+            body["scope_email"] = scope_email
+
+        if scope_groups is not None:
+            body["scope_groups"] = scope_groups
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete an OIDC application.
+
+        Args:
+            key: Application $key (row ID).
+
+        Raises:
+            NotFoundError: If application not found.
+
+        Example:
+            >>> client.oidc_applications.delete(app.key)
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")
+
+    def allowed_users(self, key: int) -> OidcApplicationUserManager:
+        """Get a user ACL manager scoped to a specific application.
+
+        Args:
+            key: Application $key (row ID).
+
+        Returns:
+            OidcApplicationUserManager for the application.
+        """
+        return OidcApplicationUserManager(self._client, application_key=key)
+
+    def allowed_groups(self, key: int) -> OidcApplicationGroupManager:
+        """Get a group ACL manager scoped to a specific application.
+
+        Args:
+            key: Application $key (row ID).
+
+        Returns:
+            OidcApplicationGroupManager for the application.
+        """
+        return OidcApplicationGroupManager(self._client, application_key=key)
+
+    def logs(self, key: int) -> OidcApplicationLogManager:
+        """Get a log manager scoped to a specific application.
+
+        Args:
+            key: Application $key (row ID).
+
+        Returns:
+            OidcApplicationLogManager for the application.
+        """
+        return OidcApplicationLogManager(self._client, application_key=key)
+
+    def _to_model(self, data: dict[str, Any]) -> OidcApplication:
+        """Convert API response to OidcApplication object."""
+        return OidcApplication(data, self)

--- a/tests/integration/test_auth_sources.py
+++ b/tests/integration/test_auth_sources.py
@@ -1,0 +1,425 @@
+"""Integration tests for authentication source operations."""
+
+import contextlib
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.auth_sources import AuthSource
+
+
+@pytest.mark.integration
+class TestAuthSourceOperations:
+    """Integration tests for auth source operations against live VergeOS."""
+
+    def test_list_auth_sources(self, live_client: VergeClient) -> None:
+        """Test listing authentication sources."""
+        auth_sources = live_client.auth_sources.list()
+        assert isinstance(auth_sources, list)
+
+        # If sources exist, verify structure
+        if len(auth_sources) > 0:
+            source = auth_sources[0]
+            assert "$key" in source
+            assert "name" in source
+            assert "driver" in source
+
+    def test_list_auth_sources_by_driver(self, live_client: VergeClient) -> None:
+        """Test listing auth sources filtered by driver."""
+        # This test works even if no sources exist for the driver
+        azure_sources = live_client.auth_sources.list(driver="azure")
+        assert isinstance(azure_sources, list)
+
+        # All returned sources should have azure driver
+        for source in azure_sources:
+            assert source.driver == "azure"
+
+    def test_get_auth_source_not_found(self, live_client: VergeClient) -> None:
+        """Test getting a non-existent auth source."""
+        with pytest.raises(NotFoundError):
+            live_client.auth_sources.get(999999)
+
+    def test_get_auth_source_by_name_not_found(self, live_client: VergeClient) -> None:
+        """Test getting a non-existent auth source by name."""
+        with pytest.raises(NotFoundError):
+            live_client.auth_sources.get(name="NonexistentAuthSource12345")
+
+
+@pytest.mark.integration
+class TestAuthSourceCRUD:
+    """Integration tests for auth source CRUD operations."""
+
+    @pytest.fixture
+    def test_auth_source(self, live_client: VergeClient):
+        """Create a test auth source for CRUD tests and cleanup afterwards."""
+        source = live_client.auth_sources.create(
+            name="pytest_test_source",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+            },
+        )
+        yield source
+        # Cleanup
+        with contextlib.suppress(NotFoundError):
+            live_client.auth_sources.delete(source.key)
+
+    def test_create_auth_source(self, live_client: VergeClient) -> None:
+        """Test creating an auth source."""
+        source = live_client.auth_sources.create(
+            name="pytest_create_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+            },
+        )
+
+        try:
+            assert isinstance(source, AuthSource)
+            assert source.name == "pytest_create_test"
+            assert source.driver == "openid-well-known"
+            assert source.is_openid is True
+
+            # Verify source exists
+            retrieved = live_client.auth_sources.get(source.key)
+            assert retrieved.name == "pytest_create_test"
+        finally:
+            live_client.auth_sources.delete(source.key)
+
+    def test_create_auth_source_with_styling(self, live_client: VergeClient) -> None:
+        """Test creating an auth source with button styling."""
+        source = live_client.auth_sources.create(
+            name="pytest_styled_source",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+            },
+            button_background_color="#4285F4",
+            button_color="#ffffff",
+            button_fa_icon="bi-box-arrow-in-right",
+        )
+
+        try:
+            retrieved = live_client.auth_sources.get(source.key)
+            style = retrieved.button_style
+            assert style["background_color"] == "#4285F4"
+            assert style["text_color"] == "#ffffff"
+            assert style["icon"] == "bi-box-arrow-in-right"
+        finally:
+            live_client.auth_sources.delete(source.key)
+
+    def test_get_auth_source_by_key(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test getting an auth source by key."""
+        source = live_client.auth_sources.get(test_auth_source.key)
+        assert source.key == test_auth_source.key
+        assert source.name == "pytest_test_source"
+
+    def test_get_auth_source_by_name(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test getting an auth source by name."""
+        source = live_client.auth_sources.get(name="pytest_test_source")
+        assert source.key == test_auth_source.key
+        assert source.name == "pytest_test_source"
+
+    def test_get_auth_source_with_settings(
+        self, test_auth_source, live_client: VergeClient
+    ) -> None:
+        """Test getting an auth source with settings included."""
+        source = live_client.auth_sources.get(test_auth_source.key, include_settings=True)
+        assert source.settings is not None
+        assert isinstance(source.settings, dict)
+        # Settings should contain what we created
+        assert "client_id" in source.settings
+
+    def test_update_auth_source(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test updating an auth source."""
+        updated = live_client.auth_sources.update(
+            test_auth_source.key,
+            name="pytest_updated_source",
+        )
+
+        assert updated.name == "pytest_updated_source"
+
+        # Verify change persisted
+        retrieved = live_client.auth_sources.get(test_auth_source.key)
+        assert retrieved.name == "pytest_updated_source"
+
+    def test_update_auth_source_settings(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test updating auth source settings."""
+        updated = live_client.auth_sources.update(
+            test_auth_source.key,
+            settings={
+                "server_url": "https://new-example.com/.well-known/openid-configuration",
+                "client_id": "updated-client-id",
+                "client_secret": "updated-secret",
+            },
+        )
+
+        # Retrieve with settings to verify
+        retrieved = live_client.auth_sources.get(updated.key, include_settings=True)
+        assert retrieved.settings.get("client_id") == "updated-client-id"
+
+    def test_delete_auth_source(self, live_client: VergeClient) -> None:
+        """Test deleting an auth source."""
+        source = live_client.auth_sources.create(
+            name="pytest_delete_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+            },
+        )
+
+        # Delete
+        live_client.auth_sources.delete(source.key)
+
+        # Verify deleted
+        with pytest.raises(NotFoundError):
+            live_client.auth_sources.get(source.key)
+
+    def test_delete_via_object_method(self, live_client: VergeClient) -> None:
+        """Test deleting via AuthSource.delete() method."""
+        source = live_client.auth_sources.create(
+            name="pytest_obj_delete_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+            },
+        )
+
+        # Delete via method
+        source.delete()
+
+        # Verify deleted
+        with pytest.raises(NotFoundError):
+            live_client.auth_sources.get(source.key)
+
+
+@pytest.mark.integration
+class TestAuthSourceProperties:
+    """Integration tests for auth source property access."""
+
+    @pytest.fixture
+    def test_auth_source(self, live_client: VergeClient):
+        """Create a test auth source and cleanup afterwards."""
+        source = live_client.auth_sources.create(
+            name="pytest_props_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "prop-test-client",
+                "client_secret": "prop-test-secret",
+            },
+            menu=True,
+            button_background_color="#333333",
+            button_color="#ffffff",
+            button_fa_icon="bi-key",
+        )
+        yield source
+        with contextlib.suppress(NotFoundError):
+            live_client.auth_sources.delete(source.key)
+
+    def test_auth_source_basic_properties(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test accessing basic properties on auth source."""
+        source = live_client.auth_sources.get(test_auth_source.key)
+
+        assert isinstance(source, AuthSource)
+        assert source.key == test_auth_source.key
+        assert source.name == "pytest_props_test"
+        assert source.driver == "openid-well-known"
+
+    def test_auth_source_driver_properties(
+        self, test_auth_source, live_client: VergeClient
+    ) -> None:
+        """Test driver type checking properties."""
+        source = live_client.auth_sources.get(test_auth_source.key)
+
+        assert source.is_openid is True
+        assert source.is_azure is False
+        assert source.is_google is False
+        assert source.is_gitlab is False
+        assert source.is_okta is False
+        assert source.is_oauth2 is False
+        assert source.is_vergeos is False
+
+    def test_auth_source_menu_property(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test menu property."""
+        source = live_client.auth_sources.get(test_auth_source.key)
+        assert source.is_menu is True
+
+    def test_auth_source_button_style(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test button style properties."""
+        source = live_client.auth_sources.get(test_auth_source.key)
+        style = source.button_style
+
+        assert isinstance(style, dict)
+        assert style["background_color"] == "#333333"
+        assert style["text_color"] == "#ffffff"
+        assert style["icon"] == "bi-key"
+
+
+@pytest.mark.integration
+class TestAuthSourceDebugMode:
+    """Integration tests for auth source debug mode."""
+
+    @pytest.fixture
+    def test_auth_source(self, live_client: VergeClient):
+        """Create a test auth source and cleanup afterwards."""
+        source = live_client.auth_sources.create(
+            name="pytest_debug_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "debug-test-client",
+                "client_secret": "debug-test-secret",
+            },
+        )
+        yield source
+        with contextlib.suppress(NotFoundError):
+            live_client.auth_sources.delete(source.key)
+
+    def test_enable_debug_mode(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test enabling debug mode."""
+        # Verify initially not in debug mode
+        source = live_client.auth_sources.get(test_auth_source.key)
+        assert source.is_debug_enabled is False
+
+        # Enable debug mode
+        updated = source.enable_debug()
+        assert updated.is_debug_enabled is True
+
+        # Verify persisted
+        retrieved = live_client.auth_sources.get(test_auth_source.key)
+        assert retrieved.is_debug_enabled is True
+
+    def test_disable_debug_mode(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test disabling debug mode."""
+        # Enable first
+        source = live_client.auth_sources.get(test_auth_source.key)
+        source.enable_debug()
+
+        # Disable
+        updated = source.disable_debug()
+        assert updated.is_debug_enabled is False
+
+        # Verify persisted
+        retrieved = live_client.auth_sources.get(test_auth_source.key)
+        assert retrieved.is_debug_enabled is False
+
+    def test_update_debug_via_manager(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test updating debug mode via manager."""
+        # Enable via manager update
+        updated = live_client.auth_sources.update(test_auth_source.key, debug=True)
+        assert updated.is_debug_enabled is True
+
+        # Disable via manager update
+        updated = live_client.auth_sources.update(test_auth_source.key, debug=False)
+        assert updated.is_debug_enabled is False
+
+
+@pytest.mark.integration
+class TestAuthSourceStates:
+    """Integration tests for auth source state operations."""
+
+    def test_list_states_empty(self, live_client: VergeClient) -> None:
+        """Test listing states (usually empty since they're ephemeral)."""
+        states = live_client.auth_source_states.list()
+        assert isinstance(states, list)
+
+    def test_list_states_for_auth_source(self, live_client: VergeClient) -> None:
+        """Test listing states for a specific auth source."""
+        # Create a test auth source
+        source = live_client.auth_sources.create(
+            name="pytest_state_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "state-test-client",
+                "client_secret": "state-test-secret",
+            },
+        )
+
+        try:
+            # List states for this source (likely empty)
+            states = live_client.auth_source_states.list(auth_source=source.key)
+            assert isinstance(states, list)
+
+            # Also test via source object
+            scoped_states = source.states.list()
+            assert isinstance(scoped_states, list)
+        finally:
+            with contextlib.suppress(NotFoundError):
+                live_client.auth_sources.delete(source.key)
+
+    def test_states_scoped_manager(self, live_client: VergeClient) -> None:
+        """Test getting scoped state manager from auth source."""
+        # Create a test auth source
+        source = live_client.auth_sources.create(
+            name="pytest_scoped_state_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "scoped-test-client",
+                "client_secret": "scoped-test-secret",
+            },
+        )
+
+        try:
+            # Get scoped manager via manager method
+            scoped_mgr = live_client.auth_sources.states(source.key)
+            states = scoped_mgr.list()
+            assert isinstance(states, list)
+        finally:
+            with contextlib.suppress(NotFoundError):
+                live_client.auth_sources.delete(source.key)
+
+
+@pytest.mark.integration
+class TestAuthSourceRefresh:
+    """Integration tests for auth source refresh functionality."""
+
+    @pytest.fixture
+    def test_auth_source(self, live_client: VergeClient):
+        """Create a test auth source and cleanup afterwards."""
+        source = live_client.auth_sources.create(
+            name="pytest_refresh_test",
+            driver="openid-well-known",
+            settings={
+                "server_url": "https://example.com/.well-known/openid-configuration",
+                "client_id": "refresh-test-client",
+                "client_secret": "refresh-test-secret",
+            },
+        )
+        yield source
+        with contextlib.suppress(NotFoundError):
+            live_client.auth_sources.delete(source.key)
+
+    def test_refresh_auth_source(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test refreshing an auth source."""
+        # Update via manager
+        live_client.auth_sources.update(test_auth_source.key, name="pytest_refreshed_name")
+
+        # Original object still has old name
+        assert test_auth_source.name == "pytest_refresh_test"
+
+        # Refresh to get new data
+        refreshed = test_auth_source.refresh()
+        assert refreshed.name == "pytest_refreshed_name"
+
+    def test_save_auth_source(self, test_auth_source, live_client: VergeClient) -> None:
+        """Test saving changes via object method."""
+        updated = test_auth_source.save(name="pytest_saved_name")
+        assert updated.name == "pytest_saved_name"
+
+        # Verify persisted
+        retrieved = live_client.auth_sources.get(test_auth_source.key)
+        assert retrieved.name == "pytest_saved_name"

--- a/tests/integration/test_oidc_applications.py
+++ b/tests/integration/test_oidc_applications.py
@@ -1,0 +1,570 @@
+"""Integration tests for OIDC application operations."""
+
+import contextlib
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.oidc_applications import OidcApplication
+
+
+@pytest.mark.integration
+class TestOidcApplicationOperations:
+    """Integration tests for OIDC application operations against live VergeOS."""
+
+    def test_list_oidc_applications(self, live_client: VergeClient) -> None:
+        """Test listing OIDC applications."""
+        applications = live_client.oidc_applications.list()
+        assert isinstance(applications, list)
+
+        # If applications exist, verify structure
+        if len(applications) > 0:
+            app = applications[0]
+            assert "$key" in app
+            assert "name" in app
+
+    def test_list_oidc_applications_enabled_filter(self, live_client: VergeClient) -> None:
+        """Test listing OIDC applications filtered by enabled status."""
+        enabled_apps = live_client.oidc_applications.list(enabled=True)
+        assert isinstance(enabled_apps, list)
+
+        # All returned apps should be enabled
+        for app in enabled_apps:
+            assert app.is_enabled is True
+
+    def test_get_oidc_application_not_found(self, live_client: VergeClient) -> None:
+        """Test getting a non-existent OIDC application."""
+        with pytest.raises(NotFoundError):
+            live_client.oidc_applications.get(999999)
+
+    def test_get_oidc_application_by_name_not_found(self, live_client: VergeClient) -> None:
+        """Test getting a non-existent OIDC application by name."""
+        with pytest.raises(NotFoundError):
+            live_client.oidc_applications.get(name="NonexistentOidcApp12345")
+
+
+@pytest.mark.integration
+class TestOidcApplicationCRUD:
+    """Integration tests for OIDC application CRUD operations."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application for CRUD tests and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_test_oidc_app",
+            redirect_uri="https://pytest.example.com/callback",
+            description="PyTest integration test OIDC app",
+        )
+        yield app
+        # Cleanup
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_create_oidc_application(self, live_client: VergeClient) -> None:
+        """Test creating an OIDC application."""
+        app = live_client.oidc_applications.create(
+            name="pytest_create_test_oidc",
+            redirect_uri="https://pytest-create.example.com/callback",
+            description="Created by pytest",
+        )
+
+        try:
+            assert isinstance(app, OidcApplication)
+            assert app.name == "pytest_create_test_oidc"
+            assert app.is_enabled is True
+
+            # Should have auto-generated credentials
+            assert app.client_id is not None
+            assert len(app.client_id) > 0
+            assert app.client_secret is not None
+            assert len(app.client_secret) > 0
+
+            # Verify redirect URIs
+            assert "https://pytest-create.example.com/callback" in app.redirect_uris
+
+            # Verify application exists
+            retrieved = live_client.oidc_applications.get(app.key)
+            assert retrieved.name == "pytest_create_test_oidc"
+        finally:
+            live_client.oidc_applications.delete(app.key)
+
+    def test_create_oidc_application_multiple_redirects(self, live_client: VergeClient) -> None:
+        """Test creating an OIDC application with multiple redirect URIs."""
+        app = live_client.oidc_applications.create(
+            name="pytest_multi_redirect_oidc",
+            redirect_uri=[
+                "https://app1.example.com/callback",
+                "https://app2.example.com/callback",
+                "https://staging.example.com/callback",
+            ],
+        )
+
+        try:
+            uris = app.redirect_uris
+            assert len(uris) == 3
+            assert "https://app1.example.com/callback" in uris
+            assert "https://app2.example.com/callback" in uris
+            assert "https://staging.example.com/callback" in uris
+        finally:
+            live_client.oidc_applications.delete(app.key)
+
+    def test_create_oidc_application_with_scopes(self, live_client: VergeClient) -> None:
+        """Test creating an OIDC application with custom scopes."""
+        app = live_client.oidc_applications.create(
+            name="pytest_scopes_oidc",
+            redirect_uri="https://pytest-scopes.example.com/callback",
+            scope_profile=True,
+            scope_email=True,
+            scope_groups=False,
+        )
+
+        try:
+            scopes = app.scopes
+            assert "openid" in scopes  # Always included
+            assert "profile" in scopes
+            assert "email" in scopes
+            assert "groups" not in scopes
+        finally:
+            live_client.oidc_applications.delete(app.key)
+
+    def test_get_oidc_application_by_key(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test getting an OIDC application by key."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        assert app.key == test_oidc_app.key
+        assert app.name == "pytest_test_oidc_app"
+
+    def test_get_oidc_application_by_name(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test getting an OIDC application by name."""
+        app = live_client.oidc_applications.get(name="pytest_test_oidc_app")
+        assert app.key == test_oidc_app.key
+        assert app.name == "pytest_test_oidc_app"
+
+    def test_get_oidc_application_with_secret(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test getting an OIDC application with client secret."""
+        # Without include_secret, secret may be None
+        app = live_client.oidc_applications.get(test_oidc_app.key, include_secret=True)
+        assert app.client_secret is not None
+        assert len(app.client_secret) > 0
+
+    def test_get_oidc_application_with_well_known(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test getting an OIDC application with well-known configuration."""
+        app = live_client.oidc_applications.get(test_oidc_app.key, include_well_known=True)
+        # well_known_configuration may or may not be set depending on config
+        # Just verify we can access it
+        _ = app.well_known_configuration
+
+    def test_update_oidc_application(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test updating an OIDC application."""
+        updated = live_client.oidc_applications.update(
+            test_oidc_app.key,
+            name="pytest_updated_oidc_app",
+            description="Updated by pytest",
+        )
+
+        assert updated.name == "pytest_updated_oidc_app"
+        assert updated.description == "Updated by pytest"
+
+        # Verify change persisted
+        retrieved = live_client.oidc_applications.get(test_oidc_app.key)
+        assert retrieved.name == "pytest_updated_oidc_app"
+
+    def test_update_oidc_application_redirect_uri(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test updating OIDC application redirect URIs."""
+        updated = live_client.oidc_applications.update(
+            test_oidc_app.key,
+            redirect_uri="https://new-redirect.example.com/callback",
+        )
+
+        assert "https://new-redirect.example.com/callback" in updated.redirect_uris
+
+    def test_delete_oidc_application(self, live_client: VergeClient) -> None:
+        """Test deleting an OIDC application."""
+        app = live_client.oidc_applications.create(
+            name="pytest_delete_test_oidc",
+            redirect_uri="https://pytest-delete.example.com/callback",
+        )
+
+        # Delete
+        live_client.oidc_applications.delete(app.key)
+
+        # Verify deleted
+        with pytest.raises(NotFoundError):
+            live_client.oidc_applications.get(app.key)
+
+    def test_delete_via_object_method(self, live_client: VergeClient) -> None:
+        """Test deleting via OidcApplication.delete() method."""
+        app = live_client.oidc_applications.create(
+            name="pytest_obj_delete_oidc",
+            redirect_uri="https://pytest-objdel.example.com/callback",
+        )
+
+        # Delete via method
+        app.delete()
+
+        # Verify deleted
+        with pytest.raises(NotFoundError):
+            live_client.oidc_applications.get(app.key)
+
+
+@pytest.mark.integration
+class TestOidcApplicationProperties:
+    """Integration tests for OIDC application property access."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_props_test_oidc",
+            redirect_uri=[
+                "https://prop-test1.example.com/callback",
+                "https://prop-test2.example.com/callback",
+            ],
+            description="Property test OIDC app",
+            scope_profile=True,
+            scope_email=True,
+            scope_groups=True,
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_oidc_application_basic_properties(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test accessing basic properties on OIDC application."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+
+        assert isinstance(app, OidcApplication)
+        assert app.key == test_oidc_app.key
+        assert app.name == "pytest_props_test_oidc"
+        assert app.description == "Property test OIDC app"
+        assert app.is_enabled is True
+
+    def test_oidc_application_client_credentials(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test client credentials on OIDC application."""
+        app = live_client.oidc_applications.get(test_oidc_app.key, include_secret=True)
+
+        assert app.client_id is not None
+        assert len(app.client_id) > 0
+        assert app.client_secret is not None
+        assert len(app.client_secret) > 0
+
+    def test_oidc_application_redirect_uris(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test redirect URIs property."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+
+        uris = app.redirect_uris
+        assert isinstance(uris, list)
+        assert len(uris) == 2
+        assert "https://prop-test1.example.com/callback" in uris
+        assert "https://prop-test2.example.com/callback" in uris
+
+    def test_oidc_application_scopes(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test scopes property."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+
+        scopes = app.scopes
+        assert isinstance(scopes, list)
+        assert "openid" in scopes
+        assert "profile" in scopes
+        assert "email" in scopes
+        assert "groups" in scopes
+
+
+@pytest.mark.integration
+class TestOidcApplicationEnableDisable:
+    """Integration tests for OIDC application enable/disable."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_enable_test_oidc",
+            redirect_uri="https://enable-test.example.com/callback",
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_disable_oidc_application(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test disabling an OIDC application."""
+        # Verify initially enabled
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        assert app.is_enabled is True
+
+        # Disable
+        updated = app.disable()
+        assert updated.is_enabled is False
+
+        # Verify persisted
+        retrieved = live_client.oidc_applications.get(test_oidc_app.key)
+        assert retrieved.is_enabled is False
+
+    def test_enable_oidc_application(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test enabling an OIDC application."""
+        # Disable first
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        app.disable()
+
+        # Enable
+        updated = app.enable()
+        assert updated.is_enabled is True
+
+        # Verify persisted
+        retrieved = live_client.oidc_applications.get(test_oidc_app.key)
+        assert retrieved.is_enabled is True
+
+    def test_update_enabled_via_manager(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test updating enabled state via manager."""
+        # Disable via manager
+        updated = live_client.oidc_applications.update(test_oidc_app.key, enabled=False)
+        assert updated.is_enabled is False
+
+        # Enable via manager
+        updated = live_client.oidc_applications.update(test_oidc_app.key, enabled=True)
+        assert updated.is_enabled is True
+
+
+@pytest.mark.integration
+class TestOidcApplicationAccessControl:
+    """Integration tests for OIDC application access control."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application with access restriction."""
+        app = live_client.oidc_applications.create(
+            name="pytest_acl_test_oidc",
+            redirect_uri="https://acl-test.example.com/callback",
+            restrict_access=True,
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_oidc_application_restrict_access(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test that access restriction is enabled."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        assert app.is_access_restricted is True
+
+    def test_list_allowed_users_empty(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test listing allowed users (initially empty)."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        users = app.allowed_users.list()
+        assert isinstance(users, list)
+        assert len(users) == 0
+
+    def test_list_allowed_groups_empty(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test listing allowed groups (initially empty)."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        groups = app.allowed_groups.list()
+        assert isinstance(groups, list)
+        assert len(groups) == 0
+
+    def test_add_and_remove_allowed_user(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test adding and removing an allowed user."""
+        # Get admin user
+        admin = live_client.users.get(name="admin")
+
+        # Add user to allowed list
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        entry = app.allowed_users.add(user_key=admin.key)
+
+        try:
+            assert entry.user_key == admin.key
+
+            # Verify user in list
+            users = app.allowed_users.list()
+            assert len(users) == 1
+            assert users[0].user_key == admin.key
+        finally:
+            # Remove user
+            entry.delete()
+
+        # Verify removed
+        users = app.allowed_users.list()
+        assert len(users) == 0
+
+    def test_add_and_remove_allowed_group(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test adding and removing an allowed group."""
+        # Get groups
+        groups = live_client.groups.list(limit=1)
+        if len(groups) == 0:
+            pytest.skip("No groups exist to test with")
+
+        test_group = groups[0]
+
+        # Add group to allowed list
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        entry = app.allowed_groups.add(group_key=test_group.key)
+
+        try:
+            assert entry.group_key == test_group.key
+
+            # Verify group in list
+            allowed = app.allowed_groups.list()
+            assert len(allowed) == 1
+            assert allowed[0].group_key == test_group.key
+        finally:
+            # Remove group
+            entry.delete()
+
+        # Verify removed
+        allowed = app.allowed_groups.list()
+        assert len(allowed) == 0
+
+
+@pytest.mark.integration
+class TestOidcApplicationLogs:
+    """Integration tests for OIDC application log operations."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_log_test_oidc",
+            redirect_uri="https://log-test.example.com/callback",
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_list_application_logs(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test listing application logs."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        logs = app.logs.list()
+        assert isinstance(logs, list)
+
+    def test_list_application_logs_via_manager(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test listing application logs via manager."""
+        logs_mgr = live_client.oidc_applications.logs(test_oidc_app.key)
+        logs = logs_mgr.list()
+        assert isinstance(logs, list)
+
+    def test_list_errors_method(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test list_errors convenience method."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        errors = app.logs.list_errors()
+        assert isinstance(errors, list)
+
+    def test_list_warnings_method(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test list_warnings convenience method."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        warnings = app.logs.list_warnings()
+        assert isinstance(warnings, list)
+
+    def test_list_audits_method(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test list_audits convenience method."""
+        app = live_client.oidc_applications.get(test_oidc_app.key)
+        audits = app.logs.list_audits()
+        assert isinstance(audits, list)
+
+
+@pytest.mark.integration
+class TestOidcApplicationRefresh:
+    """Integration tests for OIDC application refresh functionality."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_refresh_test_oidc",
+            redirect_uri="https://refresh-test.example.com/callback",
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_refresh_oidc_application(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test refreshing an OIDC application."""
+        # Update via manager
+        live_client.oidc_applications.update(test_oidc_app.key, name="pytest_refreshed_oidc_name")
+
+        # Original object still has old name
+        assert test_oidc_app.name == "pytest_refresh_test_oidc"
+
+        # Refresh to get new data
+        refreshed = test_oidc_app.refresh()
+        assert refreshed.name == "pytest_refreshed_oidc_name"
+
+    def test_save_oidc_application(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test saving changes via object method."""
+        updated = test_oidc_app.save(
+            name="pytest_saved_oidc_name",
+            description="Saved via object method",
+        )
+        assert updated.name == "pytest_saved_oidc_name"
+        assert updated.description == "Saved via object method"
+
+        # Verify persisted
+        retrieved = live_client.oidc_applications.get(test_oidc_app.key)
+        assert retrieved.name == "pytest_saved_oidc_name"
+
+
+@pytest.mark.integration
+class TestOidcApplicationScopedManagers:
+    """Integration tests for scoped manager access patterns."""
+
+    @pytest.fixture
+    def test_oidc_app(self, live_client: VergeClient):
+        """Create a test OIDC application and cleanup afterwards."""
+        app = live_client.oidc_applications.create(
+            name="pytest_scoped_mgr_test",
+            redirect_uri="https://scoped-test.example.com/callback",
+            restrict_access=True,
+        )
+        yield app
+        with contextlib.suppress(NotFoundError):
+            live_client.oidc_applications.delete(app.key)
+
+    def test_allowed_users_via_manager_method(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test getting allowed users manager via manager method."""
+        mgr = live_client.oidc_applications.allowed_users(test_oidc_app.key)
+        users = mgr.list()
+        assert isinstance(users, list)
+
+    def test_allowed_groups_via_manager_method(
+        self, test_oidc_app, live_client: VergeClient
+    ) -> None:
+        """Test getting allowed groups manager via manager method."""
+        mgr = live_client.oidc_applications.allowed_groups(test_oidc_app.key)
+        groups = mgr.list()
+        assert isinstance(groups, list)
+
+    def test_logs_via_manager_method(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test getting logs manager via manager method."""
+        mgr = live_client.oidc_applications.logs(test_oidc_app.key)
+        logs = mgr.list()
+        assert isinstance(logs, list)
+
+    def test_global_user_manager_filtering(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test filtering global user manager by application."""
+        # Use global manager with filter
+        users = live_client.oidc_application_users.list(oidc_application=test_oidc_app.key)
+        assert isinstance(users, list)
+
+    def test_global_group_manager_filtering(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test filtering global group manager by application."""
+        # Use global manager with filter
+        groups = live_client.oidc_application_groups.list(oidc_application=test_oidc_app.key)
+        assert isinstance(groups, list)
+
+    def test_global_log_manager_filtering(self, test_oidc_app, live_client: VergeClient) -> None:
+        """Test filtering global log manager by application."""
+        # Use global manager with filter
+        logs = live_client.oidc_application_logs.list(oidc_application=test_oidc_app.key)
+        assert isinstance(logs, list)

--- a/tests/unit/test_auth_sources.py
+++ b/tests/unit/test_auth_sources.py
@@ -1,0 +1,565 @@
+"""Unit tests for authentication source resources."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.client import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.auth_sources import (
+    AuthSource,
+    AuthSourceManager,
+    AuthSourceState,
+    AuthSourceStateManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client.is_connected = True
+    return client
+
+
+# =============================================================================
+# AuthSourceStateManager Tests
+# =============================================================================
+
+
+class TestAuthSourceStateManager:
+    """Tests for AuthSourceStateManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = AuthSourceStateManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "auth_source_states"
+        assert manager._auth_source_key is None
+
+    def test_init_scoped(self, mock_client: MagicMock) -> None:
+        """Test scoped manager initialization."""
+        manager = AuthSourceStateManager(mock_client, auth_source_key=1)
+        assert manager._auth_source_key == 1
+
+    def test_list_returns_states(self, mock_client: MagicMock) -> None:
+        """Test listing states."""
+        mock_client._request.return_value = [
+            {"$key": "a" * 40, "state": "a" * 40, "auth_source": 1},
+            {"$key": "b" * 40, "state": "b" * 40, "auth_source": 1},
+        ]
+
+        manager = AuthSourceStateManager(mock_client)
+        states = manager.list()
+
+        assert len(states) == 2
+        assert isinstance(states[0], AuthSourceState)
+
+    def test_list_with_auth_source_filter(self, mock_client: MagicMock) -> None:
+        """Test listing with auth_source filter."""
+        mock_client._request.return_value = []
+
+        manager = AuthSourceStateManager(mock_client)
+        manager.list(auth_source=1)
+
+        call_args = mock_client._request.call_args
+        assert "auth_source eq 1" in call_args[1]["params"]["filter"]
+
+    def test_list_scoped_filters_by_auth_source(self, mock_client: MagicMock) -> None:
+        """Test scoped manager auto-filters by auth source."""
+        mock_client._request.return_value = []
+
+        manager = AuthSourceStateManager(mock_client, auth_source_key=5)
+        manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "auth_source eq 5" in call_args[1]["params"]["filter"]
+
+    def test_list_returns_empty_on_none(self, mock_client: MagicMock) -> None:
+        """Test listing returns empty list on None response."""
+        mock_client._request.return_value = None
+
+        manager = AuthSourceStateManager(mock_client)
+        states = manager.list()
+
+        assert states == []
+
+    def test_get_by_key(self, mock_client: MagicMock) -> None:
+        """Test getting state by key."""
+        state_key = "a" * 40
+        mock_client._request.return_value = [
+            {"$key": state_key, "state": state_key, "auth_source": 1},
+        ]
+
+        manager = AuthSourceStateManager(mock_client)
+        state = manager.get(key=state_key)
+
+        assert isinstance(state, AuthSourceState)
+        assert state.key == state_key
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        """Test get raises NotFoundError when not found."""
+        mock_client._request.return_value = []
+
+        manager = AuthSourceStateManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(key="nonexistent" + "0" * 30)
+
+    def test_get_requires_key(self, mock_client: MagicMock) -> None:
+        """Test get raises ValueError without key."""
+        manager = AuthSourceStateManager(mock_client)
+        with pytest.raises(ValueError, match="Key must be provided"):
+            manager.get()
+
+
+class TestAuthSourceState:
+    """Tests for AuthSourceState resource object."""
+
+    def test_key_property(self, mock_client: MagicMock) -> None:
+        """Test key property returns state."""
+        state_key = "a" * 40
+        manager = AuthSourceStateManager(mock_client)
+        state = AuthSourceState({"state": state_key}, manager)
+
+        assert state.key == state_key
+
+    def test_key_from_key_field(self, mock_client: MagicMock) -> None:
+        """Test key property falls back to $key."""
+        state_key = "a" * 40
+        manager = AuthSourceStateManager(mock_client)
+        state = AuthSourceState({"$key": state_key}, manager)
+
+        assert state.key == state_key
+
+    def test_key_raises_without_key(self, mock_client: MagicMock) -> None:
+        """Test key raises ValueError when not set."""
+        manager = AuthSourceStateManager(mock_client)
+        state = AuthSourceState({}, manager)
+
+        with pytest.raises(ValueError, match="State has no key"):
+            _ = state.key
+
+    def test_auth_source_key_property(self, mock_client: MagicMock) -> None:
+        """Test auth_source_key property."""
+        manager = AuthSourceStateManager(mock_client)
+        state = AuthSourceState({"auth_source": 5}, manager)
+
+        assert state.auth_source_key == 5
+
+    def test_is_expired_fresh(self, mock_client: MagicMock) -> None:
+        """Test is_expired returns False for fresh state."""
+        import time
+
+        manager = AuthSourceStateManager(mock_client)
+        # Timestamp in microseconds, now - 1 minute
+        ts = int((time.time() - 60) * 1_000_000)
+        state = AuthSourceState({"timestamp": ts}, manager)
+
+        assert state.is_expired is False
+
+    def test_is_expired_old(self, mock_client: MagicMock) -> None:
+        """Test is_expired returns True for old state."""
+        import time
+
+        manager = AuthSourceStateManager(mock_client)
+        # Timestamp in microseconds, now - 20 minutes (>15 min = expired)
+        ts = int((time.time() - 1200) * 1_000_000)
+        state = AuthSourceState({"timestamp": ts}, manager)
+
+        assert state.is_expired is True
+
+    def test_is_expired_no_timestamp(self, mock_client: MagicMock) -> None:
+        """Test is_expired returns True when no timestamp."""
+        manager = AuthSourceStateManager(mock_client)
+        state = AuthSourceState({}, manager)
+
+        assert state.is_expired is True
+
+
+# =============================================================================
+# AuthSourceManager Tests
+# =============================================================================
+
+
+class TestAuthSourceManager:
+    """Tests for AuthSourceManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = AuthSourceManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "auth_sources"
+
+    def test_list_returns_sources(self, mock_client: MagicMock) -> None:
+        """Test listing auth sources."""
+        mock_client._request.return_value = [
+            {"$key": 1, "name": "Azure AD", "driver": "azure"},
+            {"$key": 2, "name": "Google", "driver": "google"},
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        sources = manager.list()
+
+        assert len(sources) == 2
+        assert isinstance(sources[0], AuthSource)
+        assert sources[0]["name"] == "Azure AD"
+        assert sources[1]["driver"] == "google"
+
+    def test_list_with_driver_filter(self, mock_client: MagicMock) -> None:
+        """Test listing with driver filter."""
+        mock_client._request.return_value = [
+            {"$key": 1, "name": "Azure AD", "driver": "azure"},
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        manager.list(driver="azure")
+
+        call_args = mock_client._request.call_args
+        assert "driver eq 'azure'" in call_args[1]["params"]["filter"]
+
+    def test_list_returns_empty_on_none(self, mock_client: MagicMock) -> None:
+        """Test listing returns empty list on None response."""
+        mock_client._request.return_value = None
+
+        manager = AuthSourceManager(mock_client)
+        sources = manager.list()
+
+        assert sources == []
+
+    def test_get_by_key(self, mock_client: MagicMock) -> None:
+        """Test getting auth source by key."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "Azure AD",
+            "driver": "azure",
+        }
+
+        manager = AuthSourceManager(mock_client)
+        source = manager.get(key=1)
+
+        assert isinstance(source, AuthSource)
+        assert source.key == 1
+        assert source["name"] == "Azure AD"
+
+    def test_get_by_name(self, mock_client: MagicMock) -> None:
+        """Test getting auth source by name."""
+        mock_client._request.return_value = [
+            {"$key": 2, "name": "Google", "driver": "google"},
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        source = manager.get(name="Google")
+
+        assert source["name"] == "Google"
+
+    def test_get_with_include_settings(self, mock_client: MagicMock) -> None:
+        """Test get with include_settings includes settings field."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "Azure",
+            "settings": {"tenant_id": "abc"},
+        }
+
+        manager = AuthSourceManager(mock_client)
+        manager.get(key=1, include_settings=True)
+
+        call_args = mock_client._request.call_args
+        assert "settings" in call_args[1]["params"]["fields"]
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        """Test get raises NotFoundError when not found."""
+        mock_client._request.return_value = None
+
+        manager = AuthSourceManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(key=999)
+
+    def test_get_requires_identifier(self, mock_client: MagicMock) -> None:
+        """Test get raises ValueError without identifier."""
+        manager = AuthSourceManager(mock_client)
+        with pytest.raises(ValueError, match="Either key or name"):
+            manager.get()
+
+    def test_create_auth_source(self, mock_client: MagicMock) -> None:
+        """Test creating an auth source."""
+        mock_client._request.side_effect = [
+            {"$key": 3},  # POST response
+            {"$key": 3, "name": "Test", "driver": "google"},  # GET response
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        source = manager.create(
+            name="Test",
+            driver="google",
+            settings={"client_id": "test-id"},
+        )
+
+        assert source.key == 3
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call[0] == ("POST", "auth_sources")
+        body = post_call[1]["json_data"]
+        assert body["name"] == "Test"
+        assert body["driver"] == "google"
+        assert body["settings"]["client_id"] == "test-id"
+
+    def test_create_with_styling(self, mock_client: MagicMock) -> None:
+        """Test creating with button styling."""
+        mock_client._request.side_effect = [
+            {"$key": 3},
+            {"$key": 3, "name": "Google", "driver": "google"},
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        manager.create(
+            name="Google",
+            driver="google",
+            button_background_color="#4285F4",
+            button_color="#ffffff",
+            button_fa_icon="bi-google",
+            icon_color="#ffffff",
+        )
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        assert body["button_background_color"] == "#4285F4"
+        assert body["button_color"] == "#ffffff"
+        assert body["button_fa_icon"] == "bi-google"
+        assert body["icon_color"] == "#ffffff"
+
+    def test_update_auth_source(self, mock_client: MagicMock) -> None:
+        """Test updating an auth source."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {"$key": 1, "name": "Updated", "driver": "google"},  # GET response
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        manager.update(key=1, name="Updated", debug=True)
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[0] == ("PUT", "auth_sources/1")
+        body = put_call[1]["json_data"]
+        assert body["name"] == "Updated"
+        assert body["debug"] is True
+
+    def test_update_no_changes(self, mock_client: MagicMock) -> None:
+        """Test update with no changes returns current source."""
+        mock_client._request.return_value = {"$key": 1, "name": "Test"}
+
+        manager = AuthSourceManager(mock_client)
+        manager.update(key=1)
+
+        mock_client._request.assert_called_once()
+        assert mock_client._request.call_args[0][0] == "GET"
+
+    def test_delete_auth_source(self, mock_client: MagicMock) -> None:
+        """Test deleting an auth source."""
+        mock_client._request.return_value = None
+
+        manager = AuthSourceManager(mock_client)
+        manager.delete(key=1)
+
+        mock_client._request.assert_called_once_with("DELETE", "auth_sources/1")
+
+    def test_states_returns_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test states() returns scoped AuthSourceStateManager."""
+        manager = AuthSourceManager(mock_client)
+        state_mgr = manager.states(key=5)
+
+        assert isinstance(state_mgr, AuthSourceStateManager)
+        assert state_mgr._auth_source_key == 5
+
+
+class TestAuthSource:
+    """Tests for AuthSource resource object."""
+
+    def test_driver_property(self, mock_client: MagicMock) -> None:
+        """Test driver property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "azure"}, manager)
+
+        assert source.driver == "azure"
+
+    def test_is_azure(self, mock_client: MagicMock) -> None:
+        """Test is_azure property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "azure"}, manager)
+
+        assert source.is_azure is True
+        assert source.is_google is False
+
+    def test_is_google(self, mock_client: MagicMock) -> None:
+        """Test is_google property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "google"}, manager)
+
+        assert source.is_google is True
+        assert source.is_azure is False
+
+    def test_is_gitlab(self, mock_client: MagicMock) -> None:
+        """Test is_gitlab property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "gitlab"}, manager)
+
+        assert source.is_gitlab is True
+
+    def test_is_okta(self, mock_client: MagicMock) -> None:
+        """Test is_okta property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "okta"}, manager)
+
+        assert source.is_okta is True
+
+    def test_is_openid(self, mock_client: MagicMock) -> None:
+        """Test is_openid property."""
+        manager = AuthSourceManager(mock_client)
+
+        source1 = AuthSource({"driver": "openid"}, manager)
+        assert source1.is_openid is True
+
+        source2 = AuthSource({"driver": "openid-well-known"}, manager)
+        assert source2.is_openid is True
+
+    def test_is_oauth2(self, mock_client: MagicMock) -> None:
+        """Test is_oauth2 property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "oauth2"}, manager)
+
+        assert source.is_oauth2 is True
+
+    def test_is_vergeos(self, mock_client: MagicMock) -> None:
+        """Test is_vergeos property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"driver": "verge.io"}, manager)
+
+        assert source.is_vergeos is True
+
+    def test_settings_property(self, mock_client: MagicMock) -> None:
+        """Test settings property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource(
+            {"settings": {"client_id": "abc", "tenant_id": "xyz"}},
+            manager,
+        )
+
+        assert source.settings == {"client_id": "abc", "tenant_id": "xyz"}
+
+    def test_settings_empty(self, mock_client: MagicMock) -> None:
+        """Test settings returns empty dict when not set."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({}, manager)
+
+        assert source.settings == {}
+
+    def test_is_debug_enabled(self, mock_client: MagicMock) -> None:
+        """Test is_debug_enabled property."""
+        manager = AuthSourceManager(mock_client)
+
+        source1 = AuthSource({"debug": True}, manager)
+        assert source1.is_debug_enabled is True
+
+        source2 = AuthSource({"debug": False}, manager)
+        assert source2.is_debug_enabled is False
+
+    def test_is_menu(self, mock_client: MagicMock) -> None:
+        """Test is_menu property."""
+        manager = AuthSourceManager(mock_client)
+
+        source1 = AuthSource({"menu": True}, manager)
+        assert source1.is_menu is True
+
+        source2 = AuthSource({"menu": False}, manager)
+        assert source2.is_menu is False
+
+    def test_button_style(self, mock_client: MagicMock) -> None:
+        """Test button_style property."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource(
+            {
+                "button_background_color": "#4285F4",
+                "button_color": "#fff",
+                "button_fa_icon": "bi-google",
+                "icon_color": "#fff",
+            },
+            manager,
+        )
+
+        style = source.button_style
+        assert style["background_color"] == "#4285F4"
+        assert style["text_color"] == "#fff"
+        assert style["icon"] == "bi-google"
+        assert style["icon_color"] == "#fff"
+
+    def test_states_property(self, mock_client: MagicMock) -> None:
+        """Test states property returns scoped manager."""
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 5}, manager)
+
+        state_mgr = source.states
+        assert isinstance(state_mgr, AuthSourceStateManager)
+        assert state_mgr._auth_source_key == 5
+
+    def test_enable_debug(self, mock_client: MagicMock) -> None:
+        """Test enable_debug calls update."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "debug": True},  # GET
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 1}, manager)
+        result = source.enable_debug()
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["debug"] is True
+        assert result["debug"] is True
+
+    def test_disable_debug(self, mock_client: MagicMock) -> None:
+        """Test disable_debug calls update."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "debug": False},  # GET
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 1, "debug": True}, manager)
+        result = source.disable_debug()
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["debug"] is False
+        assert result["debug"] is False
+
+    def test_refresh(self, mock_client: MagicMock) -> None:
+        """Test refresh reloads from API."""
+        mock_client._request.return_value = {"$key": 1, "name": "Updated"}
+
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 1, "name": "Old"}, manager)
+        refreshed = source.refresh()
+
+        assert refreshed["name"] == "Updated"
+
+    def test_save(self, mock_client: MagicMock) -> None:
+        """Test save calls update."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "name": "New Name"},  # GET
+        ]
+
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 1, "name": "Old"}, manager)
+        result = source.save(name="New Name")
+
+        assert result["name"] == "New Name"
+
+    def test_delete(self, mock_client: MagicMock) -> None:
+        """Test delete."""
+        mock_client._request.return_value = None
+
+        manager = AuthSourceManager(mock_client)
+        source = AuthSource({"$key": 1}, manager)
+        source.delete()
+
+        mock_client._request.assert_called_once_with("DELETE", "auth_sources/1")

--- a/tests/unit/test_oidc_applications.py
+++ b/tests/unit/test_oidc_applications.py
@@ -1,0 +1,852 @@
+"""Unit tests for OIDC application resources."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.client import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.oidc_applications import (
+    OidcApplication,
+    OidcApplicationGroup,
+    OidcApplicationGroupManager,
+    OidcApplicationLog,
+    OidcApplicationLogManager,
+    OidcApplicationManager,
+    OidcApplicationUser,
+    OidcApplicationUserManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock(spec=VergeClient)
+    client.is_connected = True
+    return client
+
+
+# =============================================================================
+# OidcApplicationUserManager Tests
+# =============================================================================
+
+
+class TestOidcApplicationUserManager:
+    """Tests for OidcApplicationUserManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = OidcApplicationUserManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "oidc_application_users"
+        assert manager._application_key is None
+
+    def test_init_scoped(self, mock_client: MagicMock) -> None:
+        """Test scoped manager initialization."""
+        manager = OidcApplicationUserManager(mock_client, application_key=1)
+        assert manager._application_key == 1
+
+    def test_list_returns_users(self, mock_client: MagicMock) -> None:
+        """Test listing users."""
+        mock_client._request.return_value = [
+            {"$key": 1, "oidc_application": 1, "user": 10, "user_display": "admin"},
+            {"$key": 2, "oidc_application": 1, "user": 20, "user_display": "user1"},
+        ]
+
+        manager = OidcApplicationUserManager(mock_client)
+        users = manager.list()
+
+        assert len(users) == 2
+        assert isinstance(users[0], OidcApplicationUser)
+        assert users[0]["user_display"] == "admin"
+
+    def test_list_with_application_filter(self, mock_client: MagicMock) -> None:
+        """Test listing with application filter."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationUserManager(mock_client)
+        manager.list(oidc_application=5)
+
+        call_args = mock_client._request.call_args
+        assert "oidc_application eq 5" in call_args[1]["params"]["filter"]
+
+    def test_list_scoped_filters_by_application(self, mock_client: MagicMock) -> None:
+        """Test scoped manager auto-filters by application."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationUserManager(mock_client, application_key=3)
+        manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "oidc_application eq 3" in call_args[1]["params"]["filter"]
+
+    def test_get_by_key(self, mock_client: MagicMock) -> None:
+        """Test getting user ACL entry by key."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "oidc_application": 1,
+            "user": 10,
+        }
+
+        manager = OidcApplicationUserManager(mock_client)
+        entry = manager.get(key=1)
+
+        assert isinstance(entry, OidcApplicationUser)
+        assert entry.key == 1
+
+    def test_get_requires_key(self, mock_client: MagicMock) -> None:
+        """Test get raises ValueError without key."""
+        manager = OidcApplicationUserManager(mock_client)
+        with pytest.raises(ValueError, match="Key must be provided"):
+            manager.get()
+
+    def test_add_user(self, mock_client: MagicMock) -> None:
+        """Test adding a user."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # POST response
+            {"$key": 1, "oidc_application": 1, "user": 10},  # GET response
+        ]
+
+        manager = OidcApplicationUserManager(mock_client, application_key=1)
+        entry = manager.add(user_key=10)
+
+        assert entry.key == 1
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call[0] == ("POST", "oidc_application_users")
+        body = post_call[1]["json_data"]
+        assert body["oidc_application"] == 1
+        assert body["user"] == 10
+
+    def test_add_requires_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test add raises ValueError without scoped manager."""
+        manager = OidcApplicationUserManager(mock_client)
+        with pytest.raises(ValueError, match="Manager must be scoped"):
+            manager.add(user_key=10)
+
+    def test_delete_user(self, mock_client: MagicMock) -> None:
+        """Test deleting a user ACL entry."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationUserManager(mock_client)
+        manager.delete(key=1)
+
+        mock_client._request.assert_called_once_with("DELETE", "oidc_application_users/1")
+
+
+class TestOidcApplicationUser:
+    """Tests for OidcApplicationUser resource object."""
+
+    def test_application_key_property(self, mock_client: MagicMock) -> None:
+        """Test application_key property."""
+        manager = OidcApplicationUserManager(mock_client)
+        entry = OidcApplicationUser({"oidc_application": 5}, manager)
+
+        assert entry.application_key == 5
+
+    def test_user_key_property(self, mock_client: MagicMock) -> None:
+        """Test user_key property."""
+        manager = OidcApplicationUserManager(mock_client)
+        entry = OidcApplicationUser({"user": 10}, manager)
+
+        assert entry.user_key == 10
+
+    def test_user_display_property(self, mock_client: MagicMock) -> None:
+        """Test user_display property."""
+        manager = OidcApplicationUserManager(mock_client)
+        entry = OidcApplicationUser({"user_display": "admin"}, manager)
+
+        assert entry.user_display == "admin"
+
+    def test_delete(self, mock_client: MagicMock) -> None:
+        """Test delete method."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationUserManager(mock_client)
+        entry = OidcApplicationUser({"$key": 1}, manager)
+        entry.delete()
+
+        mock_client._request.assert_called_once_with("DELETE", "oidc_application_users/1")
+
+
+# =============================================================================
+# OidcApplicationGroupManager Tests
+# =============================================================================
+
+
+class TestOidcApplicationGroupManager:
+    """Tests for OidcApplicationGroupManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = OidcApplicationGroupManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "oidc_application_groups"
+        assert manager._application_key is None
+
+    def test_init_scoped(self, mock_client: MagicMock) -> None:
+        """Test scoped manager initialization."""
+        manager = OidcApplicationGroupManager(mock_client, application_key=1)
+        assert manager._application_key == 1
+
+    def test_list_returns_groups(self, mock_client: MagicMock) -> None:
+        """Test listing groups."""
+        mock_client._request.return_value = [
+            {"$key": 1, "oidc_application": 1, "group": 10, "group_display": "admins"},
+            {"$key": 2, "oidc_application": 1, "group": 20, "group_display": "users"},
+        ]
+
+        manager = OidcApplicationGroupManager(mock_client)
+        groups = manager.list()
+
+        assert len(groups) == 2
+        assert isinstance(groups[0], OidcApplicationGroup)
+        assert groups[0]["group_display"] == "admins"
+
+    def test_list_scoped_filters_by_application(self, mock_client: MagicMock) -> None:
+        """Test scoped manager auto-filters by application."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationGroupManager(mock_client, application_key=3)
+        manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "oidc_application eq 3" in call_args[1]["params"]["filter"]
+
+    def test_add_group(self, mock_client: MagicMock) -> None:
+        """Test adding a group."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # POST response
+            {"$key": 1, "oidc_application": 1, "group": 10},  # GET response
+        ]
+
+        manager = OidcApplicationGroupManager(mock_client, application_key=1)
+        entry = manager.add(group_key=10)
+
+        assert entry.key == 1
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        assert body["oidc_application"] == 1
+        assert body["group"] == 10
+
+    def test_add_requires_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test add raises ValueError without scoped manager."""
+        manager = OidcApplicationGroupManager(mock_client)
+        with pytest.raises(ValueError, match="Manager must be scoped"):
+            manager.add(group_key=10)
+
+
+class TestOidcApplicationGroup:
+    """Tests for OidcApplicationGroup resource object."""
+
+    def test_application_key_property(self, mock_client: MagicMock) -> None:
+        """Test application_key property."""
+        manager = OidcApplicationGroupManager(mock_client)
+        entry = OidcApplicationGroup({"oidc_application": 5}, manager)
+
+        assert entry.application_key == 5
+
+    def test_group_key_property(self, mock_client: MagicMock) -> None:
+        """Test group_key property."""
+        manager = OidcApplicationGroupManager(mock_client)
+        entry = OidcApplicationGroup({"group": 10}, manager)
+
+        assert entry.group_key == 10
+
+    def test_group_display_property(self, mock_client: MagicMock) -> None:
+        """Test group_display property."""
+        manager = OidcApplicationGroupManager(mock_client)
+        entry = OidcApplicationGroup({"group_display": "admins"}, manager)
+
+        assert entry.group_display == "admins"
+
+
+# =============================================================================
+# OidcApplicationLogManager Tests
+# =============================================================================
+
+
+class TestOidcApplicationLogManager:
+    """Tests for OidcApplicationLogManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = OidcApplicationLogManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "oidc_application_logs"
+        assert manager._application_key is None
+
+    def test_init_scoped(self, mock_client: MagicMock) -> None:
+        """Test scoped manager initialization."""
+        manager = OidcApplicationLogManager(mock_client, application_key=1)
+        assert manager._application_key == 1
+
+    def test_list_returns_logs(self, mock_client: MagicMock) -> None:
+        """Test listing logs."""
+        mock_client._request.return_value = [
+            {"$key": 1, "level": "audit", "text": "Created"},
+            {"$key": 2, "level": "error", "text": "Failed"},
+        ]
+
+        manager = OidcApplicationLogManager(mock_client)
+        logs = manager.list()
+
+        assert len(logs) == 2
+        assert isinstance(logs[0], OidcApplicationLog)
+
+    def test_list_with_level_filter(self, mock_client: MagicMock) -> None:
+        """Test listing with level filter."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationLogManager(mock_client)
+        manager.list(level="error")
+
+        call_args = mock_client._request.call_args
+        assert "level eq 'error'" in call_args[1]["params"]["filter"]
+
+    def test_list_errors(self, mock_client: MagicMock) -> None:
+        """Test list_errors helper."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationLogManager(mock_client)
+        manager.list_errors()
+
+        call_args = mock_client._request.call_args
+        filter_str = call_args[1]["params"]["filter"]
+        assert "level eq 'error'" in filter_str or "level eq 'critical'" in filter_str
+
+    def test_list_warnings(self, mock_client: MagicMock) -> None:
+        """Test list_warnings helper."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationLogManager(mock_client)
+        manager.list_warnings()
+
+        call_args = mock_client._request.call_args
+        assert "level eq 'warning'" in call_args[1]["params"]["filter"]
+
+    def test_list_audits(self, mock_client: MagicMock) -> None:
+        """Test list_audits helper."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationLogManager(mock_client)
+        manager.list_audits()
+
+        call_args = mock_client._request.call_args
+        assert "level eq 'audit'" in call_args[1]["params"]["filter"]
+
+
+class TestOidcApplicationLog:
+    """Tests for OidcApplicationLog resource object."""
+
+    def test_application_key_property(self, mock_client: MagicMock) -> None:
+        """Test application_key property."""
+        manager = OidcApplicationLogManager(mock_client)
+        log = OidcApplicationLog({"oidc_application": 5}, manager)
+
+        assert log.application_key == 5
+
+    def test_is_error(self, mock_client: MagicMock) -> None:
+        """Test is_error property."""
+        manager = OidcApplicationLogManager(mock_client)
+
+        log1 = OidcApplicationLog({"level": "error"}, manager)
+        assert log1.is_error is True
+
+        log2 = OidcApplicationLog({"level": "critical"}, manager)
+        assert log2.is_error is True
+
+        log3 = OidcApplicationLog({"level": "warning"}, manager)
+        assert log3.is_error is False
+
+    def test_is_warning(self, mock_client: MagicMock) -> None:
+        """Test is_warning property."""
+        manager = OidcApplicationLogManager(mock_client)
+
+        log1 = OidcApplicationLog({"level": "warning"}, manager)
+        assert log1.is_warning is True
+
+        log2 = OidcApplicationLog({"level": "error"}, manager)
+        assert log2.is_warning is False
+
+    def test_is_audit(self, mock_client: MagicMock) -> None:
+        """Test is_audit property."""
+        manager = OidcApplicationLogManager(mock_client)
+
+        log1 = OidcApplicationLog({"level": "audit"}, manager)
+        assert log1.is_audit is True
+
+        log2 = OidcApplicationLog({"level": "message"}, manager)
+        assert log2.is_audit is False
+
+
+# =============================================================================
+# OidcApplicationManager Tests
+# =============================================================================
+
+
+class TestOidcApplicationManager:
+    """Tests for OidcApplicationManager."""
+
+    def test_init(self, mock_client: MagicMock) -> None:
+        """Test manager initialization."""
+        manager = OidcApplicationManager(mock_client)
+        assert manager._client == mock_client
+        assert manager._endpoint == "oidc_applications"
+
+    def test_list_returns_applications(self, mock_client: MagicMock) -> None:
+        """Test listing applications."""
+        mock_client._request.return_value = [
+            {"$key": 1, "name": "Tenant Portal", "enabled": True},
+            {"$key": 2, "name": "Partner Portal", "enabled": True},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        apps = manager.list()
+
+        assert len(apps) == 2
+        assert isinstance(apps[0], OidcApplication)
+        assert apps[0]["name"] == "Tenant Portal"
+
+    def test_list_with_enabled_filter(self, mock_client: MagicMock) -> None:
+        """Test listing with enabled filter."""
+        mock_client._request.return_value = []
+
+        manager = OidcApplicationManager(mock_client)
+        manager.list(enabled=True)
+
+        call_args = mock_client._request.call_args
+        assert "enabled eq 1" in call_args[1]["params"]["filter"]
+
+    def test_list_returns_empty_on_none(self, mock_client: MagicMock) -> None:
+        """Test listing returns empty list on None response."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationManager(mock_client)
+        apps = manager.list()
+
+        assert apps == []
+
+    def test_get_by_key(self, mock_client: MagicMock) -> None:
+        """Test getting application by key."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "Tenant Portal",
+            "client_id": "abc123",
+        }
+
+        manager = OidcApplicationManager(mock_client)
+        app = manager.get(key=1)
+
+        assert isinstance(app, OidcApplication)
+        assert app.key == 1
+        assert app["name"] == "Tenant Portal"
+
+    def test_get_by_name(self, mock_client: MagicMock) -> None:
+        """Test getting application by name."""
+        mock_client._request.return_value = [
+            {"$key": 2, "name": "Partner Portal"},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        app = manager.get(name="Partner Portal")
+
+        assert app["name"] == "Partner Portal"
+
+    def test_get_with_include_secret(self, mock_client: MagicMock) -> None:
+        """Test get with include_secret includes client_secret field."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "Test",
+            "client_secret": "secret123",
+        }
+
+        manager = OidcApplicationManager(mock_client)
+        manager.get(key=1, include_secret=True)
+
+        call_args = mock_client._request.call_args
+        assert "client_secret" in call_args[1]["params"]["fields"]
+
+    def test_get_with_include_well_known(self, mock_client: MagicMock) -> None:
+        """Test get with include_well_known includes well_known_configuration."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "Test",
+            "well_known_configuration": "https://example.com/.well-known/openid-configuration",
+        }
+
+        manager = OidcApplicationManager(mock_client)
+        manager.get(key=1, include_well_known=True)
+
+        call_args = mock_client._request.call_args
+        assert "well_known_configuration" in call_args[1]["params"]["fields"]
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        """Test get raises NotFoundError when not found."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(key=999)
+
+    def test_get_requires_identifier(self, mock_client: MagicMock) -> None:
+        """Test get raises ValueError without identifier."""
+        manager = OidcApplicationManager(mock_client)
+        with pytest.raises(ValueError, match="Either key or name"):
+            manager.get()
+
+    def test_create_application(self, mock_client: MagicMock) -> None:
+        """Test creating an application."""
+        mock_client._request.side_effect = [
+            {"$key": 3},  # POST response
+            {"$key": 3, "name": "Test", "client_id": "abc", "client_secret": "xyz"},  # GET
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        app = manager.create(
+            name="Test",
+            redirect_uri="https://example.com/callback",
+            description="Test app",
+        )
+
+        assert app.key == 3
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call[0] == ("POST", "oidc_applications")
+        body = post_call[1]["json_data"]
+        assert body["name"] == "Test"
+        assert body["redirect_uri"] == "https://example.com/callback"
+        assert body["description"] == "Test app"
+
+    def test_create_with_list_redirect_uri(self, mock_client: MagicMock) -> None:
+        """Test creating with list of redirect URIs."""
+        mock_client._request.side_effect = [
+            {"$key": 3},
+            {"$key": 3, "name": "Test"},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        manager.create(
+            name="Test",
+            redirect_uri=[
+                "https://example.com/callback",
+                "https://staging.example.com/callback",
+            ],
+        )
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        expected = "https://example.com/callback\nhttps://staging.example.com/callback"
+        assert body["redirect_uri"] == expected
+
+    def test_create_with_scopes(self, mock_client: MagicMock) -> None:
+        """Test creating with scope settings."""
+        mock_client._request.side_effect = [
+            {"$key": 3},
+            {"$key": 3, "name": "Test"},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        manager.create(
+            name="Test",
+            scope_profile=True,
+            scope_email=True,
+            scope_groups=False,
+        )
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        assert body["scope_profile"] is True
+        assert body["scope_email"] is True
+        assert body["scope_groups"] is False
+
+    def test_create_with_restrict_access(self, mock_client: MagicMock) -> None:
+        """Test creating with access restriction."""
+        mock_client._request.side_effect = [
+            {"$key": 3},
+            {"$key": 3, "name": "Test", "restrict_access": True},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        manager.create(
+            name="Test",
+            restrict_access=True,
+        )
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        assert body["restrict_access"] is True
+
+    def test_update_application(self, mock_client: MagicMock) -> None:
+        """Test updating an application."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {"$key": 1, "name": "Updated"},  # GET response
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        manager.update(key=1, name="Updated", enabled=False)
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[0] == ("PUT", "oidc_applications/1")
+        body = put_call[1]["json_data"]
+        assert body["name"] == "Updated"
+        assert body["enabled"] is False
+
+    def test_update_redirect_uri_list(self, mock_client: MagicMock) -> None:
+        """Test updating with list of redirect URIs."""
+        mock_client._request.side_effect = [
+            None,
+            {"$key": 1},
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        manager.update(
+            key=1,
+            redirect_uri=["https://new.example.com/callback"],
+        )
+
+        put_call = mock_client._request.call_args_list[0]
+        body = put_call[1]["json_data"]
+        assert body["redirect_uri"] == "https://new.example.com/callback"
+
+    def test_update_no_changes(self, mock_client: MagicMock) -> None:
+        """Test update with no changes returns current app."""
+        mock_client._request.return_value = {"$key": 1, "name": "Test"}
+
+        manager = OidcApplicationManager(mock_client)
+        manager.update(key=1)
+
+        mock_client._request.assert_called_once()
+        assert mock_client._request.call_args[0][0] == "GET"
+
+    def test_delete_application(self, mock_client: MagicMock) -> None:
+        """Test deleting an application."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationManager(mock_client)
+        manager.delete(key=1)
+
+        mock_client._request.assert_called_once_with("DELETE", "oidc_applications/1")
+
+    def test_allowed_users_returns_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test allowed_users returns scoped OidcApplicationUserManager."""
+        manager = OidcApplicationManager(mock_client)
+        user_mgr = manager.allowed_users(key=5)
+
+        assert isinstance(user_mgr, OidcApplicationUserManager)
+        assert user_mgr._application_key == 5
+
+    def test_allowed_groups_returns_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test allowed_groups returns scoped OidcApplicationGroupManager."""
+        manager = OidcApplicationManager(mock_client)
+        group_mgr = manager.allowed_groups(key=5)
+
+        assert isinstance(group_mgr, OidcApplicationGroupManager)
+        assert group_mgr._application_key == 5
+
+    def test_logs_returns_scoped_manager(self, mock_client: MagicMock) -> None:
+        """Test logs returns scoped OidcApplicationLogManager."""
+        manager = OidcApplicationManager(mock_client)
+        log_mgr = manager.logs(key=5)
+
+        assert isinstance(log_mgr, OidcApplicationLogManager)
+        assert log_mgr._application_key == 5
+
+
+class TestOidcApplication:
+    """Tests for OidcApplication resource object."""
+
+    def test_client_id_property(self, mock_client: MagicMock) -> None:
+        """Test client_id property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"client_id": "abc123"}, manager)
+
+        assert app.client_id == "abc123"
+
+    def test_client_secret_property(self, mock_client: MagicMock) -> None:
+        """Test client_secret property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"client_secret": "xyz789"}, manager)
+
+        assert app.client_secret == "xyz789"
+
+    def test_is_enabled(self, mock_client: MagicMock) -> None:
+        """Test is_enabled property."""
+        manager = OidcApplicationManager(mock_client)
+
+        app1 = OidcApplication({"enabled": True}, manager)
+        assert app1.is_enabled is True
+
+        app2 = OidcApplication({"enabled": False}, manager)
+        assert app2.is_enabled is False
+
+    def test_is_access_restricted(self, mock_client: MagicMock) -> None:
+        """Test is_access_restricted property."""
+        manager = OidcApplicationManager(mock_client)
+
+        app1 = OidcApplication({"restrict_access": True}, manager)
+        assert app1.is_access_restricted is True
+
+        app2 = OidcApplication({"restrict_access": False}, manager)
+        assert app2.is_access_restricted is False
+
+    def test_redirect_uris(self, mock_client: MagicMock) -> None:
+        """Test redirect_uris property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication(
+            {"redirect_uri": "https://a.com/cb\nhttps://b.com/cb"},
+            manager,
+        )
+
+        uris = app.redirect_uris
+        assert len(uris) == 2
+        assert "https://a.com/cb" in uris
+        assert "https://b.com/cb" in uris
+
+    def test_redirect_uris_empty(self, mock_client: MagicMock) -> None:
+        """Test redirect_uris returns empty list when not set."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({}, manager)
+
+        assert app.redirect_uris == []
+
+    def test_well_known_configuration(self, mock_client: MagicMock) -> None:
+        """Test well_known_configuration property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication(
+            {"well_known_configuration": "https://example.com/.well-known"},
+            manager,
+        )
+
+        assert app.well_known_configuration == "https://example.com/.well-known"
+
+    def test_scopes(self, mock_client: MagicMock) -> None:
+        """Test scopes property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication(
+            {"scope_profile": True, "scope_email": True, "scope_groups": False},
+            manager,
+        )
+
+        scopes = app.scopes
+        assert "openid" in scopes
+        assert "profile" in scopes
+        assert "email" in scopes
+        assert "groups" not in scopes
+
+    def test_scopes_all_enabled(self, mock_client: MagicMock) -> None:
+        """Test scopes with all enabled."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication(
+            {"scope_profile": True, "scope_email": True, "scope_groups": True},
+            manager,
+        )
+
+        scopes = app.scopes
+        assert len(scopes) == 4
+        assert set(scopes) == {"openid", "profile", "email", "groups"}
+
+    def test_force_auth_source_key(self, mock_client: MagicMock) -> None:
+        """Test force_auth_source_key property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"force_auth_source": 5}, manager)
+
+        assert app.force_auth_source_key == 5
+
+    def test_map_user_key(self, mock_client: MagicMock) -> None:
+        """Test map_user_key property."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"map_user": 10}, manager)
+
+        assert app.map_user_key == 10
+
+    def test_allowed_users_property(self, mock_client: MagicMock) -> None:
+        """Test allowed_users property returns scoped manager."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 5}, manager)
+
+        user_mgr = app.allowed_users
+        assert isinstance(user_mgr, OidcApplicationUserManager)
+        assert user_mgr._application_key == 5
+
+    def test_allowed_groups_property(self, mock_client: MagicMock) -> None:
+        """Test allowed_groups property returns scoped manager."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 5}, manager)
+
+        group_mgr = app.allowed_groups
+        assert isinstance(group_mgr, OidcApplicationGroupManager)
+        assert group_mgr._application_key == 5
+
+    def test_logs_property(self, mock_client: MagicMock) -> None:
+        """Test logs property returns scoped manager."""
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 5}, manager)
+
+        log_mgr = app.logs
+        assert isinstance(log_mgr, OidcApplicationLogManager)
+        assert log_mgr._application_key == 5
+
+    def test_enable(self, mock_client: MagicMock) -> None:
+        """Test enable method."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "enabled": True},  # GET
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 1, "enabled": False}, manager)
+        result = app.enable()
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["enabled"] is True
+        assert result["enabled"] is True
+
+    def test_disable(self, mock_client: MagicMock) -> None:
+        """Test disable method."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "enabled": False},  # GET
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 1, "enabled": True}, manager)
+        result = app.disable()
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["enabled"] is False
+        assert result["enabled"] is False
+
+    def test_refresh(self, mock_client: MagicMock) -> None:
+        """Test refresh reloads from API."""
+        mock_client._request.return_value = {"$key": 1, "name": "Updated"}
+
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 1, "name": "Old"}, manager)
+        refreshed = app.refresh()
+
+        assert refreshed["name"] == "Updated"
+
+    def test_save(self, mock_client: MagicMock) -> None:
+        """Test save calls update."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {"$key": 1, "name": "New Name"},  # GET
+        ]
+
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 1, "name": "Old"}, manager)
+        result = app.save(name="New Name")
+
+        assert result["name"] == "New Name"
+
+    def test_delete(self, mock_client: MagicMock) -> None:
+        """Test delete."""
+        mock_client._request.return_value = None
+
+        manager = OidcApplicationManager(mock_client)
+        app = OidcApplication({"$key": 1}, manager)
+        app.delete()
+
+        mock_client._request.assert_called_once_with("DELETE", "oidc_applications/1")


### PR DESCRIPTION
## Summary

Implements Section 5.1 Authentication Sources from the v1.0 release plan, enabling SSO and external identity provider integration.

- Add `auth_sources` resource manager for external identity providers (Azure AD, Google, GitLab, Okta, OpenID, OAuth2, Verge.io)
- Add `auth_source_states` for OAuth state token management (40-char hex keys)
- Add `oidc_applications` for VergeOS as OIDC identity provider
- Add `oidc_application_users`, `oidc_application_groups`, `oidc_application_logs` for ACL and audit management
- Add client properties for all new managers with lazy loading

## Changes

**New Files:**
- `pyvergeos/resources/auth_sources.py` - AuthSource, AuthSourceState and their managers
- `pyvergeos/resources/oidc_applications.py` - OidcApplication, User/Group/Log ACL managers
- `tests/unit/test_auth_sources.py` - 50 unit tests
- `tests/unit/test_oidc_applications.py` - 74 unit tests
- `tests/integration/test_auth_sources.py` - Integration tests
- `tests/integration/test_oidc_applications.py` - Integration tests

**Modified Files:**
- `pyvergeos/client.py` - Added 6 new manager properties
- `pyvergeos/resources/__init__.py` - Added 12 new exports

## Test plan

- [x] All 3769 unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes (79 files)
- [x] Tests pass on Python 3.9 and 3.12
- [x] CI pipeline passes