### PR TITLE
Fix: remove broken vm.snapshot() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ vm.power_off()
 vm.reset()
 
 # Snapshots
-vm.snapshot(retention=86400, quiesce=True)
+vm.snapshots.create(retention=86400, quiesce=True)
 
 # Clone
 clone = vm.clone(name="test-clone")
@@ -160,7 +160,7 @@ vms = client.vms.list(filter=str(f))
 
 ### Task Waiting
 ```python
-result = vm.snapshot()
+result = vm.snapshots.create(name="backup")
 task = client.tasks.wait(result["task"], timeout=300)
 ```
 

--- a/docs/plans/2026-02-05-fix-vm-snapshot-endpoint-design.md
+++ b/docs/plans/2026-02-05-fix-vm-snapshot-endpoint-design.md
@@ -1,0 +1,45 @@
+# Fix: Remove broken vm.snapshot() method (Issue #23)
+
+## Problem
+
+`VM.snapshot()` in `pyvergeos/resources/vms.py` sends `POST /api/v4/vm_actions`
+with `{"action": "snapshot"}`, but `"snapshot"` is not a valid action for the
+`vm_actions` endpoint. This causes all snapshot creation via `vm.snapshot()` to
+fail with: `value 'snapshot' is not in list for field 'action'`.
+
+The correct endpoint is `POST /api/v4/machine_snapshots`, which is already used
+by `vm.snapshots.create()`.
+
+## Solution
+
+Remove `VM.snapshot()` entirely. The working `vm.snapshots.create()` method is
+the correct API and already exists.
+
+## Changes
+
+### 1. Remove `VM.snapshot()` method
+**File:** `pyvergeos/resources/vms.py`
+- Delete the `snapshot()` method (lines 229-254)
+
+### 2. Remove broken unit test
+**File:** `tests/unit/test_vms.py`
+- Delete `test_snapshot` (lines 511-531) which asserts the broken behavior
+
+### 3. Update example
+**File:** `examples/vm_example.py`
+- Change `vm.snapshot(name=..., retention=..., quiesce=...)` to
+  `vm.snapshots.create(name=..., retention=..., quiesce=...)`
+
+### 4. Update README
+**File:** `README.md`
+- Line 114: `vm.snapshot(retention=86400, quiesce=True)` ->
+  `vm.snapshots.create(retention=86400, quiesce=True)`
+- Lines 163-164: `result = vm.snapshot()` ->
+  `result = vm.snapshots.create(name="backup")`
+
+## Verification
+
+- `uv run pytest tests/unit -k "test_vm or test_snapshot"` passes
+- `uv run ruff check --fix . && uv run ruff format .` passes
+- `uv run mypy pyvergeos` passes
+- No remaining references to `vm.snapshot(` in codebase

--- a/examples/vm_example.py
+++ b/examples/vm_example.py
@@ -178,7 +178,7 @@ def snapshot_and_clone() -> None:
 
         # Take a snapshot
         print(f"Taking snapshot of {vm.name}...")
-        result = vm.snapshot(
+        result = vm.snapshots.create(
             name="my-snapshot",
             retention=86400 * 7,  # 7 days
             quiesce=False,

--- a/pyvergeos/resources/vms.py
+++ b/pyvergeos/resources/vms.py
@@ -226,33 +226,6 @@ class VM(ResourceObject):
         )
         return self
 
-    def snapshot(
-        self,
-        name: str | None = None,
-        retention: int = 86400,
-        quiesce: bool = False,
-    ) -> dict[str, Any] | None:
-        """Take a VM snapshot.
-
-        Args:
-            name: Snapshot name (optional).
-            retention: Snapshot retention in seconds (default 24h).
-            quiesce: Quiesce disk activity (requires guest agent).
-
-        Returns:
-            Snapshot task information.
-        """
-        body: dict[str, Any] = {
-            "vm": self.key,
-            "action": "snapshot",
-            "params": {"retention": retention, "quiesce": quiesce},
-        }
-        if name:
-            body["params"]["name"] = name
-
-        result = self._manager._client._request("POST", "vm_actions", json_data=body)
-        return result if isinstance(result, dict) else None
-
     def clone(
         self,
         name: str | None = None,

--- a/tests/unit/test_vms.py
+++ b/tests/unit/test_vms.py
@@ -508,28 +508,6 @@ class TestVM:
         body = call_args.kwargs.get("json", {})
         assert body["action"] == "guestshutdown"
 
-    def test_snapshot(
-        self,
-        mock_client: VergeClient,
-        mock_session: MagicMock,
-        vm_data: dict[str, Any],
-    ) -> None:
-        """Test taking a snapshot."""
-        mock_session.request.return_value.json.return_value = {
-            "$key": 999,
-            "name": "my-snapshot",
-        }
-
-        vm = VM(vm_data, mock_client.vms)
-        vm.snapshot(name="my-snapshot", retention=172800, quiesce=True)
-
-        call_args = mock_session.request.call_args
-        body = call_args.kwargs.get("json", {})
-        assert body["action"] == "snapshot"
-        assert body["params"]["name"] == "my-snapshot"
-        assert body["params"]["retention"] == 172800
-        assert body["params"]["quiesce"] is True
-
     def test_clone(
         self,
         mock_client: VergeClient,


### PR DESCRIPTION
## Summary

- Remove `VM.snapshot()` which used the wrong API endpoint (`vm_actions` with `"action": "snapshot"`) — `"snapshot"` is not a valid action
- Update examples and README to use the working `vm.snapshots.create()` method instead

## Details

`vm.snapshot()` sent `POST /api/v4/vm_actions` with `{"action": "snapshot"}`, but the API does not recognize `"snapshot"` as a valid action. The correct endpoint is `POST /api/v4/machine_snapshots`, which `vm.snapshots.create()` already uses correctly.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit -k "test_vm or test_snapshot"` — 283 passed)
- [x] Ruff lint/format clean
- [x] Mypy type check clean
- [x] No remaining references to `vm.snapshot(` in codebase (outside design doc)

Closes #23