### PR TITLE
Add DNS View management and zone CRUD support

### DIFF
--- a/docs/plans/2026-02-05-dns-views-design.md
+++ b/docs/plans/2026-02-05-dns-views-design.md
@@ -1,0 +1,105 @@
+# Add DNS View Management Support (Issue #24)
+
+## Problem
+
+DNS Views are used internally by `DNSZoneManager._get_views()` but not exposed
+as a public manager. Users cannot create, update, or delete DNS views. Zone
+creation is also missing, so the full View -> Zone -> Records workflow is
+incomplete.
+
+## Solution
+
+Add `DNSViewManager` with full CRUD, expose it on `Network.dns_views`, and add
+zone create/delete to `DNSZoneManager`.
+
+## New File: `pyvergeos/resources/dns_views.py`
+
+### DNSView (ResourceObject)
+
+Properties: `name`, `recursion`, `match_clients`, `match_destinations`,
+`max_cache_size`, `query_source`.
+
+`zones` property returns a `DNSZoneManager` scoped to this view, enabling
+`view.zones.list()` and `view.zones.create()`.
+
+### DNSViewManager (ResourceManager[DNSView])
+
+Endpoint: `vnet_dns_views`. Accessed via `network.dns_views`.
+
+Default fields: `$key`, `name`, `recursion`, `match_clients`,
+`match_destinations`, `max_cache_size`, `query_source`, `vnet`.
+
+Methods:
+- `list(filter, fields)` — filtered by `vnet eq {network_key}`
+- `get(key, name)` — by key or name
+- `create(name, recursion=False, match_clients=None, match_destinations=None,
+  max_cache_size=33554432, query_source=None)` — all API fields exposed
+- `update(key, name, recursion, match_clients, match_destinations,
+  max_cache_size, query_source)` — update any field
+- `delete(key)` — delete a view
+
+## Modified: `pyvergeos/resources/dns.py`
+
+### DNSZoneManager Changes
+
+Accept either a `Network` or `DNSView` as parent.
+
+Add `create()`:
+- Parameters: `domain`, `zone_type="master"`, `nameserver`, `email`,
+  `default_ttl="1h"`, plus remaining zone fields via `**kwargs`
+- Automatically sets view key when scoped to a DNSView
+- Raises `ValueError` when constructed from Network (must go through a view)
+
+Add `delete(key)`:
+- `DELETE vnet_dns_zones/{key}`
+
+## Modified: `pyvergeos/resources/networks.py`
+
+Add `dns_views` property to `Network` class returning `DNSViewManager`.
+
+## Tests
+
+### New: `tests/unit/test_dns_views.py`
+
+- DNSView property access for all fields
+- DNSViewManager: list, get (by key/name), create, update, delete
+- Verify network scoping (`vnet eq {key}`) in all requests
+- `view.zones` returns scoped DNSZoneManager
+
+### Modified: `tests/unit/test_dns.py`
+
+- Zone create via view-scoped manager
+- Zone delete
+- Zone create without view raises ValueError
+
+## Usage
+
+```python
+# List views
+views = network.dns_views.list()
+
+# Create a view with all options
+view = network.dns_views.create(
+    name="internal",
+    recursion=True,
+    match_clients="10/8;172.16/16;",
+)
+
+# Update a view
+network.dns_views.update(view.key, recursion=False)
+
+# Create a zone through a view
+zone = view.zones.create(domain="example.com", zone_type="master")
+
+# Records (existing)
+zone.records.create(host="www", record_type="A", value="10.0.0.1")
+
+# Delete
+network.dns_views.delete(view.key)
+```
+
+## Verification
+
+- `uv run pytest tests/unit -k "test_dns"` passes
+- `uv run ruff check --fix . && uv run ruff format .` passes
+- `uv run mypy pyvergeos` passes

--- a/pyvergeos/resources/dns_views.py
+++ b/pyvergeos/resources/dns_views.py
@@ -1,0 +1,333 @@
+"""DNS View resource manager."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+    from pyvergeos.resources.dns import DNSZoneManager
+    from pyvergeos.resources.networks import Network
+
+# Default fields for DNS view data
+DNS_VIEW_DEFAULT_FIELDS = [
+    "$key",
+    "name",
+    "recursion",
+    "match_clients",
+    "match_destinations",
+    "max_cache_size",
+    "query_source",
+    "vnet",
+]
+
+
+class DNSView(ResourceObject):
+    """DNS View resource object."""
+
+    @property
+    def name(self) -> str:
+        """Get the view name."""
+        return self.get("name") or ""
+
+    @property
+    def recursion(self) -> bool:
+        """Get whether recursive DNS queries are enabled."""
+        return bool(self.get("recursion", False))
+
+    @property
+    def match_clients(self) -> str | None:
+        """Get client IP networks to match (semicolon-delimited)."""
+        return self.get("match_clients")
+
+    @property
+    def match_destinations(self) -> str | None:
+        """Get destination networks to match (semicolon-delimited)."""
+        return self.get("match_destinations")
+
+    @property
+    def max_cache_size(self) -> int:
+        """Get maximum RAM for DNS cache in bytes (0 = unlimited)."""
+        return self.get("max_cache_size") or 0
+
+    @property
+    def query_source(self) -> int | None:
+        """Get the query source address reference."""
+        val = self.get("query_source")
+        return int(val) if val is not None else None
+
+    @property
+    def network_key(self) -> int:
+        """Get the network key this view belongs to."""
+        vnet = self.get("vnet")
+        if vnet is None:
+            raise ValueError("View has no network key")
+        return int(vnet)
+
+    @property
+    def zones(self) -> DNSZoneManager:
+        """Access DNS zones in this view.
+
+        Returns:
+            DNSZoneManager scoped to this view.
+
+        Examples:
+            List zones in this view::
+
+                zones = view.zones.list()
+
+            Create a zone::
+
+                zone = view.zones.create(domain="example.com")
+        """
+        from pyvergeos.resources.dns import DNSZoneManager
+
+        return DNSZoneManager(self._manager._client, view=self)
+
+
+class DNSViewManager(ResourceManager[DNSView]):
+    """Manager for DNS View operations.
+
+    This manager is accessed through a Network object's dns_views property.
+
+    Examples:
+        List all views for a network::
+
+            views = network.dns_views.list()
+
+        Get a view by name::
+
+            view = network.dns_views.get(name="internal")
+
+        Create a view::
+
+            view = network.dns_views.create(
+                name="internal",
+                recursion=True,
+                match_clients="10/8;172.16/16;",
+            )
+
+        Access zones through a view::
+
+            zones = view.zones.list()
+            zone = view.zones.create(domain="example.com")
+    """
+
+    _endpoint = "vnet_dns_views"
+    _default_fields = DNS_VIEW_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, network: Network) -> None:
+        super().__init__(client)
+        self._network = network
+
+    @property
+    def network_key(self) -> int:
+        """Get the network key for this manager."""
+        return self._network.key
+
+    def _to_model(self, data: dict[str, Any]) -> DNSView:
+        return DNSView(data, self)
+
+    def list(  # type: ignore[override]
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        **kwargs: Any,
+    ) -> builtins.list[DNSView]:
+        """List DNS views for this network.
+
+        Args:
+            filter: Additional OData filter string.
+            fields: List of fields to return.
+            **kwargs: Additional filter arguments.
+
+        Returns:
+            List of DNSView objects.
+        """
+        if fields is None:
+            fields = self._default_fields.copy()
+
+        filters: builtins.list[str] = [f"vnet eq {self.network_key}"]
+
+        if filter:
+            filters.append(f"({filter})")
+
+        combined_filter = " and ".join(filters)
+
+        params: dict[str, Any] = {
+            "filter": combined_filter,
+            "fields": ",".join(fields),
+        }
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> DNSView:
+        """Get a DNS view by key or name.
+
+        Args:
+            key: View $key (ID).
+            name: View name.
+            fields: List of fields to return.
+
+        Returns:
+            DNSView object.
+
+        Raises:
+            NotFoundError: If view not found.
+            ValueError: If neither key nor name provided.
+        """
+        if fields is None:
+            fields = self._default_fields.copy()
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"DNS view {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"DNS view {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            views = self.list(filter=f"name eq '{escaped_name}'")
+            if not views:
+                raise NotFoundError(f"DNS view '{name}' not found on this network")
+            return views[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        recursion: bool = False,
+        match_clients: str | None = None,
+        match_destinations: str | None = None,
+        max_cache_size: int = 33554432,
+        query_source: int | None = None,
+    ) -> DNSView:
+        """Create a new DNS view.
+
+        Args:
+            name: View name (must be unique per network).
+            recursion: Enable recursive DNS queries (default False).
+            match_clients: Client IP networks to match (semicolon-delimited,
+                e.g., "10/8;172.16/16;").
+            match_destinations: Destination networks to match
+                (semicolon-delimited).
+            max_cache_size: Maximum RAM for DNS cache in bytes
+                (default 33554432 / 32MB, 0 = unlimited).
+            query_source: Reference to vnet_addresses for query source IP.
+
+        Returns:
+            Created DNSView object.
+
+        Note:
+            DNS changes require DNS apply on the network to take effect.
+        """
+        body: dict[str, Any] = {
+            "vnet": self.network_key,
+            "name": name,
+            "recursion": recursion,
+            "max_cache_size": max_cache_size,
+        }
+
+        if match_clients is not None:
+            body["match_clients"] = match_clients
+
+        if match_destinations is not None:
+            body["match_destinations"] = match_destinations
+
+        if query_source is not None:
+            body["query_source"] = query_source
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+        if response is None:
+            raise ValueError("No response from create operation")
+        if not isinstance(response, dict):
+            raise ValueError("Create operation returned invalid response")
+
+        key = response.get("$key")
+        if key is None:
+            raise ValueError("Create response missing $key")
+
+        return self.get(int(key))
+
+    def update(  # type: ignore[override]
+        self,
+        key: int,
+        name: str | None = None,
+        recursion: bool | None = None,
+        match_clients: str | None = None,
+        match_destinations: str | None = None,
+        max_cache_size: int | None = None,
+        query_source: int | None = None,
+    ) -> DNSView:
+        """Update a DNS view.
+
+        Args:
+            key: View $key (ID).
+            name: New view name.
+            recursion: Enable/disable recursive DNS queries.
+            match_clients: Client IP networks to match.
+            match_destinations: Destination networks to match.
+            max_cache_size: Maximum RAM for DNS cache in bytes.
+            query_source: Reference to vnet_addresses for query source IP.
+
+        Returns:
+            Updated DNSView object.
+
+        Note:
+            DNS changes require DNS apply on the network to take effect.
+        """
+        body: dict[str, Any] = {}
+
+        if name is not None:
+            body["name"] = name
+        if recursion is not None:
+            body["recursion"] = recursion
+        if match_clients is not None:
+            body["match_clients"] = match_clients
+        if match_destinations is not None:
+            body["match_destinations"] = match_destinations
+        if max_cache_size is not None:
+            body["max_cache_size"] = max_cache_size
+        if query_source is not None:
+            body["query_source"] = query_source
+
+        if not body:
+            return self.get(key)
+
+        self._client._request("PUT", f"{self._endpoint}/{key}", json_data=body)
+
+        return self.get(key)
+
+    def delete(self, key: int) -> None:
+        """Delete a DNS view.
+
+        Args:
+            key: View $key (ID).
+
+        Note:
+            Deleting a view also deletes all zones and records within it.
+            DNS changes require DNS apply on the network to take effect.
+        """
+        self._client._request("DELETE", f"{self._endpoint}/{key}")

--- a/pyvergeos/resources/networks.py
+++ b/pyvergeos/resources/networks.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from pyvergeos.client import VergeClient
     from pyvergeos.resources.aliases import NetworkAliasManager
     from pyvergeos.resources.dns import DNSZoneManager
+    from pyvergeos.resources.dns_views import DNSViewManager
     from pyvergeos.resources.hosts import NetworkHostManager
     from pyvergeos.resources.ipsec import IPSecConnectionManager
     from pyvergeos.resources.network_stats import (
@@ -347,7 +348,38 @@ class Network(ResourceObject):
         """
         from pyvergeos.resources.dns import DNSZoneManager
 
-        return DNSZoneManager(self._manager._client, self)
+        return DNSZoneManager(self._manager._client, network=self)
+
+    @property
+    def dns_views(self) -> DNSViewManager:
+        """Access DNS views for this network.
+
+        Returns:
+            DNSViewManager for this network.
+
+        Examples:
+            List all DNS views::
+
+                views = network.dns_views.list()
+
+            Get a view by name::
+
+                view = network.dns_views.get(name="internal")
+
+            Create a view::
+
+                view = network.dns_views.create(name="internal")
+
+            Create a zone through a view::
+
+                zone = view.zones.create(domain="example.com")
+
+        Note:
+            DNS changes require DNS apply on the network to take effect.
+        """
+        from pyvergeos.resources.dns_views import DNSViewManager
+
+        return DNSViewManager(self._manager._client, self)
 
     @property
     def ipsec(self) -> IPSecConnectionManager:

--- a/tests/integration/test_dns_views_integration.py
+++ b/tests/integration/test_dns_views_integration.py
@@ -1,0 +1,257 @@
+"""Integration tests for DNS View operations.
+
+These tests require a live VergeOS system with a network that has DNS (bind) enabled.
+Run with: VERGE_HOST=192.168.10.75 VERGE_USERNAME=admin VERGE_PASSWORD=jenifer8 \
+          pytest tests/integration/test_dns_views_integration.py -v
+
+Environment variables:
+    VERGE_HOST: VergeOS hostname/IP
+    VERGE_USERNAME: Username
+    VERGE_PASSWORD: Password
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pyvergeos import VergeClient
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.dns import DNSZone, DNSZoneManager
+from pyvergeos.resources.dns_views import DNSView, DNSViewManager
+
+# Skip all tests if not in integration mode
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("VERGE_HOST"),
+    reason="Integration tests require VERGE_HOST environment variable",
+)
+
+
+@pytest.fixture(scope="module")
+def client() -> VergeClient:
+    """Create a connected VergeClient for integration tests."""
+    client = VergeClient(
+        host=os.environ.get("VERGE_HOST", ""),
+        username=os.environ.get("VERGE_USERNAME", ""),
+        password=os.environ.get("VERGE_PASSWORD", ""),
+        verify_ssl=False,
+    )
+    yield client
+    client.disconnect()
+
+
+@pytest.fixture(scope="module")
+def dns_network(client: VergeClient):
+    """Get a network with DNS (bind) enabled for testing."""
+    networks = client.networks.list()
+    for network in networks:
+        if network.get("dns") == "bind":
+            return network
+
+    pytest.skip("No network with bind DNS found")
+
+
+# =============================================================================
+# DNS View Manager Tests
+# =============================================================================
+
+
+class TestDNSViewIntegration:
+    """Integration tests for DNS view operations."""
+
+    def test_list_views(self, dns_network) -> None:
+        """Test listing DNS views."""
+        views = dns_network.dns_views.list()
+        assert isinstance(views, list)
+        if views:
+            assert isinstance(views[0], DNSView)
+
+    def test_dns_views_manager_type(self, dns_network) -> None:
+        """Test dns_views property returns correct type."""
+        assert isinstance(dns_network.dns_views, DNSViewManager)
+
+    def test_view_properties(self, dns_network) -> None:
+        """Test DNS view properties are accessible."""
+        views = dns_network.dns_views.list()
+        if not views:
+            pytest.skip("No DNS views available")
+
+        view = views[0]
+        assert view.key > 0
+        assert isinstance(view.name, str)
+        assert view.name  # should not be empty
+        assert isinstance(view.recursion, bool)
+        assert isinstance(view.max_cache_size, int)
+
+    def test_get_view_by_key(self, dns_network) -> None:
+        """Test getting view by key."""
+        views = dns_network.dns_views.list()
+        if not views:
+            pytest.skip("No DNS views available")
+
+        view = dns_network.dns_views.get(views[0].key)
+        assert view.key == views[0].key
+        assert view.name == views[0].name
+
+    def test_get_view_by_name(self, dns_network) -> None:
+        """Test getting view by name."""
+        views = dns_network.dns_views.list()
+        if not views:
+            pytest.skip("No DNS views available")
+
+        view = dns_network.dns_views.get(name=views[0].name)
+        assert view.name == views[0].name
+
+    def test_get_view_not_found(self, dns_network) -> None:
+        """Test getting non-existent view raises NotFoundError."""
+        with pytest.raises(NotFoundError):
+            dns_network.dns_views.get(name="nonexistent-pytest-view-999")
+
+    def test_view_zones_property(self, dns_network) -> None:
+        """Test view.zones returns DNSZoneManager."""
+        views = dns_network.dns_views.list()
+        if not views:
+            pytest.skip("No DNS views available")
+
+        view = views[0]
+        assert isinstance(view.zones, DNSZoneManager)
+        assert view.zones.view_key == view.key
+
+    def test_list_zones_through_view(self, dns_network) -> None:
+        """Test listing zones through a view."""
+        views = dns_network.dns_views.list()
+        if not views:
+            pytest.skip("No DNS views available")
+
+        view = views[0]
+        zones = view.zones.list()
+        assert isinstance(zones, list)
+        if zones:
+            assert isinstance(zones[0], DNSZone)
+
+    def test_create_update_delete_view(self, dns_network) -> None:
+        """Test full CRUD lifecycle for a DNS view."""
+        # Create
+        view = dns_network.dns_views.create(
+            name="pytest-test-view",
+            recursion=False,
+        )
+
+        try:
+            assert view.key > 0
+            assert view.name == "pytest-test-view"
+            assert view.recursion is False
+
+            # Verify retrieval
+            retrieved = dns_network.dns_views.get(view.key)
+            assert retrieved.key == view.key
+            assert retrieved.name == "pytest-test-view"
+
+            # Update
+            updated = dns_network.dns_views.update(
+                view.key,
+                recursion=True,
+            )
+            assert updated.recursion is True
+            assert updated.name == "pytest-test-view"
+
+        finally:
+            # Delete
+            dns_network.dns_views.delete(view.key)
+
+            # Verify deletion
+            with pytest.raises(NotFoundError):
+                dns_network.dns_views.get(view.key)
+
+
+# =============================================================================
+# DNS Zone CRUD Tests (through views)
+# =============================================================================
+
+
+class TestDNSZoneCRUDIntegration:
+    """Integration tests for DNS zone create/delete through views."""
+
+    def test_create_and_delete_zone(self, dns_network) -> None:
+        """Test creating and deleting a zone through a view."""
+        # Create a view for this test
+        view = dns_network.dns_views.create(name="pytest-zone-test-view")
+
+        try:
+            # Create a zone through the view
+            zone = view.zones.create(
+                domain="pytest-example.local",
+                zone_type="master",
+                default_ttl="5m",
+            )
+
+            try:
+                assert zone.key > 0
+                assert zone.domain == "pytest-example.local"
+                assert zone.zone_type == "master"
+
+                # Verify it shows in the view's zone list
+                zones = view.zones.list()
+                zone_domains = [z.domain for z in zones]
+                assert "pytest-example.local" in zone_domains
+
+                # Verify it shows in the network's zone list
+                all_zones = dns_network.dns_zones.list(
+                    domain="pytest-example.local"
+                )
+                assert len(all_zones) > 0
+
+            finally:
+                # Delete the zone
+                view.zones.delete(zone.key)
+
+                # Verify zone deletion
+                remaining = view.zones.list(domain="pytest-example.local")
+                assert len(remaining) == 0
+
+        finally:
+            # Delete the view
+            dns_network.dns_views.delete(view.key)
+
+    def test_create_zone_with_records(self, dns_network) -> None:
+        """Test creating a zone and adding records through the full hierarchy."""
+        view = dns_network.dns_views.create(name="pytest-records-test-view")
+
+        try:
+            zone = view.zones.create(
+                domain="pytest-records.local",
+                zone_type="master",
+            )
+
+            try:
+                # Add a record through the zone
+                record = zone.records.create(
+                    host="www",
+                    record_type="A",
+                    value="10.0.0.99",
+                )
+
+                try:
+                    assert record.key > 0
+                    assert record.host == "www"
+                    assert record.value == "10.0.0.99"
+
+                    # Verify record is retrievable
+                    records = zone.records.list()
+                    hosts = [r.host for r in records]
+                    assert "www" in hosts
+
+                finally:
+                    zone.records.delete(record.key)
+
+            finally:
+                view.zones.delete(zone.key)
+
+        finally:
+            dns_network.dns_views.delete(view.key)
+
+    def test_create_zone_without_view_raises(self, dns_network) -> None:
+        """Test creating a zone without a view raises ValueError."""
+        with pytest.raises(ValueError, match="Zone creation requires a view"):
+            dns_network.dns_zones.create(domain="should-fail.local")

--- a/tests/unit/test_dns_views.py
+++ b/tests/unit/test_dns_views.py
@@ -1,0 +1,466 @@
+"""Unit tests for DNS View operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.dns import DNSZoneManager
+from pyvergeos.resources.dns_views import (
+    DNS_VIEW_DEFAULT_FIELDS,
+    DNSView,
+    DNSViewManager,
+)
+from pyvergeos.resources.networks import Network
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def mock_network(mock_client: MagicMock) -> Network:
+    """Create a mock Network object."""
+    from pyvergeos.resources.networks import NetworkManager
+
+    manager = MagicMock(spec=NetworkManager)
+    manager._client = mock_client
+    return Network(
+        {
+            "$key": 1,
+            "name": "test-network",
+            "dns": "bind",
+        },
+        manager,
+    )
+
+
+@pytest.fixture
+def view_manager(mock_client: MagicMock, mock_network: Network) -> DNSViewManager:
+    """Create a DNSViewManager instance."""
+    return DNSViewManager(mock_client, mock_network)
+
+
+@pytest.fixture
+def sample_view_data() -> dict[str, Any]:
+    """Sample DNS view data."""
+    return {
+        "$key": 1,
+        "name": "internal",
+        "recursion": True,
+        "match_clients": "10/8;172.16/16;",
+        "match_destinations": None,
+        "max_cache_size": 33554432,
+        "query_source": None,
+        "vnet": 1,
+    }
+
+
+@pytest.fixture
+def mock_view(view_manager: DNSViewManager, sample_view_data: dict[str, Any]) -> DNSView:
+    """Create a mock DNSView object."""
+    return DNSView(sample_view_data, view_manager)
+
+
+# =============================================================================
+# DNSView Object Tests
+# =============================================================================
+
+
+class TestDNSView:
+    """Tests for DNSView resource object."""
+
+    def test_view_properties(self, mock_view: DNSView) -> None:
+        """Test DNS view properties."""
+        assert mock_view.key == 1
+        assert mock_view.name == "internal"
+        assert mock_view.recursion is True
+        assert mock_view.match_clients == "10/8;172.16/16;"
+        assert mock_view.match_destinations is None
+        assert mock_view.max_cache_size == 33554432
+        assert mock_view.query_source is None
+        assert mock_view.network_key == 1
+
+    def test_view_defaults(self, view_manager: DNSViewManager) -> None:
+        """Test DNS view default values."""
+        view = DNSView({"$key": 2, "vnet": 1}, view_manager)
+        assert view.name == ""
+        assert view.recursion is False
+        assert view.match_clients is None
+        assert view.match_destinations is None
+        assert view.max_cache_size == 0
+        assert view.query_source is None
+
+    def test_view_network_key_missing_raises(self, view_manager: DNSViewManager) -> None:
+        """Test view network_key raises when not available."""
+        view = DNSView({"$key": 1, "name": "test"}, view_manager)
+        with pytest.raises(ValueError, match="View has no network key"):
+            _ = view.network_key
+
+    def test_view_query_source_int(self, view_manager: DNSViewManager) -> None:
+        """Test query_source returns int when set."""
+        view = DNSView({"$key": 1, "vnet": 1, "query_source": 5}, view_manager)
+        assert view.query_source == 5
+
+    def test_view_zones_property(self, mock_client: MagicMock, mock_view: DNSView) -> None:
+        """Test view.zones returns scoped DNSZoneManager."""
+        zones_mgr = mock_view.zones
+        assert isinstance(zones_mgr, DNSZoneManager)
+        assert zones_mgr.view_key == mock_view.key
+
+    def test_view_zones_network_key(self, mock_client: MagicMock, mock_view: DNSView) -> None:
+        """Test view.zones manager has correct network key."""
+        zones_mgr = mock_view.zones
+        assert zones_mgr.network_key == 1
+
+
+# =============================================================================
+# DNSViewManager Tests
+# =============================================================================
+
+
+class TestDNSViewManager:
+    """Tests for DNSViewManager operations."""
+
+    def test_network_key_property(self, view_manager: DNSViewManager) -> None:
+        """Test network_key property."""
+        assert view_manager.network_key == 1
+
+    def test_list_views_empty(self, view_manager: DNSViewManager, mock_client: MagicMock) -> None:
+        """Test list returns empty when no views."""
+        mock_client._request.return_value = None
+        views = view_manager.list()
+        assert views == []
+
+    def test_list_views_success(self, view_manager: DNSViewManager, mock_client: MagicMock) -> None:
+        """Test list views successfully."""
+        mock_client._request.return_value = [
+            {"$key": 1, "name": "internal", "vnet": 1},
+            {"$key": 2, "name": "external", "vnet": 1},
+        ]
+        views = view_manager.list()
+        assert len(views) == 2
+        assert views[0].name == "internal"
+        assert views[1].name == "external"
+
+    def test_list_views_single_response(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test list views with single view response."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "default",
+            "vnet": 1,
+        }
+        views = view_manager.list()
+        assert len(views) == 1
+        assert views[0].name == "default"
+
+    def test_list_views_filters_by_network(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test list views filters by network key."""
+        mock_client._request.return_value = []
+        view_manager.list()
+
+        call_args = mock_client._request.call_args
+        assert "vnet eq 1" in call_args[1]["params"]["filter"]
+
+    def test_list_views_with_additional_filter(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test list views with additional filter."""
+        mock_client._request.return_value = []
+        view_manager.list(filter="recursion eq true")
+
+        call_args = mock_client._request.call_args
+        filter_str = call_args[1]["params"]["filter"]
+        assert "vnet eq 1" in filter_str
+        assert "(recursion eq true)" in filter_str
+
+    def test_get_view_by_key(self, view_manager: DNSViewManager, mock_client: MagicMock) -> None:
+        """Test get view by key."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "internal",
+            "vnet": 1,
+        }
+        view = view_manager.get(1)
+        assert view.key == 1
+        assert view.name == "internal"
+
+    def test_get_view_by_name(
+        self,
+        view_manager: DNSViewManager,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test get view by name."""
+        mock_client._request.return_value = [
+            {"$key": 1, "name": "internal", "vnet": 1},
+        ]
+        view = view_manager.get(name="internal")
+        assert view.name == "internal"
+
+        # Verify name filter was included
+        call_args = mock_client._request.call_args
+        assert "name eq 'internal'" in call_args[1]["params"]["filter"]
+
+    def test_get_view_not_found_by_key(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test get view raises NotFoundError for non-existent key."""
+        mock_client._request.return_value = None
+        with pytest.raises(NotFoundError, match="DNS view 999 not found"):
+            view_manager.get(999)
+
+    def test_get_view_not_found_by_name(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test get view raises NotFoundError for non-existent name."""
+        mock_client._request.return_value = []
+        with pytest.raises(NotFoundError, match="DNS view 'nonexistent'"):
+            view_manager.get(name="nonexistent")
+
+    def test_get_view_no_identifier_raises(self, view_manager: DNSViewManager) -> None:
+        """Test get view raises ValueError when no identifier provided."""
+        with pytest.raises(ValueError, match="Either key or name must be provided"):
+            view_manager.get()
+
+    def test_get_view_by_key_invalid_response(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test get view raises NotFoundError for invalid response."""
+        mock_client._request.return_value = []
+        with pytest.raises(NotFoundError, match="DNS view 1 returned invalid response"):
+            view_manager.get(1)
+
+    def test_create_view_minimal(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test create view with minimal params."""
+        mock_client._request.side_effect = [
+            {"$key": 1},  # create response
+            {  # get response
+                "$key": 1,
+                "name": "internal",
+                "recursion": False,
+                "vnet": 1,
+            },
+        ]
+        view = view_manager.create(name="internal")
+        assert view.key == 1
+        assert view.name == "internal"
+
+        # Verify POST body
+        call_args = mock_client._request.call_args_list[0]
+        body = call_args[1]["json_data"]
+        assert body["vnet"] == 1
+        assert body["name"] == "internal"
+        assert body["recursion"] is False
+        assert body["max_cache_size"] == 33554432
+
+    def test_create_view_full_params(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test create view with all params."""
+        mock_client._request.side_effect = [
+            {"$key": 1},
+            {
+                "$key": 1,
+                "name": "internal",
+                "recursion": True,
+                "match_clients": "10/8;",
+                "match_destinations": "172.16/16;",
+                "max_cache_size": 67108864,
+                "query_source": 5,
+                "vnet": 1,
+            },
+        ]
+        view = view_manager.create(
+            name="internal",
+            recursion=True,
+            match_clients="10/8;",
+            match_destinations="172.16/16;",
+            max_cache_size=67108864,
+            query_source=5,
+        )
+        assert view.recursion is True
+        assert view.match_clients == "10/8;"
+
+        call_args = mock_client._request.call_args_list[0]
+        body = call_args[1]["json_data"]
+        assert body["recursion"] is True
+        assert body["match_clients"] == "10/8;"
+        assert body["match_destinations"] == "172.16/16;"
+        assert body["max_cache_size"] == 67108864
+        assert body["query_source"] == 5
+
+    def test_create_view_no_response_raises(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test create view raises when no response."""
+        mock_client._request.return_value = None
+        with pytest.raises(ValueError, match="No response from create"):
+            view_manager.create(name="test")
+
+    def test_create_view_invalid_response_raises(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test create view raises when response is not dict."""
+        mock_client._request.return_value = []
+        with pytest.raises(ValueError, match="invalid response"):
+            view_manager.create(name="test")
+
+    def test_create_view_no_key_raises(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test create view raises when no key in response."""
+        mock_client._request.return_value = {"location": "/v4/views/1"}
+        with pytest.raises(ValueError, match="missing \\$key"):
+            view_manager.create(name="test")
+
+    def test_update_view(self, view_manager: DNSViewManager, mock_client: MagicMock) -> None:
+        """Test update view."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {  # GET response
+                "$key": 1,
+                "name": "internal-updated",
+                "recursion": True,
+                "vnet": 1,
+            },
+        ]
+        view = view_manager.update(1, name="internal-updated", recursion=True)
+        assert view.name == "internal-updated"
+
+        # Verify PUT body
+        call_args = mock_client._request.call_args_list[0]
+        assert call_args[0][0] == "PUT"
+        body = call_args[1]["json_data"]
+        assert body["name"] == "internal-updated"
+        assert body["recursion"] is True
+
+    def test_update_view_partial(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test update view with single field."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {"$key": 1, "name": "internal", "recursion": True, "vnet": 1},
+        ]
+        view = view_manager.update(1, recursion=True)
+        assert view.recursion is True
+
+        call_args = mock_client._request.call_args_list[0]
+        body = call_args[1]["json_data"]
+        assert body == {"recursion": True}
+
+    def test_update_view_no_changes(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test update view with no changes just returns current."""
+        mock_client._request.return_value = {
+            "$key": 1,
+            "name": "internal",
+            "vnet": 1,
+        }
+        view = view_manager.update(1)
+        assert view.key == 1
+
+        # Should only call GET, not PUT
+        mock_client._request.assert_called_once()
+
+    def test_update_view_all_fields(
+        self, view_manager: DNSViewManager, mock_client: MagicMock
+    ) -> None:
+        """Test update view with all fields."""
+        mock_client._request.side_effect = [
+            None,  # PUT
+            {
+                "$key": 1,
+                "name": "updated",
+                "recursion": True,
+                "match_clients": "10/8;",
+                "match_destinations": "172.16/16;",
+                "max_cache_size": 0,
+                "query_source": 3,
+                "vnet": 1,
+            },
+        ]
+        _ = view_manager.update(
+            1,
+            name="updated",
+            recursion=True,
+            match_clients="10/8;",
+            match_destinations="172.16/16;",
+            max_cache_size=0,
+            query_source=3,
+        )
+
+        call_args = mock_client._request.call_args_list[0]
+        body = call_args[1]["json_data"]
+        assert body["name"] == "updated"
+        assert body["recursion"] is True
+        assert body["match_clients"] == "10/8;"
+        assert body["match_destinations"] == "172.16/16;"
+        assert body["max_cache_size"] == 0
+        assert body["query_source"] == 3
+
+    def test_delete_view(self, view_manager: DNSViewManager, mock_client: MagicMock) -> None:
+        """Test delete view."""
+        mock_client._request.return_value = None
+        view_manager.delete(1)
+
+        mock_client._request.assert_called_once_with("DELETE", "vnet_dns_views/1")
+
+
+# =============================================================================
+# Network Integration Tests
+# =============================================================================
+
+
+class TestNetworkDNSViewIntegration:
+    """Tests for Network.dns_views property."""
+
+    def test_network_dns_views_property(
+        self, mock_client: MagicMock, mock_network: Network
+    ) -> None:
+        """Test Network.dns_views returns DNSViewManager."""
+        manager = mock_network.dns_views
+        assert isinstance(manager, DNSViewManager)
+        assert manager.network_key == mock_network.key
+
+    def test_network_dns_views_multiple_access(
+        self, mock_client: MagicMock, mock_network: Network
+    ) -> None:
+        """Test Network.dns_views creates new manager each time."""
+        manager1 = mock_network.dns_views
+        manager2 = mock_network.dns_views
+        assert manager1.network_key == manager2.network_key
+
+
+# =============================================================================
+# Default Fields Tests
+# =============================================================================
+
+
+class TestDNSViewDefaultFields:
+    """Tests for default field constants."""
+
+    def test_view_default_fields(self) -> None:
+        """Test DNS view default fields include essential fields."""
+        assert "$key" in DNS_VIEW_DEFAULT_FIELDS
+        assert "name" in DNS_VIEW_DEFAULT_FIELDS
+        assert "recursion" in DNS_VIEW_DEFAULT_FIELDS
+        assert "vnet" in DNS_VIEW_DEFAULT_FIELDS
+        assert "match_clients" in DNS_VIEW_DEFAULT_FIELDS
+        assert "match_destinations" in DNS_VIEW_DEFAULT_FIELDS
+        assert "max_cache_size" in DNS_VIEW_DEFAULT_FIELDS
+        assert "query_source" in DNS_VIEW_DEFAULT_FIELDS


### PR DESCRIPTION
## Summary

- Add `DNSViewManager` with full CRUD (list, get, create, update, delete) accessible via `network.dns_views`
- Add zone `create()` and `delete()` to `DNSZoneManager`, requiring a view scope (`view.zones.create()`)
- Complete the View -> Zone -> Records hierarchy matching the VergeOS UI workflow

## Changes

| File | Change |
|------|--------|
| `pyvergeos/resources/dns_views.py` | New — `DNSView` and `DNSViewManager` |
| `pyvergeos/resources/dns.py` | Modified — `DNSZoneManager` accepts Network or DNSView parent, added `create()`/`delete()` |
| `pyvergeos/resources/networks.py` | Modified — added `dns_views` property to `Network` |
| `tests/unit/test_dns_views.py` | New — 31 unit tests for view CRUD |
| `tests/unit/test_dns.py` | Modified — 8 new tests for zone create/delete |
| `tests/integration/test_dns_views_integration.py` | New — 12 integration tests |

## Usage

```python
# List views
views = network.dns_views.list()

# Create a view
view = network.dns_views.create(name="internal", recursion=True)

# Create a zone through a view
zone = view.zones.create(domain="example.com", zone_type="master")

# Add records
zone.records.create(host="www", record_type="A", value="10.0.0.1")

# Update / delete
network.dns_views.update(view.key, recursion=False)
network.dns_views.delete(view.key)
```

## Test plan

- [x] 87 DNS unit tests pass (31 new view tests + 8 new zone CRUD tests)
- [x] 4023 full unit test suite passes (no regressions)
- [x] 12 integration tests pass against live VergeOS system
- [x] 17 existing DNS integration tests pass (no regressions)
- [x] Ruff lint/format clean
- [x] Mypy type check clean

Closes #24