### PR TITLE
Bump version to 1.0.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
## Summary
- Bumps version from `1.0.0` to `1.0.1` in both `pyproject.toml` and `pyvergeos/__version__.py`
- The v1.0.1 release workflow failed pushing to PyPI because the version was still `1.0.0`

## Test plan
- [ ] Verify `pyproject.toml` version is `1.0.1`
- [ ] Verify `pyvergeos/__version__.py` version is `1.0.1`
- [ ] Re-run PyPI publish workflow after merge