### PR TITLE
feat: add importing parameter to VmImportManager.create()

### DIFF
--- a/pyvergeos/resources/vm_imports.py
+++ b/pyvergeos/resources/vm_imports.py
@@ -376,6 +376,7 @@ class VmImportManager(ResourceManager["VmImport"]):
         override_drive_interface: str | None = None,
         override_nic_interface: str | None = None,
         cleanup_on_delete: bool = False,
+        importing: bool = False,
     ) -> VmImport:
         """Create a new VM import.
 
@@ -393,6 +394,7 @@ class VmImportManager(ResourceManager["VmImport"]):
             override_drive_interface: Override drive interface type.
             override_nic_interface: Override NIC interface type.
             cleanup_on_delete: Clean up import file path on delete.
+            importing: Auto-start the import immediately after creation (default False).
 
         Returns:
             Created VmImport object.
@@ -401,19 +403,21 @@ class VmImportManager(ResourceManager["VmImport"]):
             ValueError: If no source (file, volume, or shared_object) provided.
 
         Example:
-            >>> # Import from media catalog file
+            >>> # Import from media catalog file (auto-start)
             >>> imp = client.vm_imports.create(
             ...     name="imported-vm",
             ...     file=123,
-            ...     preferred_tier="1"
+            ...     preferred_tier="1",
+            ...     importing=True
             ... )
 
-            >>> # Import from NAS volume
+            >>> # Import from NAS volume (two-step: create then start)
             >>> imp = client.vm_imports.create(
             ...     name="imported-vm",
             ...     volume="abc123...",
             ...     volume_path="/exports/vm.vmdk"
             ... )
+            >>> imp.start()
         """
         if file is None and volume is None and shared_object is None:
             raise ValueError("One of file, volume, or shared_object must be provided")
@@ -450,6 +454,9 @@ class VmImportManager(ResourceManager["VmImport"]):
 
         if cleanup_on_delete:
             body["cleanup_on_delete"] = True
+
+        if importing:
+            body["importing"] = True
 
         response = self._client._request("POST", self._endpoint, json_data=body)
 


### PR DESCRIPTION
## Summary
- Fixes #28
- Add `importing` parameter to `VmImportManager.create()` for auto-starting imports
- Eliminates the unreliable two-step create() + start() workflow
- Import now transitions properly: initializing → importing → complete

## Changes
**SDK - VmImportManager**
- Add `importing: bool = False` parameter to `create()` method signature
- Add conditional body field: `if importing: body["importing"] = True`
- Update method docstring with parameter description
- Update examples showing both auto-start and two-step workflows

**Implementation Details**
- Follows API schema specification (vm_imports.importing field)
- Maintains backward compatibility (defaults to False)
- Total: 10 insertions, 3 deletions

## Test Plan
- [x] Create import with `importing=True` and verify it transitions to complete
- [x] Verify import progresses through states: initializing → importing → complete
- [x] Test two-step workflow still works (importing=False or omitted)
- [x] Run existing tests to ensure no regressions
- [x] Test with real OVA file import

## Notes
- This matches the workaround already used in the Ansible collection
- The REST API has always supported this field; the SDK just wasn't exposing it
- Two-step workflow remains available for backward compatibility