### PR TITLE
fix: use POST vm_actions endpoint for NAS power operations

### DIFF
--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/pyvergeos/resources/nas_services.py
+++ b/pyvergeos/resources/nas_services.py
@@ -560,7 +560,7 @@ class NASServiceManager(ResourceManager[NASService]):
         service = self.get(key)
         if service.vm_key:
             result = self._client._request(
-                "PUT", f"vms/{service.vm_key}?action=poweron", json_data={}
+                "POST", "vm_actions", json_data={"vm": service.vm_key, "action": "poweron"}
             )
             if isinstance(result, dict):
                 return result
@@ -585,9 +585,9 @@ class NASServiceManager(ResourceManager[NASService]):
         """
         service = self.get(key)
         if service.vm_key:
-            action = "killpower" if force else "poweroff"
+            action = "kill" if force else "poweroff"
             result = self._client._request(
-                "PUT", f"vms/{service.vm_key}?action={action}", json_data={}
+                "POST", "vm_actions", json_data={"vm": service.vm_key, "action": action}
             )
             if isinstance(result, dict):
                 return result
@@ -608,7 +608,7 @@ class NASServiceManager(ResourceManager[NASService]):
         service = self.get(key)
         if service.vm_key:
             result = self._client._request(
-                "PUT", f"vms/{service.vm_key}?action=reset", json_data={}
+                "POST", "vm_actions", json_data={"vm": service.vm_key, "action": "reset"}
             )
             if isinstance(result, dict):
                 return result

--- a/tests/unit/test_nas.py
+++ b/tests/unit/test_nas.py
@@ -408,8 +408,10 @@ class TestNASServiceManagerPower:
 
         assert result == {"task": 123}
         power_call = mock_client._request.call_args_list[1]
-        assert power_call[0][0] == "PUT"
-        assert "action=poweron" in power_call[0][1]
+        assert power_call[0][0] == "POST"
+        assert power_call[0][1] == "vm_actions"
+        assert power_call[1]["json_data"]["action"] == "poweron"
+        assert power_call[1]["json_data"]["vm"] == sample_nas_service["vm"]
 
     def test_power_off(self, nas_manager, mock_client, sample_nas_service):
         """Test powering off a NAS service."""
@@ -422,7 +424,9 @@ class TestNASServiceManagerPower:
 
         assert result == {"task": 123}
         power_call = mock_client._request.call_args_list[1]
-        assert "action=poweroff" in power_call[0][1]
+        assert power_call[0][0] == "POST"
+        assert power_call[0][1] == "vm_actions"
+        assert power_call[1]["json_data"]["action"] == "poweroff"
 
     def test_power_off_force(self, nas_manager, mock_client, sample_nas_service):
         """Test force power off."""
@@ -435,7 +439,9 @@ class TestNASServiceManagerPower:
 
         assert result == {"task": 123}
         power_call = mock_client._request.call_args_list[1]
-        assert "action=killpower" in power_call[0][1]
+        assert power_call[0][0] == "POST"
+        assert power_call[0][1] == "vm_actions"
+        assert power_call[1]["json_data"]["action"] == "kill"
 
     def test_restart(self, nas_manager, mock_client, sample_nas_service):
         """Test restarting a NAS service."""
@@ -448,7 +454,9 @@ class TestNASServiceManagerPower:
 
         assert result == {"task": 123}
         reset_call = mock_client._request.call_args_list[1]
-        assert "action=reset" in reset_call[0][1]
+        assert reset_call[0][0] == "POST"
+        assert reset_call[0][1] == "vm_actions"
+        assert reset_call[1]["json_data"]["action"] == "reset"
 
 
 class TestNASServiceManagerCIFSSettings:

--- a/tests/unit/test_nas_services.py
+++ b/tests/unit/test_nas_services.py
@@ -239,12 +239,12 @@ class TestNASServiceManager:
         result = mock_client.nas_services.power_on(1)
 
         assert result == {"task": 123}
-        put_calls = [
+        post_calls = [
             call
             for call in mock_session.request.call_args_list
-            if call.kwargs.get("method") == "PUT"
+            if call.kwargs.get("method") == "POST"
         ]
-        assert any("action=poweron" in call.kwargs.get("url", "") for call in put_calls)
+        assert any(call.kwargs.get("url", "").endswith("vm_actions") for call in post_calls)
 
     def test_power_off(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
         """Test powering off a NAS service."""
@@ -256,12 +256,12 @@ class TestNASServiceManager:
         result = mock_client.nas_services.power_off(1)
 
         assert result == {"task": 124}
-        put_calls = [
+        post_calls = [
             call
             for call in mock_session.request.call_args_list
-            if call.kwargs.get("method") == "PUT"
+            if call.kwargs.get("method") == "POST"
         ]
-        assert any("action=poweroff" in call.kwargs.get("url", "") for call in put_calls)
+        assert any(call.kwargs.get("url", "").endswith("vm_actions") for call in post_calls)
 
     def test_power_off_force(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
         """Test force powering off a NAS service."""
@@ -272,12 +272,12 @@ class TestNASServiceManager:
 
         mock_client.nas_services.power_off(1, force=True)
 
-        put_calls = [
+        post_calls = [
             call
             for call in mock_session.request.call_args_list
-            if call.kwargs.get("method") == "PUT"
+            if call.kwargs.get("method") == "POST"
         ]
-        assert any("action=killpower" in call.kwargs.get("url", "") for call in put_calls)
+        assert any(call.kwargs.get("url", "").endswith("vm_actions") for call in post_calls)
 
     def test_restart(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
         """Test restarting a NAS service."""


### PR DESCRIPTION
## Summary
- Fixed `power_on`, `power_off`, and `restart` in `NASServiceManager` to use `POST vm_actions` with a JSON body instead of `PUT vms/{key}?action=...`, matching the correct VergeOS API endpoint
- Fixed force power off action name from `killpower` to `kill`
- Bumped version to `1.0.2` to match the GitHub release

## Test plan
- [x] Unit tests updated to assert new endpoint and JSON body
- [x] All 133 NAS tests passing