### PR TITLE
chore: bump version to 1.0.2 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- `pyproject.toml` still had `version = "1.0.1"` which is what hatchling uses for builds
- PyPI publish failed because it built a `1.0.1` wheel that already exists
- Bumps to `1.0.2` to match `__version__.py` and the GitHub release

## Test plan
- [x] Version string matches in both `pyproject.toml` and `__version__.py`