### PR TITLE
Fix API parameter formats for tasks, OIDC, and API keys

### DIFF
--- a/docs/plans/2026-02-11-fix-issues-37-38-39-design.md
+++ b/docs/plans/2026-02-11-fix-issues-37-38-39-design.md
@@ -1,0 +1,62 @@
+# Fix Issues #37, #38, #39 — API Parameter Bugs
+
+## Summary
+
+Three bug fixes for incorrect API request construction in the SDK.
+
+## Issue #37: tasks.create() and task_events.create() parameter format
+
+**Root cause:** `tasks.create()` sends `owner` as a bare integer and `table` as a separate
+field. The VergeOS API expects `owner` in `"table/key"` combined format (e.g., `"vms/39"`).
+For `task_events.create()`, the `owner` field should not be sent at all — it is auto-populated
+from the parent task.
+
+**Evidence:** Captured from VergeOS UI:
+- Tasks POST: `{"owner": "smtp_settings/1", "action": "send", ...}` (combined format, no
+  separate `table`)
+- Task events POST: `{"task": "5", "table": "alarms", "event": "lowered", ...}` (no `owner`)
+
+### tasks.create() changes
+
+- Make `table` a required keyword argument (was optional)
+- Format `owner` as `f"{table}/{owner}"` in the request body
+- Remove `table` as a separate body field
+- Update docstring and examples
+
+### task_events.create() changes
+
+- Remove `owner` parameter entirely (auto-populated from parent task)
+- Make `table` a required keyword argument (event source table, e.g., `"alarms"`)
+- Update docstring to clarify `table` = event source table and document task-first workflow
+
+**Files:** `pyvergeos/resources/tasks.py`, `pyvergeos/resources/task_events.py`
+
+## Issue #38: oidc_applications.create() omits required fields
+
+**Root cause:** `force_auth_source` and `map_user` are only included in the request body when
+not `None`. API schema marks both as `required: true` with `show_none: true` — they must
+always be present, with `0` meaning "not set."
+
+### Changes
+
+- Always include `force_auth_source` in body (default `0` when `None`)
+- Always include `map_user` in body (default `0` when `None`)
+
+**Files:** `pyvergeos/resources/oidc_applications.py`
+
+## Issue #39: api_keys.list() silently ignores unresolved user
+
+**Root cause:** `_resolve_user_key()` returns `None` on lookup failure. `list()` silently
+drops the user filter when `None`, returning ALL API keys instead of raising an error.
+
+### Changes
+
+- `_resolve_user_key()`: Remove try/except, let `NotFoundError` propagate naturally
+- Return type changes from `int | None` to `int`
+- Simplify `list()` caller — no more `None` check needed
+
+**Files:** `pyvergeos/resources/api_keys.py`
+
+## Testing
+
+Unit tests for each fix following existing test patterns in `tests/unit/`.

--- a/pyvergeos/resources/api_keys.py
+++ b/pyvergeos/resources/api_keys.py
@@ -261,8 +261,7 @@ class APIKeyManager(ResourceManager[APIKey]):
         # Handle user filter
         if user is not None:
             user_key = self._resolve_user_key(user)
-            if user_key is not None:
-                filters.append(f"user eq {user_key}")
+            filters.append(f"user eq {user_key}")
 
         if filters:
             params["filter"] = " and ".join(filters)
@@ -479,24 +478,24 @@ class APIKeyManager(ResourceManager[APIKey]):
         """
         self._client._request("DELETE", f"{self._endpoint}/{key}")
 
-    def _resolve_user_key(self, user: int | str) -> int | None:
+    def _resolve_user_key(self, user: int | str) -> int:
         """Resolve a user identifier to a user $key.
 
         Args:
             user: User $key (int) or username (str).
 
         Returns:
-            User $key, or None if not found.
+            User $key.
+
+        Raises:
+            NotFoundError: If the username cannot be resolved.
         """
         if isinstance(user, int):
             return user
 
-        # Look up user by name
-        try:
-            user_obj = self._client.users.get(name=str(user))
-            return user_obj.key
-        except NotFoundError:
-            return None
+        # Look up user by name — raises NotFoundError if not found
+        user_obj = self._client.users.get(name=str(user))
+        return user_obj.key
 
     def _get_user_name(self, user_key: int) -> str | None:
         """Get a username by user key.

--- a/pyvergeos/resources/oidc_applications.py
+++ b/pyvergeos/resources/oidc_applications.py
@@ -1137,14 +1137,12 @@ class OidcApplicationManager(ResourceManager["OidcApplication"]):
         if description is not None:
             body["description"] = description
 
-        if force_auth_source is not None:
-            body["force_auth_source"] = force_auth_source
+        body["force_auth_source"] = force_auth_source if force_auth_source is not None else 0
 
         if restrict_access:
             body["restrict_access"] = restrict_access
 
-        if map_user is not None:
-            body["map_user"] = map_user
+        body["map_user"] = map_user if map_user is not None else 0
 
         response = self._client._request("POST", self._endpoint, json_data=body)
 

--- a/pyvergeos/resources/tasks.py
+++ b/pyvergeos/resources/tasks.py
@@ -683,7 +683,7 @@ class TaskManager(ResourceManager[Task]):
         owner: int,
         action: str,
         *,
-        table: str | None = None,
+        table: str,
         description: str | None = None,
         enabled: bool = True,
         delete_after_run: bool = False,
@@ -695,7 +695,8 @@ class TaskManager(ResourceManager[Task]):
             name: Task name (required).
             owner: Owner resource $key (required).
             action: Action type to perform (required).
-            table: Owner table name (usually auto-detected).
+            table: Owner table name (required, e.g. ``"vms"``).
+                Combined with owner to form the ``"table/key"`` reference.
             description: Task description.
             enabled: Whether task is enabled (default True).
             delete_after_run: Delete task after execution (default False).
@@ -710,6 +711,7 @@ class TaskManager(ResourceManager[Task]):
             ...     name="Daily Snapshot",
             ...     owner=vm.key,
             ...     action="snapshot",
+            ...     table="vms",
             ...     description="Daily snapshot of production VM",
             ... )
 
@@ -718,19 +720,18 @@ class TaskManager(ResourceManager[Task]):
             ...     name="One-time Backup",
             ...     owner=vm.key,
             ...     action="snapshot",
+            ...     table="vms",
             ...     delete_after_run=True,
             ... )
         """
         body: dict[str, Any] = {
             "name": name,
-            "owner": owner,
+            "owner": f"{table}/{owner}",
             "action": action,
             "enabled": enabled,
             "delete_after_run": delete_after_run,
         }
 
-        if table is not None:
-            body["table"] = table
         if description is not None:
             body["description"] = description
         if settings_args is not None:

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -600,13 +600,12 @@ class TestAPIKeyManager:
         client.users.get.assert_called_once_with(name="admin")
 
     def test_resolve_user_key_not_found(self) -> None:
-        """Test _resolve_user_key returns None when user not found."""
+        """Test _resolve_user_key raises NotFoundError when user not found."""
         manager, client = self._create_manager()
         client.users.get.side_effect = NotFoundError("User not found")
 
-        result = manager._resolve_user_key("nonexistent")
-
-        assert result is None
+        with pytest.raises(NotFoundError):
+            manager._resolve_user_key("nonexistent")
 
     # _parse_expires_in() tests
 

--- a/tests/unit/test_oidc_applications.py
+++ b/tests/unit/test_oidc_applications.py
@@ -517,6 +517,9 @@ class TestOidcApplicationManager:
         assert body["name"] == "Test"
         assert body["redirect_uri"] == "https://example.com/callback"
         assert body["description"] == "Test app"
+        # force_auth_source and map_user always included (default 0)
+        assert body["force_auth_source"] == 0
+        assert body["map_user"] == 0
 
     def test_create_with_list_redirect_uri(self, mock_client: MagicMock) -> None:
         """Test creating with list of redirect URIs."""

--- a/tests/unit/test_task_events.py
+++ b/tests/unit/test_task_events.py
@@ -325,7 +325,7 @@ class TestTaskEventManagerCreate:
             {"$key": 1, "event": "poweron", "task": 100, "owner": 123},  # GET response
         ]
 
-        event = mock_client.task_events.create(task=100, owner=123, event="poweron")
+        event = mock_client.task_events.create(task=100, event="poweron", table="vms")
 
         assert event.key == 1
         assert event.event_type == "poweron"
@@ -341,7 +341,6 @@ class TestTaskEventManagerCreate:
 
         event = mock_client.task_events.create(
             task=100,
-            owner=123,
             event="poweron",
             table="vms",
             event_name="Power On VM",
@@ -350,7 +349,7 @@ class TestTaskEventManagerCreate:
         )
 
         assert event.key == 1
-        # Verify POST body contained optional fields
+        # Verify POST body contained correct fields (no owner)
         post_calls = [
             c
             for c in mock_session.request.call_args_list
@@ -362,6 +361,7 @@ class TestTaskEventManagerCreate:
         assert body.get("event_name") == "Power On VM"
         assert body.get("table_event_filters") == {"severity": "warning"}
         assert body.get("context") == {"notify": True}
+        assert "owner" not in body
 
     def test_create_task_event_no_response(
         self, mock_client: VergeClient, mock_session: MagicMock
@@ -371,7 +371,7 @@ class TestTaskEventManagerCreate:
         mock_session.request.return_value.text = ""
 
         with pytest.raises(ValueError, match="No response from create operation"):
-            mock_client.task_events.create(task=100, owner=123, event="poweron")
+            mock_client.task_events.create(task=100, event="poweron", table="vms")
 
     def test_create_task_event_invalid_response(
         self, mock_client: VergeClient, mock_session: MagicMock
@@ -380,7 +380,7 @@ class TestTaskEventManagerCreate:
         mock_session.request.return_value.json.return_value = []
 
         with pytest.raises(ValueError, match="Create operation returned invalid response"):
-            mock_client.task_events.create(task=100, owner=123, event="poweron")
+            mock_client.task_events.create(task=100, event="poweron", table="vms")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes three bugs where the SDK constructed incorrect API request bodies:

- **#37** — `tasks.create()` sent `owner` as bare integer; API expects `"table/key"` format (e.g., `"vms/39"`). Also removed `owner` from `task_events.create()` since it's auto-populated from the parent task.
- **#38** — `oidc_applications.create()` omitted `force_auth_source` and `map_user` when `None`; API requires both fields (default `0` for "not set").
- **#39** — `api_keys.list(user=...)` silently returned all keys when the user couldn't be resolved; now raises `NotFoundError`.

Closes #37, closes #38, closes #39

## Changes

| File | Change |
|------|--------|
| `tasks.py` | `table` now required; `owner` formatted as `f"{table}/{owner}"` |
| `task_events.py` | Removed `owner` param; `table` now required (event source table) |
| `oidc_applications.py` | Always include `force_auth_source` and `map_user` (default `0`) |
| `api_keys.py` | `_resolve_user_key()` raises `NotFoundError` instead of returning `None` |

## Test plan

- [x] Updated unit tests for all four methods
- [x] All 4023 unit tests pass
- [x] mypy type checking passes
- [x] ruff lint and format clean