### PR TITLE
Fix snapshot retention field ignored by API

### DIFF
--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/pyvergeos/resources/cloud_snapshots.py
+++ b/pyvergeos/resources/cloud_snapshots.py
@@ -23,7 +23,6 @@ _DEFAULT_SNAPSHOT_FIELDS = [
     "description",
     "created",
     "expires",
-    "expires_type",
     "snapshot_profile",
     "private",
     "remote_sync",
@@ -556,10 +555,9 @@ class CloudSnapshot(ResourceObject):
 
     @property
     def never_expires(self) -> bool:
-        """Check if snapshot never expires."""
+        """Check if snapshot never expires (expires == 0)."""
         expires = self.get("expires")
-        expires_type = self.get("expires_type")
-        return expires_type == "never" or (expires is not None and int(expires) == 0)
+        return expires is not None and int(expires) == 0
 
     @property
     def snapshot_profile_key(self) -> int | None:
@@ -971,16 +969,22 @@ class CloudSnapshotManager(ResourceManager[CloudSnapshot]):
             "min_snapshots": min_snapshots,
         }
 
-        # Handle retention
+        # Handle expiry — API uses "expires" (absolute Unix timestamp) and
+        # "expires_type" ("never" or "date"). Note: expires_type is write-only
+        # (accepted on POST/PUT but not returned on GET).
         if never_expire:
-            body["retention"] = 0
+            body["expires"] = 0
+            body["expires_type"] = "never"
         elif retention is not None:
-            body["retention"] = int(retention.total_seconds())
+            body["expires"] = int(time.time() + retention.total_seconds())
+            body["expires_type"] = "date"
         elif retention_seconds is not None:
-            body["retention"] = retention_seconds
+            body["expires"] = int(time.time()) + retention_seconds
+            body["expires_type"] = "date"
         else:
             # Default: 3 days
-            body["retention"] = 259200
+            body["expires"] = int(time.time()) + 259200
+            body["expires_type"] = "date"
 
         if immutable:
             body["immutable"] = True

--- a/tests/unit/test_cloud_snapshots.py
+++ b/tests/unit/test_cloud_snapshots.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -216,24 +216,11 @@ class TestCloudSnapshot:
         assert snapshot.status == "normal"
         assert snapshot.status_info == ""
 
-    def test_snapshot_never_expires_by_type(self, mock_client: VergeClient) -> None:
-        """Test never_expires detection via expires_type."""
-        data = {
-            "$key": 1,
-            "name": "Never Expires",
-            "expires_type": "never",
-            "expires": 0,
-        }
-        snapshot = CloudSnapshot(data, mock_client.cloud_snapshots)
-        assert snapshot.never_expires is True
-        assert snapshot.expires_at is None
-
-    def test_snapshot_never_expires_by_zero(self, mock_client: VergeClient) -> None:
+    def test_snapshot_never_expires(self, mock_client: VergeClient) -> None:
         """Test never_expires detection via zero expires value."""
         data = {
             "$key": 1,
             "name": "Never Expires",
-            "expires_type": "time",
             "expires": 0,
         }
         snapshot = CloudSnapshot(data, mock_client.cloud_snapshots)
@@ -524,10 +511,12 @@ class TestCloudSnapshotManager:
         with pytest.raises(ValueError, match="Either key or name must be provided"):
             mock_client.cloud_snapshots.get()
 
+    @patch("pyvergeos.resources.cloud_snapshots.time")
     def test_create_snapshot_default(
-        self, mock_client: VergeClient, mock_session: MagicMock
+        self, mock_time: MagicMock, mock_client: VergeClient, mock_session: MagicMock
     ) -> None:
         """Test creating a snapshot with defaults."""
+        mock_time.time.return_value = 1735689600.0
         created_data = {
             "$key": 5,
             "name": "Snapshot_20250101_1234",
@@ -540,20 +529,24 @@ class TestCloudSnapshotManager:
 
         assert snapshot.key == 5
 
-        # Verify POST call - check any call that had json body with "name" key
+        # Verify POST call
         found_create = False
         for call in mock_session.request.call_args_list:
             body = call.kwargs.get("json", {})
             if body and body.get("name") == "Test Create":
                 found_create = True
-                assert body.get("retention") == 259200  # Default 3 days
+                assert body.get("expires") == 1735689600 + 259200
+                assert body.get("expires_type") == "date"
+                assert "retention" not in body
                 break
         assert found_create, "Create call not found"
 
+    @patch("pyvergeos.resources.cloud_snapshots.time")
     def test_create_snapshot_custom_retention(
-        self, mock_client: VergeClient, mock_session: MagicMock
+        self, mock_time: MagicMock, mock_client: VergeClient, mock_session: MagicMock
     ) -> None:
         """Test creating a snapshot with custom retention_seconds."""
+        mock_time.time.return_value = 1735689600.0
         created_data = {"$key": 6, "name": "Custom Retention"}
         mock_session.request.return_value.json.return_value = created_data
 
@@ -564,14 +557,18 @@ class TestCloudSnapshotManager:
             body = call.kwargs.get("json", {})
             if body and body.get("name") == "Custom Retention":
                 found = True
-                assert body.get("retention") == 3600
+                assert body.get("expires") == 1735689600 + 3600
+                assert body.get("expires_type") == "date"
+                assert "retention" not in body
                 break
         assert found, "Create call not found"
 
+    @patch("pyvergeos.resources.cloud_snapshots.time")
     def test_create_snapshot_timedelta_retention(
-        self, mock_client: VergeClient, mock_session: MagicMock
+        self, mock_time: MagicMock, mock_client: VergeClient, mock_session: MagicMock
     ) -> None:
         """Test creating a snapshot with timedelta retention."""
+        mock_time.time.return_value = 1735689600.0
         created_data = {"$key": 7, "name": "Timedelta Retention"}
         mock_session.request.return_value.json.return_value = created_data
 
@@ -582,7 +579,9 @@ class TestCloudSnapshotManager:
             body = call.kwargs.get("json", {})
             if body and body.get("name") == "Timedelta Retention":
                 found = True
-                assert body.get("retention") == 7200  # 2 hours
+                assert body.get("expires") == 1735689600 + 7200
+                assert body.get("expires_type") == "date"
+                assert "retention" not in body
                 break
         assert found, "Create call not found"
 
@@ -600,7 +599,9 @@ class TestCloudSnapshotManager:
             body = call.kwargs.get("json", {})
             if body and body.get("name") == "Never Expire":
                 found = True
-                assert body.get("retention") == 0
+                assert body.get("expires") == 0
+                assert body.get("expires_type") == "never"
+                assert "retention" not in body
                 break
         assert found, "Create call not found"
 


### PR DESCRIPTION
## Summary

- **Bug:** `create()` sent `body["retention"]` (seconds) which the VergeOS API silently ignores — all snapshots got default 72h expiry regardless of user settings
- **Fix:** Send `body["expires"]` (absolute Unix timestamp) + `body["expires_type"]` (`"never"` or `"date"`) per the API schema
- Removed `expires_type` from default GET fields (write-only — accepted on POST/PUT, not returned on GET)
- Simplified `never_expires` property to use `expires == 0`
- **Version bump:** 1.1.0 → 1.1.1

## Test plan

- [x] 44 unit tests pass
- [x] Integration test: `create(retention_seconds=3600)` → `expires` correct (0s drift)
- [x] Integration test: `create(never_expire=True)` → `expires == 0`
- [x] Integration test: `create()` default → `expires` correct (0s drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)