### PR TITLE
Fix recipe deployment 404 when using network names

### DIFF
--- a/examples/recipe_example.py
+++ b/examples/recipe_example.py
@@ -142,11 +142,13 @@ def deploy_recipe() -> None:
 
         # Prepare answers based on common recipe question names
         # These are typical YB_* variables used by VergeOS recipes
+        # Network answers accept either a vnet key (int) or network name (str)
         answers = {
             "YB_CPU_CORES": 2,
             "YB_RAM": 4096,  # 4GB in MB
             "YB_HOSTNAME": "my-ubuntu-server",
             "YB_IP_ADDR_TYPE": "dhcp",
+            "YB_NIC_0_NET": "Internal",  # Network name or key
             "YB_USER": "ubuntu",
             "YB_PASSWORD": "secure-password-here",
         }

--- a/pyvergeos/resources/vm_recipes.py
+++ b/pyvergeos/resources/vm_recipes.py
@@ -767,6 +767,70 @@ class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
 
         raise ValueError("Either key or name must be provided")
 
+    def _resolve_network_answers(self, recipe: str, answers: dict[str, Any]) -> dict[str, Any]:
+        """Resolve network name strings to vnet keys in recipe answers.
+
+        The API expects network-type answers as integer vnet keys (or the
+        special value ``__new_internal__``). This helper fetches the recipe's
+        questions, identifies network-type ones, and resolves any string
+        network names to their vnet keys so callers can pass names directly.
+
+        Args:
+            recipe: Recipe $key (40-character hex string).
+            answers: Recipe answers dict (not mutated).
+
+        Returns:
+            New answers dict with network names resolved to keys.
+        """
+        # Fetch network-type questions for this recipe
+        questions = self._client.recipe_questions.list(
+            recipe_ref=f"vm_recipes/{recipe}",
+            fields=["$key", "name", "type"],
+            filter="type eq 'network'",
+        )
+        if not questions:
+            return answers
+
+        network_question_names = {q.get("name") for q in questions}
+
+        resolved = dict(answers)
+        for qname in network_question_names:
+            if qname not in resolved:
+                continue
+            val = resolved[qname]
+            # Skip ints, __new_internal__, and already-numeric strings
+            if isinstance(val, int):
+                continue
+            if not isinstance(val, str):
+                continue
+            if val == "__new_internal__":
+                continue
+            # Check if it's a numeric string (already a key)
+            try:
+                int(val)
+                continue
+            except ValueError:
+                pass
+            # Resolve network name to vnet key
+            response = self._client._request(
+                "GET",
+                "vnets",
+                params={
+                    "filter": f"name eq '{val.replace(chr(39), chr(39) * 2)}'",
+                    "fields": "$key,name",
+                },
+            )
+            if not response:
+                raise ValueError(f"Network '{val}' not found")
+            if isinstance(response, list):
+                if not response:
+                    raise ValueError(f"Network '{val}' not found")
+                resolved[qname] = response[0].get("$key")
+            else:
+                resolved[qname] = response.get("$key")
+
+        return resolved
+
     def create(  # type: ignore[override]
         self,
         recipe: str,
@@ -776,6 +840,10 @@ class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
         auto_update: bool = False,
     ) -> VmRecipeInstance:
         """Create a new recipe instance (deploy a recipe).
+
+        Network-type answers accept either a vnet key (int) or a network
+        name (str). Names are automatically resolved to keys before sending
+        to the API.
 
         Args:
             recipe: Recipe $key (40-character hex string).
@@ -790,7 +858,7 @@ class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
             >>> instance = client.vm_recipe_instances.create(
             ...     recipe="8f73f8bcc9c9...",
             ...     name="my-vm",
-            ...     answers={"ram": 4096}
+            ...     answers={"ram": 4096, "YB_NIC_0_NET": "Internal"}
             ... )
         """
         body: dict[str, Any] = {
@@ -799,7 +867,7 @@ class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
         }
 
         if answers is not None:
-            body["answers"] = answers
+            body["answers"] = self._resolve_network_answers(recipe, answers)
 
         if auto_update:
             body["auto_update"] = True
@@ -838,7 +906,13 @@ class VmRecipeInstanceManager(ResourceManager["VmRecipeInstance"]):
             body["auto_update"] = auto_update
 
         if answers is not None:
-            body["answers"] = answers
+            # Fetch the instance to get recipe key for question lookup
+            instance = self.get(key)
+            recipe_key = instance.get("recipe")
+            if recipe_key:
+                body["answers"] = self._resolve_network_answers(str(recipe_key), answers)
+            else:
+                body["answers"] = answers
 
         if not body:
             return self.get(key)

--- a/tests/unit/test_vm_recipes.py
+++ b/tests/unit/test_vm_recipes.py
@@ -499,6 +499,128 @@ class TestVmRecipeInstanceManagerCreate:
         assert body["auto_update"] is True
 
 
+class TestVmRecipeInstanceNetworkResolution:
+    """Tests for network name resolution in recipe answers."""
+
+    def test_create_resolves_network_name(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test that string network answers are resolved to vnet keys."""
+        from pyvergeos.resources.recipe_common import RecipeQuestion, RecipeQuestionManager
+
+        # Mock recipe_questions.list to return a network-type question
+        mock_qmgr = MagicMock(spec=RecipeQuestionManager)
+        net_q = RecipeQuestion({"$key": 1, "name": "YB_NIC_0_NET", "type": "network"}, mock_qmgr)
+        mock_client.recipe_questions.list.return_value = [net_q]
+
+        # Mock vnet lookup
+        mock_client._request.side_effect = [
+            [{"$key": 42, "name": "Internal"}],  # vnet lookup
+            {"$key": 1},  # POST create
+            sample_vm_recipe_instance,  # GET created instance
+        ]
+
+        result = vm_recipe_instance_manager.create(
+            recipe="abc123",
+            name="test-vm",
+            answers={"YB_NIC_0_NET": "Internal", "YB_RAM": 4096},
+        )
+
+        assert result.name == "my-ubuntu"
+        # The POST body should have the resolved network key, not the name
+        create_call = mock_client._request.call_args_list[1]
+        body = create_call[1]["json_data"]
+        assert body["answers"]["YB_NIC_0_NET"] == 42
+        assert body["answers"]["YB_RAM"] == 4096
+
+    def test_create_passes_int_network_unchanged(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test that integer network answers are passed through unchanged."""
+        from pyvergeos.resources.recipe_common import RecipeQuestion, RecipeQuestionManager
+
+        mock_qmgr = MagicMock(spec=RecipeQuestionManager)
+        net_q = RecipeQuestion({"$key": 1, "name": "YB_NIC_0_NET", "type": "network"}, mock_qmgr)
+        mock_client.recipe_questions.list.return_value = [net_q]
+
+        mock_client._request.side_effect = [
+            {"$key": 1},  # POST create (no vnet lookup needed)
+            sample_vm_recipe_instance,  # GET
+        ]
+
+        vm_recipe_instance_manager.create(
+            recipe="abc123",
+            name="test-vm",
+            answers={"YB_NIC_0_NET": 42},
+        )
+
+        create_call = mock_client._request.call_args_list[0]
+        body = create_call[1]["json_data"]
+        assert body["answers"]["YB_NIC_0_NET"] == 42
+
+    def test_create_passes_new_internal_unchanged(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test that __new_internal__ is passed through unchanged."""
+        from pyvergeos.resources.recipe_common import RecipeQuestion, RecipeQuestionManager
+
+        mock_qmgr = MagicMock(spec=RecipeQuestionManager)
+        net_q = RecipeQuestion({"$key": 1, "name": "YB_NIC_0_NET", "type": "network"}, mock_qmgr)
+        mock_client.recipe_questions.list.return_value = [net_q]
+
+        mock_client._request.side_effect = [
+            {"$key": 1},  # POST create
+            sample_vm_recipe_instance,  # GET
+        ]
+
+        vm_recipe_instance_manager.create(
+            recipe="abc123",
+            name="test-vm",
+            answers={"YB_NIC_0_NET": "__new_internal__"},
+        )
+
+        create_call = mock_client._request.call_args_list[0]
+        body = create_call[1]["json_data"]
+        assert body["answers"]["YB_NIC_0_NET"] == "__new_internal__"
+
+    def test_create_network_not_found_raises(self, vm_recipe_instance_manager, mock_client):
+        """Test that a missing network raises ValueError."""
+        from pyvergeos.resources.recipe_common import RecipeQuestion, RecipeQuestionManager
+
+        mock_qmgr = MagicMock(spec=RecipeQuestionManager)
+        net_q = RecipeQuestion({"$key": 1, "name": "YB_NIC_0_NET", "type": "network"}, mock_qmgr)
+        mock_client.recipe_questions.list.return_value = [net_q]
+        mock_client._request.return_value = []  # vnet lookup returns empty
+
+        with pytest.raises(ValueError, match="Network 'NonExistent' not found"):
+            vm_recipe_instance_manager.create(
+                recipe="abc123",
+                name="test-vm",
+                answers={"YB_NIC_0_NET": "NonExistent"},
+            )
+
+    def test_no_network_questions_passes_through(
+        self, vm_recipe_instance_manager, mock_client, sample_vm_recipe_instance
+    ):
+        """Test answers pass through when no network questions exist."""
+        mock_client.recipe_questions.list.return_value = []
+
+        mock_client._request.side_effect = [
+            {"$key": 1},  # POST create
+            sample_vm_recipe_instance,  # GET
+        ]
+
+        vm_recipe_instance_manager.create(
+            recipe="abc123",
+            name="test-vm",
+            answers={"YB_RAM": 4096},
+        )
+
+        create_call = mock_client._request.call_args_list[0]
+        body = create_call[1]["json_data"]
+        assert body["answers"] == {"YB_RAM": 4096}
+
+
 class TestVmRecipeInstanceManagerDelete:
     """Tests for VmRecipeInstanceManager.delete()."""
 


### PR DESCRIPTION
## Summary

- **Bug:** Deploying a VM from a recipe with a network name (e.g., `"Internal"`) instead of a vnet key (int) caused a 404 error because the API expects integer keys for network-type answers
- **Fix:** Added `_resolve_network_answers()` to `VmRecipeInstanceManager` that fetches the recipe's questions, identifies `type: "network"` ones, and resolves string names to vnet keys before sending to the API
- Integer keys and `"__new_internal__"` pass through unchanged
- Applied to both `create()` and `update()` paths
- Updated example to show network name usage

## Test plan

- [x] 61 unit tests pass (56 existing + 5 new for network resolution)
- [x] Integration test: network name resolved to correct vnet key
- [x] Integration test: integer key passed through unchanged
- [x] Integration test: `__new_internal__` passed through unchanged
- [x] Integration test: non-existent network raises `ValueError`
- [x] Integration test: non-network answers unaffected

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)