### PR TITLE
Fix: expose identifier param in GroupManager create/update

### DIFF
--- a/pyvergeos/resources/groups.py
+++ b/pyvergeos/resources/groups.py
@@ -604,6 +604,7 @@ class GroupManager(ResourceManager[Group]):
         *,
         description: str | None = None,
         email: str | None = None,
+        identifier: str | None = None,
         enabled: bool = True,
     ) -> Group:
         """Create a new group.
@@ -612,6 +613,8 @@ class GroupManager(ResourceManager[Group]):
             name: Group name (1-128 characters, must be unique).
             description: Group description (optional).
             email: Group email address (optional).
+            identifier: Group identifier for external identity linking
+                (e.g. EntraID). Must be unique if provided.
             enabled: Whether the group is enabled (default True).
 
         Returns:
@@ -625,7 +628,8 @@ class GroupManager(ResourceManager[Group]):
             >>> group = client.groups.create(
             ...     name="QA Team",
             ...     description="Quality Assurance team",
-            ...     email="qa@company.com"
+            ...     email="qa@company.com",
+            ...     identifier="entra-group-id-123"
             ... )
         """
         body: dict[str, Any] = {
@@ -638,6 +642,9 @@ class GroupManager(ResourceManager[Group]):
 
         if email:
             body["email"] = email.lower()
+
+        if identifier:
+            body["id"] = identifier
 
         response = self._client._request("POST", self._endpoint, json_data=body)
 
@@ -657,6 +664,7 @@ class GroupManager(ResourceManager[Group]):
         name: str | None = None,
         description: str | None = None,
         email: str | None = None,
+        identifier: str | None = None,
         enabled: bool | None = None,
     ) -> Group:
         """Update a group.
@@ -666,6 +674,8 @@ class GroupManager(ResourceManager[Group]):
             name: New group name.
             description: New description.
             email: New email address.
+            identifier: Group identifier for external identity linking
+                (e.g. EntraID). Pass empty string to clear.
             enabled: Enable or disable the group.
 
         Returns:
@@ -688,6 +698,9 @@ class GroupManager(ResourceManager[Group]):
 
         if email is not None:
             body["email"] = email.lower() if email else ""
+
+        if identifier is not None:
+            body["id"] = identifier
 
         if enabled is not None:
             body["enabled"] = enabled

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -658,6 +658,30 @@ class TestGroupManager:
         assert body["email"] == "qa@test.com"  # Should be lowercased
         assert body["enabled"] is True
 
+    def test_create_with_identifier(self, mock_client: MagicMock) -> None:
+        """Test group creation with identifier for external identity linking."""
+        mock_client._request.side_effect = [
+            {"$key": 5},  # POST response
+            {
+                "$key": 5,
+                "name": "EntraID Group",
+                "id": "entra-group-id-123",
+                "enabled": True,
+            },  # GET
+        ]
+        manager = GroupManager(mock_client)
+
+        result = manager.create(
+            name="EntraID Group",
+            identifier="entra-group-id-123",
+        )
+
+        assert isinstance(result, Group)
+        assert result.identifier == "entra-group-id-123"
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1]["json_data"]
+        assert body["id"] == "entra-group-id-123"
+
     def test_create_disabled(self, mock_client: MagicMock) -> None:
         """Test creating a disabled group."""
         mock_client._request.side_effect = [
@@ -713,6 +737,33 @@ class TestGroupManager:
 
         put_call = mock_client._request.call_args_list[0]
         assert put_call[1]["json_data"]["email"] == ""
+
+    def test_update_identifier(self, mock_client: MagicMock) -> None:
+        """Test update with identifier for external identity linking."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {"$key": 1, "id": "entra-group-id-456"},  # GET response
+        ]
+        manager = GroupManager(mock_client)
+
+        result = manager.update(key=1, identifier="entra-group-id-456")
+
+        assert result.identifier == "entra-group-id-456"
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["id"] == "entra-group-id-456"
+
+    def test_update_clear_identifier(self, mock_client: MagicMock) -> None:
+        """Test update with empty identifier clears it."""
+        mock_client._request.side_effect = [
+            None,  # PUT response
+            {"$key": 1},  # GET response
+        ]
+        manager = GroupManager(mock_client)
+
+        manager.update(key=1, identifier="")
+
+        put_call = mock_client._request.call_args_list[0]
+        assert put_call[1]["json_data"]["id"] == ""
 
     def test_update_no_changes(self, mock_client: MagicMock) -> None:
         """Test update with no changes just returns current state."""


### PR DESCRIPTION
## Summary
- Add `identifier` parameter to `GroupManager.create()` and `GroupManager.update()` methods
- Maps to the VergeOS `id` (Identifier) field used for linking groups to external identity providers (e.g. EntraID)
- Add unit tests for create with identifier, update with identifier, and clearing identifier

Closes #46

## Test plan
- [x] Unit tests pass (`uv run pytest tests/unit/test_groups.py` — 87 passed)
- [x] Lint/format clean (`ruff check` + `ruff format`)
- [ ] Integration test against live VergeOS with EntraID-linked group

🤖 Generated with [Claude Code](https://claude.com/claude-code)