### PR TITLE
fix: use row-action pattern for node maintenance endpoints

### DIFF
--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -1807,8 +1807,7 @@ class NodeManager(ResourceManager[Node]):
             >>> node = client.nodes.enable_maintenance(node.key)
             >>> print(f"Maintenance mode: {node.is_maintenance}")
         """
-        body = {"node": key, "action": "maintenance"}
-        self._client._request("POST", "node_actions/enable_maintenance", json_data=body)
+        self._client._request("POST", f"nodes/{key}/enable_maintenance", json_data={})
         return self.get(key)
 
     def disable_maintenance(self, key: int) -> Node:
@@ -1827,8 +1826,7 @@ class NodeManager(ResourceManager[Node]):
             >>> node = client.nodes.disable_maintenance(node.key)
             >>> print(f"Maintenance mode: {node.is_maintenance}")
         """
-        body = {"node": key, "action": "leavemaintenance"}
-        self._client._request("POST", "node_actions/disable_maintenance", json_data=body)
+        self._client._request("POST", f"nodes/{key}/disable_maintenance", json_data={})
         return self.get(key)
 
     def restart(self, key: int) -> dict[str, Any] | None:
@@ -1848,8 +1846,7 @@ class NodeManager(ResourceManager[Node]):
             >>> if result and "task" in result:
             ...     client.tasks.wait(result["task"])
         """
-        body = {"node": key, "action": "maintenance_reboot"}
-        response = self._client._request("POST", "node_actions/maintenance_reboot", json_data=body)
+        response = self._client._request("POST", f"nodes/{key}/maintenance_reboot", json_data={})
         if isinstance(response, dict):
             return response
         return None

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -800,9 +800,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         post_call = mock_client._request.call_args_list[0]
         assert post_call[0][0] == "POST"
-        assert "node_actions/enable_maintenance" in post_call[0][1]
-        assert post_call[1]["json_data"]["node"] == 1
-        assert post_call[1]["json_data"]["action"] == "maintenance"
+        assert post_call[0][1] == "nodes/1/enable_maintenance"
+        assert post_call[1]["json_data"] == {}
 
     def test_disable_maintenance(self) -> None:
         """Test disable_maintenance method."""
@@ -819,9 +818,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         post_call = mock_client._request.call_args_list[0]
         assert post_call[0][0] == "POST"
-        assert "node_actions/disable_maintenance" in post_call[0][1]
-        assert post_call[1]["json_data"]["node"] == 1
-        assert post_call[1]["json_data"]["action"] == "leavemaintenance"
+        assert post_call[0][1] == "nodes/1/disable_maintenance"
+        assert post_call[1]["json_data"] == {}
 
     def test_restart(self) -> None:
         """Test restart method."""
@@ -835,9 +833,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         call_args = mock_client._request.call_args
         assert call_args[0][0] == "POST"
-        assert "node_actions/maintenance_reboot" in call_args[0][1]
-        assert call_args[1]["json_data"]["node"] == 1
-        assert call_args[1]["json_data"]["action"] == "maintenance_reboot"
+        assert call_args[0][1] == "nodes/1/maintenance_reboot"
+        assert call_args[1]["json_data"] == {}
 
 
 class TestNodeManagerDeviceManagers:


### PR DESCRIPTION
## Summary

- `NodeManager.enable_maintenance()`, `disable_maintenance()`, and `restart()` were POSTing to a non-existent `node_actions` dispatch table
- Changed to use the standard row-action-on-resource pattern: `POST nodes/<key>/<action>` with empty body
- Updated unit tests to match new endpoint assertions

Fixes MAD-7

## Test plan

- [x] Unit tests pass (160/160)
- [x] Ruff lint + format checks pass
- [x] Integration test against live VergeOS system

🤖 Generated with [Claude Code](https://claude.com/claude-code)