### PR TITLE
Release v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.1.2"
+version = "1.2.0"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -55,9 +55,11 @@ if TYPE_CHECKING:
     from pyvergeos.resources.cloud_snapshots import CloudSnapshotManager
     from pyvergeos.resources.cloudinit_files import CloudInitFileManager
     from pyvergeos.resources.clusters import ClusterManager
+    from pyvergeos.resources.diagnostics import SystemDiagnosticManager
     from pyvergeos.resources.files import FileManager
     from pyvergeos.resources.gpu import NvidiaVgpuProfileManager
     from pyvergeos.resources.groups import GroupManager
+    from pyvergeos.resources.lldp import NodeLLDPNeighborManager
     from pyvergeos.resources.logs import LogManager
     from pyvergeos.resources.nas_cifs import NASCIFSShareManager
     from pyvergeos.resources.nas_nfs import NASNFSShareManager
@@ -67,6 +69,11 @@ if TYPE_CHECKING:
     from pyvergeos.resources.nas_volumes import NASVolumeManager, NASVolumeSnapshotManager
     from pyvergeos.resources.network_stats import NetworkDashboardManager
     from pyvergeos.resources.networks import NetworkManager
+    from pyvergeos.resources.nic_stats import (
+        MachineNicFabricStatusManager,
+        MachineNicStatsManager,
+        MachineNicStatusManager,
+    )
     from pyvergeos.resources.nodes import NodeManager
     from pyvergeos.resources.oidc_applications import (
         OidcApplicationGroupManager,
@@ -275,6 +282,11 @@ class VergeClient:
         self._update_source_status: UpdateSourceStatusManager | None = None
         self._update_logs: UpdateLogManager | None = None
         self._update_dashboard: UpdateDashboardManager | None = None
+        self._system_diagnostics: SystemDiagnosticManager | None = None
+        self._node_lldp_neighbors: NodeLLDPNeighborManager | None = None
+        self._machine_nic_stats: MachineNicStatsManager | None = None
+        self._machine_nic_status: MachineNicStatusManager | None = None
+        self._machine_nic_fabric_status: MachineNicFabricStatusManager | None = None
 
         if auto_connect:
             self.connect()
@@ -1866,3 +1878,87 @@ class VergeClient:
 
             self._update_dashboard = UpdateDashboardManager(self)
         return self._update_dashboard
+
+    @property
+    def system_diagnostics(self) -> SystemDiagnosticManager:
+        """Access system diagnostic bundle operations.
+
+        System diagnostics capture comprehensive system state for
+        troubleshooting, including logs, configuration, and hardware info.
+
+        Example:
+            >>> diag = client.system_diagnostics.create(
+            ...     name="issue-2024-01",
+            ...     description="Network connectivity issue",
+            ... )
+            >>> diag = client.system_diagnostics.wait(diag.key)
+            >>> client.system_diagnostics.send_to_support(diag.key)
+        """
+        if self._system_diagnostics is None:
+            from pyvergeos.resources.diagnostics import SystemDiagnosticManager
+
+            self._system_diagnostics = SystemDiagnosticManager(self)
+        return self._system_diagnostics
+
+    @property
+    def node_lldp_neighbors(self) -> NodeLLDPNeighborManager:
+        """Access LLDP neighbor discovery results across all nodes.
+
+        LLDP neighbors show connected switch ports and other network
+        devices discovered via Link Layer Discovery Protocol.
+
+        Example:
+            >>> for neighbor in client.node_lldp_neighbors.list():
+            ...     print(f"Node {neighbor.node_key}, NIC {neighbor.nic_key}: "
+            ...           f"{neighbor.chassis_name}")
+        """
+        if self._node_lldp_neighbors is None:
+            from pyvergeos.resources.lldp import NodeLLDPNeighborManager
+
+            self._node_lldp_neighbors = NodeLLDPNeighborManager(self)
+        return self._node_lldp_neighbors
+
+    @property
+    def machine_nic_stats(self) -> MachineNicStatsManager:
+        """Access machine NIC traffic statistics globally.
+
+        Example:
+            >>> stats = client.machine_nic_stats.list(
+            ...     filter="parent_nic eq 42"
+            ... )
+        """
+        if self._machine_nic_stats is None:
+            from pyvergeos.resources.nic_stats import MachineNicStatsManager
+
+            self._machine_nic_stats = MachineNicStatsManager(self)
+        return self._machine_nic_stats
+
+    @property
+    def machine_nic_status(self) -> MachineNicStatusManager:
+        """Access machine NIC link status globally.
+
+        Example:
+            >>> statuses = client.machine_nic_status.list(
+            ...     filter="parent_nic eq 42"
+            ... )
+        """
+        if self._machine_nic_status is None:
+            from pyvergeos.resources.nic_stats import MachineNicStatusManager
+
+            self._machine_nic_status = MachineNicStatusManager(self)
+        return self._machine_nic_status
+
+    @property
+    def machine_nic_fabric_status(self) -> MachineNicFabricStatusManager:
+        """Access machine NIC fabric status globally.
+
+        Example:
+            >>> statuses = client.machine_nic_fabric_status.list(
+            ...     filter="parent_nic eq 42"
+            ... )
+        """
+        if self._machine_nic_fabric_status is None:
+            from pyvergeos.resources.nic_stats import MachineNicFabricStatusManager
+
+            self._machine_nic_fabric_status = MachineNicFabricStatusManager(self)
+        return self._machine_nic_fabric_status

--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -28,6 +28,7 @@ from pyvergeos.resources.cluster_tiers import (
     ClusterTierStatus,
 )
 from pyvergeos.resources.devices import Device, DeviceManager
+from pyvergeos.resources.diagnostics import SystemDiagnostic, SystemDiagnosticManager
 from pyvergeos.resources.gpu import (
     NodeGpu,
     NodeGpuInstance,
@@ -45,6 +46,7 @@ from pyvergeos.resources.gpu import (
     NvidiaVgpuProfile,
     NvidiaVgpuProfileManager,
 )
+from pyvergeos.resources.lldp import NodeLLDPNeighbor, NodeLLDPNeighborManager
 from pyvergeos.resources.machine_stats import (
     MachineLog,
     MachineLogManager,
@@ -96,6 +98,14 @@ from pyvergeos.resources.network_stats import (
     WireGuardPeerStatus,
     WireGuardPeerStatusManager,
 )
+from pyvergeos.resources.nic_stats import (
+    MachineNicFabricStatus,
+    MachineNicFabricStatusManager,
+    MachineNicStats,
+    MachineNicStatsManager,
+    MachineNicStatus,
+    MachineNicStatusManager,
+)
 from pyvergeos.resources.nodes import (
     Node,
     NodeDriver,
@@ -119,6 +129,14 @@ from pyvergeos.resources.oidc_applications import (
     OidcApplicationUserManager,
 )
 from pyvergeos.resources.permissions import Permission, PermissionManager
+from pyvergeos.resources.queries import (
+    NodeQueryManager,
+    QueryManager,
+    QueryResult,
+    ServiceContainerQueryManager,
+    TenantNodeQueryManager,
+    VNetQueryManager,
+)
 from pyvergeos.resources.recipe_common import (
     RecipeQuestion,
     RecipeQuestionManager,
@@ -253,10 +271,23 @@ __all__ = [
     "CloudSnapshotVMManager",
     "Device",
     "DeviceManager",
+    "ServiceContainerQueryManager",
+    "SystemDiagnostic",
+    "SystemDiagnosticManager",
+    "TenantNodeQueryManager",
+    "VNetQueryManager",
     "IPSecActiveConnection",
     "IPSecActiveConnectionManager",
+    "QueryManager",
+    "QueryResult",
     "MachineLog",
     "MachineLogManager",
+    "MachineNicFabricStatus",
+    "MachineNicFabricStatusManager",
+    "MachineNicStats",
+    "MachineNicStatsManager",
+    "MachineNicStatus",
+    "MachineNicStatusManager",
     "MachineStats",
     "MachineStatsHistory",
     "MachineStatsManager",
@@ -285,7 +316,10 @@ __all__ = [
     "Node",
     "NodeDriver",
     "NodeDriverManager",
+    "NodeLLDPNeighbor",
+    "NodeLLDPNeighborManager",
     "NodeManager",
+    "NodeQueryManager",
     "NodePCIDevice",
     "NodePCIDeviceManager",
     "NodeSriovNicDevice",

--- a/pyvergeos/resources/diagnostics.py
+++ b/pyvergeos/resources/diagnostics.py
@@ -1,0 +1,264 @@
+"""System diagnostic resource managers."""
+
+from __future__ import annotations
+
+import builtins
+import time
+from typing import TYPE_CHECKING, Any, Literal
+
+from pyvergeos.exceptions import NotFoundError, VergeTimeoutError
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+# Diagnostic status values
+DiagnosticStatus = Literal["initializing", "building", "uploading", "complete", "error"]
+
+# Default fields
+DIAGNOSTIC_DEFAULT_FIELDS = [
+    "$key",
+    "name",
+    "description",
+    "status",
+    "status_info",
+    "file",
+    "send2support",
+    "timestamp",
+]
+
+
+class SystemDiagnostic(ResourceObject):
+    """System diagnostic bundle resource object.
+
+    Represents a diagnostic bundle that captures system state for
+    troubleshooting. Max 100 diagnostics at a time.
+    """
+
+    @property
+    def name(self) -> str:
+        """Diagnostic name (unique)."""
+        return str(self.get("name", ""))
+
+    @property
+    def description(self) -> str:
+        """Diagnostic description."""
+        return str(self.get("description", ""))
+
+    @property
+    def status(self) -> str:  # noqa: A003
+        """Diagnostic status."""
+        return str(self.get("status", "initializing"))
+
+    @property
+    def is_complete(self) -> bool:
+        """Check if diagnostic bundle is ready."""
+        return self.status == "complete"
+
+    @property
+    def is_error(self) -> bool:
+        """Check if diagnostic failed."""
+        return self.status == "error"
+
+    @property
+    def is_building(self) -> bool:
+        """Check if diagnostic is still being built."""
+        return self.status in ("initializing", "building", "uploading")
+
+    @property
+    def status_info(self) -> str | None:
+        """Detailed status information."""
+        return self.get("status_info")
+
+    @property
+    def file_key(self) -> int | None:
+        """Associated file key (available when complete)."""
+        f = self.get("file")
+        return int(f) if f else None
+
+    @property
+    def timestamp(self) -> int | None:
+        """Creation timestamp."""
+        ts = self.get("timestamp")
+        return int(ts) if ts else None
+
+
+class SystemDiagnosticManager(ResourceManager[SystemDiagnostic]):
+    """Manager for system diagnostic bundle operations.
+
+    System diagnostics capture comprehensive system state including
+    logs, configuration, and hardware information for troubleshooting.
+    Max 100 diagnostics can exist at a time.
+
+    Examples:
+        Create and wait for a diagnostic::
+
+            diag = client.system_diagnostics.create(
+                name="issue-2024-01",
+                description="Network connectivity issue",
+            )
+            diag = client.system_diagnostics.wait(diag.key)
+            print(f"Status: {diag.status}")
+
+        Send diagnostic to support::
+
+            client.system_diagnostics.send_to_support(diag.key)
+    """
+
+    _endpoint = "system_diagnostics"
+    _default_fields = DIAGNOSTIC_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def _to_model(self, data: dict[str, Any]) -> SystemDiagnostic:
+        return SystemDiagnostic(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[SystemDiagnostic]:
+        """List system diagnostics.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+
+        Returns:
+            List of SystemDiagnostic objects.
+        """
+        if fields is None:
+            fields = self._default_fields
+        return super().list(
+            filter=filter,
+            fields=fields,
+            limit=limit,
+            offset=offset,
+            **filter_kwargs,
+        )
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> SystemDiagnostic:
+        """Get a diagnostic by key or name.
+
+        Args:
+            key: Diagnostic $key.
+            name: Diagnostic name (unique).
+            fields: List of fields to return.
+
+        Returns:
+            SystemDiagnostic object.
+
+        Raises:
+            NotFoundError: If diagnostic not found.
+            ValueError: If neither key nor name provided.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"Diagnostic {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Diagnostic {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            escaped_name = name.replace("'", "''")
+            results = self.list(filter=f"name eq '{escaped_name}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Diagnostic with name '{name}' not found")
+            return results[0]
+
+        raise ValueError("Either key or name must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        name: str,
+        description: str = "",
+        send2support: bool = False,
+    ) -> SystemDiagnostic:
+        """Create a new system diagnostic bundle.
+
+        Args:
+            name: Unique diagnostic name (max 128 chars).
+            description: Description (max 2048 chars).
+            send2support: Automatically send to Verge.io support.
+
+        Returns:
+            SystemDiagnostic object (status will be "initializing").
+        """
+        body: dict[str, Any] = {"name": name}
+        if description:
+            body["description"] = description
+        if send2support:
+            body["send2support"] = True
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+        if response is None:
+            raise ValueError("No response from diagnostic creation")
+        if not isinstance(response, dict):
+            raise ValueError("Diagnostic creation returned invalid response")
+
+        key = response.get("$key")
+        if key is not None:
+            return self.get(int(key))
+        return self._to_model(response)
+
+    def wait(
+        self,
+        key: int,
+        timeout: float = 300,
+        poll_interval: float = 5.0,
+    ) -> SystemDiagnostic:
+        """Wait for a diagnostic to complete.
+
+        Args:
+            key: Diagnostic $key.
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            Completed SystemDiagnostic.
+
+        Raises:
+            VergeTimeoutError: If diagnostic doesn't complete within timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            diag = self.get(key)
+            if diag.status in ("complete", "error"):
+                return diag
+            if time.monotonic() >= deadline:
+                raise VergeTimeoutError(
+                    f"Diagnostic {key} did not complete within {timeout}s (status: {diag.status})"
+                )
+            time.sleep(poll_interval)
+
+    def send_to_support(self, key: int) -> None:
+        """Send a completed diagnostic bundle to Verge.io support.
+
+        Args:
+            key: Diagnostic $key.
+        """
+        self._client._request(
+            "POST",
+            "system_diagnostic_actions",
+            json_data={
+                "system_diagnostic": key,
+                "action": "send2support",
+            },
+        )

--- a/pyvergeos/resources/lldp.py
+++ b/pyvergeos/resources/lldp.py
@@ -1,0 +1,181 @@
+"""Node LLDP neighbor resource manager."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+# Default fields for LLDP neighbors
+LLDP_DEFAULT_FIELDS = [
+    "$key",
+    "node",
+    "nic",
+    "rid",
+    "via",
+    "age",
+    "chassis",
+    "port",
+    "vlan",
+    "other",
+]
+
+
+class NodeLLDPNeighbor(ResourceObject):
+    """LLDP neighbor discovery result.
+
+    Represents a neighbor device discovered via LLDP on a node's NIC.
+    Non-persistent — populated by LLDP discovery.
+    """
+
+    @property
+    def node_key(self) -> int:
+        """Parent node key."""
+        return int(self.get("node", 0))
+
+    @property
+    def nic_key(self) -> int:
+        """NIC key where neighbor was discovered."""
+        return int(self.get("nic", 0))
+
+    @property
+    def remote_id(self) -> str | None:
+        """Remote device identifier."""
+        return self.get("rid")
+
+    @property
+    def via(self) -> str | None:
+        """Discovery method/protocol."""
+        return self.get("via")
+
+    @property
+    def age(self) -> str | None:
+        """Age of LLDP data."""
+        return self.get("age")
+
+    @property
+    def chassis(self) -> dict[str, Any] | None:
+        """Chassis information from LLDP (JSON)."""
+        return self.get("chassis")
+
+    @property
+    def port(self) -> dict[str, Any] | None:
+        """Port information from LLDP (JSON)."""
+        return self.get("port")
+
+    @property
+    def vlan(self) -> dict[str, Any] | None:
+        """VLAN information from LLDP (JSON)."""
+        return self.get("vlan")
+
+    @property
+    def other(self) -> dict[str, Any] | None:
+        """Other LLDP information (JSON)."""
+        return self.get("other")
+
+    @property
+    def chassis_name(self) -> str | None:
+        """Convenience: extract chassis name if available."""
+        chassis = self.chassis
+        if isinstance(chassis, dict):
+            return chassis.get("name") or chassis.get("ChassisID")
+        return None
+
+    @property
+    def port_id(self) -> str | None:
+        """Convenience: extract port identifier if available."""
+        port = self.port
+        if isinstance(port, dict):
+            return port.get("PortID") or port.get("id")
+        return None
+
+
+class NodeLLDPNeighborManager(ResourceManager[NodeLLDPNeighbor]):
+    """Manager for node LLDP neighbor discovery results.
+
+    Read-only — neighbors are populated by LLDP discovery on the node.
+
+    Examples:
+        List LLDP neighbors for a node::
+
+            for neighbor in node.lldp_neighbors.list():
+                print(f"NIC {neighbor.nic_key}: {neighbor.chassis_name}")
+
+        Access globally::
+
+            neighbors = client.node_lldp_neighbors.list(
+                filter="node eq 1"
+            )
+    """
+
+    _endpoint = "node_lldp_neighbors"
+    _default_fields = LLDP_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, node_key: int | None = None) -> None:
+        super().__init__(client)
+        self._node_key = node_key
+
+    def _to_model(self, data: dict[str, Any]) -> NodeLLDPNeighbor:
+        return NodeLLDPNeighbor(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[NodeLLDPNeighbor]:
+        """List LLDP neighbors.
+
+        When scoped to a node, automatically filters by node key.
+
+        Args:
+            filter: Additional OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+
+        Returns:
+            List of NodeLLDPNeighbor objects.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        filters: builtins.list[str] = []
+        if self._node_key is not None:
+            filters.append(f"node eq {self._node_key}")
+        if filter:
+            filters.append(f"({filter})")
+
+        params: dict[str, Any] = {
+            "fields": ",".join(fields),
+        }
+        if filters:
+            params["filter"] = " and ".join(filters)
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+        if response is None:
+            return []
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+        return [self._to_model(item) for item in response]
+
+    def list_by_nic(self, nic_key: int) -> builtins.list[NodeLLDPNeighbor]:
+        """List LLDP neighbors discovered on a specific NIC.
+
+        Args:
+            nic_key: NIC $key to filter by.
+
+        Returns:
+            List of NodeLLDPNeighbor objects.
+        """
+        return self.list(filter=f"nic eq {nic_key}")

--- a/pyvergeos/resources/networks.py
+++ b/pyvergeos/resources/networks.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         IPSecActiveConnectionManager,
         NetworkMonitorStatsManager,
     )
+    from pyvergeos.resources.queries import VNetQueryManager
     from pyvergeos.resources.routing import NetworkRoutingManager
     from pyvergeos.resources.rules import NetworkRuleManager
     from pyvergeos.resources.vnet_proxy import VnetProxyManager
@@ -697,6 +698,31 @@ class Network(ResourceObject):
         if not isinstance(manager, NetworkManager):
             raise TypeError("Manager must be NetworkManager")
         return manager.diagnostics(self.key, diagnostic_type=diagnostic_type)
+
+    @property
+    def queries(self) -> VNetQueryManager:
+        """Access diagnostic queries for this network.
+
+        Returns:
+            VNetQueryManager scoped to this network.
+
+        Examples:
+            Run a ping::
+
+                result = network.queries.ping("8.8.8.8")
+                print(result.result)
+
+            Run a DNS lookup::
+
+                result = network.queries.dns("example.com")
+
+            Get ARP table::
+
+                result = network.queries.arp()
+        """
+        from pyvergeos.resources.queries import VNetQueryManager
+
+        return VNetQueryManager(self._manager._client, self.key)
 
     def statistics(
         self,

--- a/pyvergeos/resources/nic_stats.py
+++ b/pyvergeos/resources/nic_stats.py
@@ -1,0 +1,523 @@
+"""Machine NIC statistics, status, and fabric status resource managers."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any, Literal
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+# NIC link status values
+NicLinkStatus = Literal["up", "down", "unknown", "lowerlayerdown"]
+
+# NIC fabric status values
+NicFabricStatus = Literal["confirmed", "degraded", "no_path"]
+
+# State display mapping
+NIC_STATE_DISPLAY = {
+    "online": "Online",
+    "offline": "Offline",
+    "warning": "Warning",
+    "error": "Error",
+}
+
+# Link status display mapping
+NIC_LINK_STATUS_DISPLAY = {
+    "up": "Up",
+    "down": "Down",
+    "unknown": "Unknown",
+    "lowerlayerdown": "Lower Layer Down",
+}
+
+# Fabric status display mapping
+NIC_FABRIC_STATUS_DISPLAY = {
+    "confirmed": "Confirmed",
+    "degraded": "Degraded",
+    "no_path": "No Path",
+}
+
+# Default fields
+NIC_STATS_DEFAULT_FIELDS = [
+    "$key",
+    "parent_nic",
+    "txpps",
+    "rxpps",
+    "txbps",
+    "rxbps",
+    "totalxbps",
+    "tx_pckts",
+    "rx_pckts",
+    "tx_bytes",
+    "rx_bytes",
+    "tx_pckts_cur",
+    "rx_pckts_cur",
+    "tx_bytes_cur",
+    "rx_bytes_cur",
+    "last_update",
+]
+
+NIC_STATUS_DEFAULT_FIELDS = [
+    "$key",
+    "parent_nic",
+    "status",
+    "state",
+    "speed",
+    "last_update",
+]
+
+NIC_FABRIC_STATUS_DEFAULT_FIELDS = [
+    "$key",
+    "parent_nic",
+    "status",
+    "state",
+    "max_score",
+    "min_score",
+    "paths",
+    "created",
+    "modified",
+]
+
+
+def _format_bps(bps: int | float) -> str:
+    """Format bits per second to human-readable string.
+
+    Args:
+        bps: Bits per second value.
+
+    Returns:
+        Formatted string like "1.23 Gbps".
+    """
+    if not bps:
+        return "0 bps"
+    units = ["bps", "Kbps", "Mbps", "Gbps", "Tbps"]
+    unit_index = 0
+    value = float(bps)
+    while value >= 1000 and unit_index < len(units) - 1:
+        value /= 1000
+        unit_index += 1
+    return f"{value:.2f} {units[unit_index]}"
+
+
+class MachineNicStats(ResourceObject):
+    """Machine NIC statistics resource object.
+
+    Provides real-time and cumulative traffic counters for a NIC.
+    """
+
+    @property
+    def nic_key(self) -> int:
+        """Parent NIC key."""
+        return int(self.get("parent_nic", 0))
+
+    @property
+    def tx_pps(self) -> int:
+        """Transmit packets per second."""
+        return int(self.get("txpps") or 0)
+
+    @property
+    def rx_pps(self) -> int:
+        """Receive packets per second."""
+        return int(self.get("rxpps") or 0)
+
+    @property
+    def tx_bps(self) -> int:
+        """Transmit bits per second."""
+        return int(self.get("txbps") or 0)
+
+    @property
+    def rx_bps(self) -> int:
+        """Receive bits per second."""
+        return int(self.get("rxbps") or 0)
+
+    @property
+    def total_bps(self) -> int:
+        """Total (TX + RX) bits per second."""
+        return int(self.get("totalxbps") or 0)
+
+    @property
+    def tx_packets(self) -> int:
+        """Total transmitted packets."""
+        return int(self.get("tx_pckts") or 0)
+
+    @property
+    def rx_packets(self) -> int:
+        """Total received packets."""
+        return int(self.get("rx_pckts") or 0)
+
+    @property
+    def tx_bytes(self) -> int:
+        """Total transmitted bytes."""
+        return int(self.get("tx_bytes") or 0)
+
+    @property
+    def rx_bytes(self) -> int:
+        """Total received bytes."""
+        return int(self.get("rx_bytes") or 0)
+
+    @property
+    def tx_packets_current(self) -> int:
+        """Current period transmitted packets."""
+        return int(self.get("tx_pckts_cur") or 0)
+
+    @property
+    def rx_packets_current(self) -> int:
+        """Current period received packets."""
+        return int(self.get("rx_pckts_cur") or 0)
+
+    @property
+    def tx_bytes_current(self) -> int:
+        """Current period transmitted bytes."""
+        return int(self.get("tx_bytes_cur") or 0)
+
+    @property
+    def rx_bytes_current(self) -> int:
+        """Current period received bytes."""
+        return int(self.get("rx_bytes_cur") or 0)
+
+    @property
+    def tx_bps_display(self) -> str:
+        """Formatted transmit rate."""
+        return _format_bps(self.tx_bps)
+
+    @property
+    def rx_bps_display(self) -> str:
+        """Formatted receive rate."""
+        return _format_bps(self.rx_bps)
+
+    @property
+    def total_bps_display(self) -> str:
+        """Formatted total rate."""
+        return _format_bps(self.total_bps)
+
+
+class MachineNicStatus(ResourceObject):
+    """Machine NIC link status resource object."""
+
+    @property
+    def nic_key(self) -> int:
+        """Parent NIC key."""
+        return int(self.get("parent_nic", 0))
+
+    @property
+    def link_status(self) -> str:
+        """Link status (up/down/unknown/lowerlayerdown)."""
+        return str(self.get("status", "unknown"))
+
+    @property
+    def link_status_display(self) -> str:
+        """Human-readable link status."""
+        return NIC_LINK_STATUS_DISPLAY.get(self.link_status, self.link_status)
+
+    @property
+    def state(self) -> str:
+        """Derived state (online/offline/warning/error)."""
+        return str(self.get("state", "offline"))
+
+    @property
+    def state_display(self) -> str:
+        """Human-readable state."""
+        return NIC_STATE_DISPLAY.get(self.state, self.state)
+
+    @property
+    def is_up(self) -> bool:
+        """Check if NIC link is up."""
+        return self.link_status == "up"
+
+    @property
+    def speed(self) -> int:
+        """Link speed in Mbps."""
+        return int(self.get("speed") or 0)
+
+    @property
+    def speed_display(self) -> str:
+        """Formatted link speed."""
+        speed = self.speed
+        if not speed:
+            return "Unknown"
+        if speed >= 1000:
+            return f"{speed // 1000} Gbps"
+        return f"{speed} Mbps"
+
+
+class MachineNicFabricStatus(ResourceObject):
+    """Machine NIC fabric status resource object.
+
+    Fabric status tracks the health of the VergeOS storage fabric
+    path through a NIC.
+    """
+
+    @property
+    def nic_key(self) -> int:
+        """Parent NIC key."""
+        return int(self.get("parent_nic", 0))
+
+    @property
+    def fabric_status(self) -> str:
+        """Fabric status (confirmed/degraded/no_path)."""
+        return str(self.get("status", "no_path"))
+
+    @property
+    def fabric_status_display(self) -> str:
+        """Human-readable fabric status."""
+        return NIC_FABRIC_STATUS_DISPLAY.get(self.fabric_status, self.fabric_status)
+
+    @property
+    def state(self) -> str:
+        """Derived state (online/offline/warning/error)."""
+        return str(self.get("state", "offline"))
+
+    @property
+    def state_display(self) -> str:
+        """Human-readable state."""
+        return NIC_STATE_DISPLAY.get(self.state, self.state)
+
+    @property
+    def is_healthy(self) -> bool:
+        """Check if fabric path is fully confirmed."""
+        return self.fabric_status == "confirmed"
+
+    @property
+    def is_degraded(self) -> bool:
+        """Check if fabric path is degraded."""
+        return self.fabric_status == "degraded"
+
+    @property
+    def max_score(self) -> float:
+        """Maximum fabric score."""
+        return float(self.get("max_score") or 0)
+
+    @property
+    def min_score(self) -> float:
+        """Minimum fabric score."""
+        return float(self.get("min_score") or 0)
+
+    @property
+    def paths(self) -> dict[str, Any] | builtins.list[Any] | None:
+        """Fabric path information (JSON)."""
+        return self.get("paths")
+
+
+class MachineNicStatsManager(ResourceManager[MachineNicStats]):
+    """Manager for machine NIC traffic statistics.
+
+    Read-only — stats are updated by the system.
+
+    Examples:
+        Get current stats for a NIC::
+
+            stats = nic.stats.get()
+            print(f"TX: {stats.tx_bps_display}, RX: {stats.rx_bps_display}")
+
+        Access from client directly::
+
+            stats_list = client.machine_nic_stats.list(
+                filter="parent_nic eq 42"
+            )
+    """
+
+    _endpoint = "machine_nic_stats"
+    _default_fields = NIC_STATS_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, nic_key: int | None = None) -> None:
+        super().__init__(client)
+        self._nic_key = nic_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineNicStats:
+        return MachineNicStats(data, self)
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> MachineNicStats:
+        """Get NIC statistics.
+
+        When scoped to a NIC (via nic_key), returns stats for that NIC.
+        When called with a key, fetches by $key directly.
+
+        Args:
+            key: Stats record $key (optional if scoped to a NIC).
+            fields: List of fields to return.
+
+        Returns:
+            MachineNicStats object.
+
+        Raises:
+            NotFoundError: If stats not found.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"NIC stats {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"NIC stats {key} returned invalid response")
+            return self._to_model(response)
+
+        if self._nic_key is not None:
+            params = {
+                "filter": f"parent_nic eq {self._nic_key}",
+                "fields": ",".join(fields),
+                "limit": 1,
+            }
+            response = self._client._request("GET", self._endpoint, params=params)
+            if response is None:
+                raise NotFoundError(f"Stats not found for NIC {self._nic_key}")
+            if isinstance(response, list):
+                if not response:
+                    raise NotFoundError(f"Stats not found for NIC {self._nic_key}")
+                return self._to_model(response[0])
+            return self._to_model(response)
+
+        raise ValueError("Either key or scoped nic_key required")
+
+
+class MachineNicStatusManager(ResourceManager[MachineNicStatus]):
+    """Manager for machine NIC link status.
+
+    Read-only — status is updated by the system.
+
+    Examples:
+        Get current link status for a NIC::
+
+            status = nic.link_status.get()
+            print(f"Link: {status.link_status_display} at {status.speed_display}")
+    """
+
+    _endpoint = "machine_nic_status"
+    _default_fields = NIC_STATUS_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, nic_key: int | None = None) -> None:
+        super().__init__(client)
+        self._nic_key = nic_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineNicStatus:
+        return MachineNicStatus(data, self)
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> MachineNicStatus:
+        """Get NIC link status.
+
+        Args:
+            key: Status record $key (optional if scoped to a NIC).
+            fields: List of fields to return.
+
+        Returns:
+            MachineNicStatus object.
+
+        Raises:
+            NotFoundError: If status not found.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"NIC status {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"NIC status {key} returned invalid response")
+            return self._to_model(response)
+
+        if self._nic_key is not None:
+            params = {
+                "filter": f"parent_nic eq {self._nic_key}",
+                "fields": ",".join(fields),
+                "limit": 1,
+            }
+            response = self._client._request("GET", self._endpoint, params=params)
+            if response is None:
+                raise NotFoundError(f"Status not found for NIC {self._nic_key}")
+            if isinstance(response, list):
+                if not response:
+                    raise NotFoundError(f"Status not found for NIC {self._nic_key}")
+                return self._to_model(response[0])
+            return self._to_model(response)
+
+        raise ValueError("Either key or scoped nic_key required")
+
+
+class MachineNicFabricStatusManager(ResourceManager[MachineNicFabricStatus]):
+    """Manager for machine NIC fabric status.
+
+    Read-only — fabric status is updated by the system.
+    Tracks storage fabric path health through physical NICs.
+
+    Examples:
+        Get fabric status for a NIC::
+
+            fabric = nic.fabric_status.get()
+            print(f"Fabric: {fabric.fabric_status_display}")
+            if not fabric.is_healthy:
+                print(f"Score: {fabric.min_score}-{fabric.max_score}")
+    """
+
+    _endpoint = "machine_nic_fabric_status"
+    _default_fields = NIC_FABRIC_STATUS_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, nic_key: int | None = None) -> None:
+        super().__init__(client)
+        self._nic_key = nic_key
+
+    def _to_model(self, data: dict[str, Any]) -> MachineNicFabricStatus:
+        return MachineNicFabricStatus(data, self)
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> MachineNicFabricStatus:
+        """Get NIC fabric status.
+
+        Args:
+            key: Fabric status record $key (optional if scoped to a NIC).
+            fields: List of fields to return.
+
+        Returns:
+            MachineNicFabricStatus object.
+
+        Raises:
+            NotFoundError: If fabric status not found.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"NIC fabric status {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"NIC fabric status {key} returned invalid response")
+            return self._to_model(response)
+
+        if self._nic_key is not None:
+            params = {
+                "filter": f"parent_nic eq {self._nic_key}",
+                "fields": ",".join(fields),
+                "limit": 1,
+            }
+            response = self._client._request("GET", self._endpoint, params=params)
+            if response is None:
+                raise NotFoundError(f"Fabric status not found for NIC {self._nic_key}")
+            if isinstance(response, list):
+                if not response:
+                    raise NotFoundError(f"Fabric status not found for NIC {self._nic_key}")
+                return self._to_model(response[0])
+            return self._to_model(response)
+
+        raise ValueError("Either key or scoped nic_key required")

--- a/pyvergeos/resources/nics.py
+++ b/pyvergeos/resources/nics.py
@@ -10,6 +10,11 @@ from pyvergeos.resources.base import ResourceManager, ResourceObject
 
 if TYPE_CHECKING:
     from pyvergeos.client import VergeClient
+    from pyvergeos.resources.nic_stats import (
+        MachineNicFabricStatusManager,
+        MachineNicStatsManager,
+        MachineNicStatusManager,
+    )
     from pyvergeos.resources.vms import VM
 
 logger = logging.getLogger(__name__)
@@ -105,6 +110,51 @@ class NIC(ResourceObject):
     def tx_bytes(self) -> int:
         """Get transmitted bytes."""
         return int(self.get("tx_bytes") or 0)
+
+    @property
+    def nic_stats(self) -> MachineNicStatsManager:
+        """Access detailed traffic statistics for this NIC.
+
+        Returns:
+            MachineNicStatsManager scoped to this NIC.
+
+        Example:
+            >>> stats = nic.nic_stats.get()
+            >>> print(f"TX: {stats.tx_bps_display}, RX: {stats.rx_bps_display}")
+        """
+        from pyvergeos.resources.nic_stats import MachineNicStatsManager
+
+        return MachineNicStatsManager(self._manager._client, self.key)
+
+    @property
+    def link_status(self) -> MachineNicStatusManager:
+        """Access link status for this NIC.
+
+        Returns:
+            MachineNicStatusManager scoped to this NIC.
+
+        Example:
+            >>> status = nic.link_status.get()
+            >>> print(f"Link: {status.link_status_display} at {status.speed_display}")
+        """
+        from pyvergeos.resources.nic_stats import MachineNicStatusManager
+
+        return MachineNicStatusManager(self._manager._client, self.key)
+
+    @property
+    def fabric_status(self) -> MachineNicFabricStatusManager:
+        """Access fabric status for this NIC.
+
+        Returns:
+            MachineNicFabricStatusManager scoped to this NIC.
+
+        Example:
+            >>> fabric = nic.fabric_status.get()
+            >>> print(f"Fabric: {fabric.fabric_status_display}")
+        """
+        from pyvergeos.resources.nic_stats import MachineNicFabricStatusManager
+
+        return MachineNicFabricStatusManager(self._manager._client, self.key)
 
 
 class NICManager(ResourceManager[NIC]):

--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -17,11 +17,13 @@ if TYPE_CHECKING:
         NodeHostGpuDeviceManager,
         NodeVgpuDeviceManager,
     )
+    from pyvergeos.resources.lldp import NodeLLDPNeighborManager
     from pyvergeos.resources.machine_stats import (
         MachineLogManager,
         MachineStatsManager,
         MachineStatusManager,
     )
+    from pyvergeos.resources.queries import NodeQueryManager
 
 
 # Status display mappings
@@ -486,6 +488,36 @@ class Node(ResourceObject):
 
         manager = cast("NodeManager", self._manager)
         return manager.sriov_nics(self.key)
+
+    @property
+    def queries(self) -> NodeQueryManager:
+        """Access diagnostic queries for this node.
+
+        Returns:
+            NodeQueryManager scoped to this node.
+
+        Example:
+            >>> result = node.queries.ping("8.8.8.8")
+            >>> result = node.queries.run("ipmi-sensor")
+        """
+        from pyvergeos.resources.queries import NodeQueryManager
+
+        return NodeQueryManager(self._manager._client, self.key)
+
+    @property
+    def lldp_neighbors(self) -> NodeLLDPNeighborManager:
+        """Access LLDP neighbor discovery results for this node.
+
+        Returns:
+            NodeLLDPNeighborManager scoped to this node.
+
+        Example:
+            >>> for neighbor in node.lldp_neighbors.list():
+            ...     print(f"NIC {neighbor.nic_key}: {neighbor.chassis_name}")
+        """
+        from pyvergeos.resources.lldp import NodeLLDPNeighborManager
+
+        return NodeLLDPNeighborManager(self._manager._client, self.key)
 
     def __repr__(self) -> str:
         return (

--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -1807,8 +1807,7 @@ class NodeManager(ResourceManager[Node]):
             >>> node = client.nodes.enable_maintenance(node.key)
             >>> print(f"Maintenance mode: {node.is_maintenance}")
         """
-        body = {"node": key, "action": "maintenance"}
-        self._client._request("POST", "node_actions/enable_maintenance", json_data=body)
+        self._client._request("POST", f"nodes/{key}/enable_maintenance", json_data={})
         return self.get(key)
 
     def disable_maintenance(self, key: int) -> Node:
@@ -1827,8 +1826,7 @@ class NodeManager(ResourceManager[Node]):
             >>> node = client.nodes.disable_maintenance(node.key)
             >>> print(f"Maintenance mode: {node.is_maintenance}")
         """
-        body = {"node": key, "action": "leavemaintenance"}
-        self._client._request("POST", "node_actions/disable_maintenance", json_data=body)
+        self._client._request("POST", f"nodes/{key}/disable_maintenance", json_data={})
         return self.get(key)
 
     def restart(self, key: int) -> dict[str, Any] | None:
@@ -1848,8 +1846,7 @@ class NodeManager(ResourceManager[Node]):
             >>> if result and "task" in result:
             ...     client.tasks.wait(result["task"])
         """
-        body = {"node": key, "action": "maintenance_reboot"}
-        response = self._client._request("POST", "node_actions/maintenance_reboot", json_data=body)
+        response = self._client._request("POST", f"nodes/{key}/maintenance_reboot", json_data={})
         if isinstance(response, dict):
             return response
         return None

--- a/pyvergeos/resources/queries.py
+++ b/pyvergeos/resources/queries.py
@@ -1,0 +1,773 @@
+"""Async query resource managers for network and node diagnostics."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Literal
+
+from pyvergeos.exceptions import NotFoundError, VergeTimeoutError
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+logger = logging.getLogger(__name__)
+
+# Query status values
+QueryStatus = Literal["running", "error", "complete"]
+
+# Query types per endpoint
+VNetQueryType = Literal[
+    "logs",
+    "top",
+    "top_if",
+    "tcpdump",
+    "ping",
+    "dns",
+    "traceroute",
+    "ip",
+    "ipsec",
+    "whatsmyip",
+    "arp",
+    "arp-scan",
+    "frr",
+    "trace",
+    "dhcp_release_renew",
+    "wireguard",
+    "firewall",
+    "nmap",
+    "tcp_connect",
+]
+
+NodeQueryType = Literal[
+    "logs",
+    "top",
+    "top_if",
+    "tcpdump",
+    "ping",
+    "dns",
+    "traceroute",
+    "ip",
+    "bridge",
+    "whatsmyip",
+    "ipmi-sel",
+    "ipmi-sensor",
+    "ipmi-fru",
+    "ipmi-lan",
+    "ipmi-chassis",
+    "ipmi-bmc",
+    "ipmi-sdr",
+    "ipmi-reset",
+    "dmidecode",
+    "lsblk",
+    "arp",
+    "arp-scan",
+    "smartctl",
+    "smartctl-test",
+    "ledctl",
+    "openssl-speed",
+    "tcp_connect",
+    "eth-tool",
+    "fabric",
+    "clear-pstore",
+    "ras-mc-ctl",
+    "bonding",
+]
+
+ServiceContainerQueryType = Literal[
+    "logs",
+    "top",
+    "top_if",
+    "tcpdump",
+    "ping",
+    "dns",
+    "traceroute",
+    "ip",
+    "arp",
+    "arp-scan",
+    "whatsmyip",
+    "dhcp_release_renew",
+    "tcp_connect",
+]
+
+TenantNodeQueryType = Literal[
+    "logs",
+    "top",
+    "top_if",
+    "tcpdump",
+    "ping",
+    "dns",
+    "traceroute",
+    "ip",
+    "arp",
+    "arp-scan",
+    "whatsmyip",
+    "tcp_connect",
+]
+
+# Default fields for query results
+QUERY_DEFAULT_FIELDS = [
+    "$key",
+    "id",
+    "query",
+    "params",
+    "status",
+    "result",
+    "command",
+    "created",
+    "modified",
+    "expires",
+]
+
+
+class QueryResult(ResourceObject):
+    """Async query result resource object.
+
+    Represents a query submitted to a VergeOS diagnostic endpoint.
+    Queries run asynchronously — poll ``status`` until ``complete`` or ``error``.
+
+    Note: Query resources use SHA1 string keys, not integer keys.
+    Use ``query_key`` instead of the base ``key`` property.
+    """
+
+    @property
+    def query_key(self) -> str:
+        """Query primary key (SHA1 string).
+
+        Query endpoints use string keys unlike most VergeOS resources.
+        """
+        k = self.get("$key")
+        if k is None:
+            raise ValueError("Query has no $key")
+        return str(k)
+
+    @property
+    def query_id(self) -> str:
+        """SHA1 query identifier."""
+        return str(self.get("id", ""))
+
+    @property
+    def query_type(self) -> str:
+        """Query type (e.g. ping, tcpdump, arp)."""
+        return str(self.get("query", ""))
+
+    @property
+    def status(self) -> str:  # noqa: A003
+        """Query status: running, error, or complete."""
+        return str(self.get("status", "running"))
+
+    @property
+    def is_complete(self) -> bool:
+        """Check if query has finished successfully."""
+        return self.status == "complete"
+
+    @property
+    def is_error(self) -> bool:
+        """Check if query ended in error."""
+        return self.status == "error"
+
+    @property
+    def is_running(self) -> bool:
+        """Check if query is still running."""
+        return self.status == "running"
+
+    @property
+    def result(self) -> str | None:
+        """Query result text (max 262KB)."""
+        return self.get("result")
+
+    @property
+    def command(self) -> str | None:
+        """Command that was executed (read-only)."""
+        return self.get("command")
+
+    @property
+    def params(self) -> dict[str, Any] | None:
+        """Query parameters."""
+        return self.get("params")
+
+
+class QueryManager(ResourceManager[QueryResult]):
+    """Base manager for async query endpoints.
+
+    All four query endpoints (vnet, node, service_container, tenant_node)
+    share the same async pattern: POST to create, poll status for
+    complete/error, read result.
+
+    Subclasses set ``_endpoint`` and ``_parent_field``.
+    """
+
+    _endpoint: str = ""
+    _parent_field: str = ""
+
+    def __init__(self, client: VergeClient, parent_key: int) -> None:
+        super().__init__(client)
+        self._parent_key = parent_key
+
+    def _to_model(self, data: dict[str, Any]) -> QueryResult:
+        return QueryResult(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[QueryResult]:
+        """List queries for this parent resource.
+
+        Args:
+            filter: Additional OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+
+        Returns:
+            List of QueryResult objects.
+        """
+        if fields is None:
+            fields = QUERY_DEFAULT_FIELDS
+
+        parent_filter = f"{self._parent_field} eq {self._parent_key}"
+        if filter:
+            parent_filter = f"{parent_filter} and ({filter})"
+
+        params: dict[str, Any] = {
+            "filter": parent_filter,
+            "fields": ",".join(fields),
+        }
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+        if response is None:
+            return []
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: str | int | None = None,
+        *,
+        query_id: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> QueryResult:
+        """Get a query by key or query ID.
+
+        Args:
+            key: Query $key (SHA1 string or integer row key).
+            query_id: SHA1 query identifier string.
+            fields: List of fields to return.
+
+        Returns:
+            QueryResult object.
+
+        Raises:
+            NotFoundError: If query not found.
+            ValueError: If neither key nor query_id provided.
+        """
+        if fields is None:
+            fields = QUERY_DEFAULT_FIELDS
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                raise NotFoundError(f"Query {key} not found")
+            if not isinstance(response, dict):
+                raise NotFoundError(f"Query {key} returned invalid response")
+            return self._to_model(response)
+
+        if query_id is not None:
+            escaped_id = query_id.replace("'", "''")
+            results = self.list(filter=f"id eq '{escaped_id}'", fields=fields, limit=1)
+            if not results:
+                raise NotFoundError(f"Query with id '{query_id}' not found")
+            return results[0]
+
+        raise ValueError("Either key or query_id must be provided")
+
+    def create(  # type: ignore[override]
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+    ) -> QueryResult:
+        """Submit a new async query.
+
+        Args:
+            query: Query type string (e.g. "ping", "tcpdump", "arp").
+            params: Query parameters (varies by query type).
+
+        Returns:
+            QueryResult object (status will be "running").
+        """
+        body: dict[str, Any] = {
+            self._parent_field: self._parent_key,
+            "query": query,
+        }
+        if params:
+            body["params"] = params
+
+        response = self._client._request("POST", self._endpoint, json_data=body)
+        if response is None:
+            raise ValueError("No response from query creation")
+        if not isinstance(response, dict):
+            raise ValueError("Query creation returned invalid response")
+
+        key = response.get("$key")
+        if key is not None:
+            return self.get(key)
+        return self._to_model(response)
+
+    def wait(
+        self,
+        key: str | int,
+        timeout: float = 120,
+        poll_interval: float = 1.0,
+    ) -> QueryResult:
+        """Poll a query until it completes or errors.
+
+        Args:
+            key: Query $key to poll (SHA1 string or integer).
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            Completed QueryResult.
+
+        Raises:
+            VergeTimeoutError: If query doesn't complete within timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            result = self.get(key)
+            if result.status in ("complete", "error"):
+                return result
+            if time.monotonic() >= deadline:
+                raise VergeTimeoutError(
+                    f"Query {key} did not complete within {timeout}s (status: {result.status})"
+                )
+            time.sleep(poll_interval)
+
+    def run(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 120,
+        poll_interval: float = 1.0,
+    ) -> QueryResult:
+        """Submit a query and wait for completion.
+
+        Convenience method combining create() + wait().
+
+        Args:
+            query: Query type string.
+            params: Query parameters.
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            Completed QueryResult.
+        """
+        result = self.create(query, params)
+        return self.wait(result.query_key, timeout=timeout, poll_interval=poll_interval)
+
+
+class VNetQueryManager(QueryManager):
+    """Manager for virtual network diagnostic queries.
+
+    Supports 19 query types including ping, dns, tcpdump, traceroute,
+    arp, firewall trace, and more.
+
+    Examples:
+        Run a ping query::
+
+            result = network.queries.run("ping", {"host": "8.8.8.8"})
+            print(result.result)
+
+        Run a tcpdump capture::
+
+            query = network.queries.create("tcpdump", {"interface": "eth0"})
+            # ... wait or poll ...
+            result = network.queries.get(query.key)
+    """
+
+    _endpoint = "vnet_queries"
+    _parent_field = "vnet"
+
+    def ping(
+        self,
+        target: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a ping query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+            **params: Additional ping parameters.
+
+        Returns:
+            Completed QueryResult with ping output.
+        """
+        return self.run("ping", {"host": target, **params}, timeout=timeout)
+
+    def dns(
+        self,
+        name: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a DNS lookup query.
+
+        Args:
+            name: Hostname to resolve.
+            timeout: Max seconds to wait for result.
+            **params: Additional DNS parameters.
+
+        Returns:
+            Completed QueryResult with DNS output.
+        """
+        return self.run("dns", {"name": name, **params}, timeout=timeout)
+
+    def traceroute(
+        self,
+        target: str,
+        timeout: float = 60,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a traceroute query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+            **params: Additional traceroute parameters.
+
+        Returns:
+            Completed QueryResult with traceroute output.
+        """
+        return self.run("traceroute", {"host": target, **params}, timeout=timeout)
+
+    def tcpdump(
+        self,
+        timeout: float = 120,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a packet capture query.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: tcpdump parameters (interface, count, filter, etc.).
+
+        Returns:
+            Completed QueryResult with capture output.
+        """
+        return self.run("tcpdump", params if params else None, timeout=timeout)
+
+    def arp(self, timeout: float = 30) -> QueryResult:
+        """Get ARP table.
+
+        Args:
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with ARP table output.
+        """
+        return self.run("arp", timeout=timeout)
+
+    def firewall(self, timeout: float = 30, **params: Any) -> QueryResult:
+        """Get firewall rule listing.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: Additional firewall query parameters.
+
+        Returns:
+            Completed QueryResult with nftables output.
+        """
+        return self.run("firewall", params if params else None, timeout=timeout)
+
+    def trace(self, timeout: float = 30, **params: Any) -> QueryResult:
+        """Run nftables packet trace.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: Trace parameters.
+
+        Returns:
+            Completed QueryResult with trace output.
+        """
+        return self.run("trace", params if params else None, timeout=timeout)
+
+
+class NodeQueryManager(QueryManager):
+    """Manager for node diagnostic queries.
+
+    Supports 30+ query types including system diagnostics, IPMI,
+    storage (smartctl, lsblk), network, and hardware queries.
+
+    Examples:
+        Check IPMI sensors::
+
+            result = node.queries.run("ipmi-sensor")
+            print(result.result)
+
+        Run a SMART check::
+
+            result = node.queries.run("smartctl", {"device": "/dev/sda"})
+    """
+
+    _endpoint = "node_queries"
+    _parent_field = "node"
+
+    def ping(
+        self,
+        target: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a ping query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+            **params: Additional ping parameters.
+
+        Returns:
+            Completed QueryResult with ping output.
+        """
+        return self.run("ping", {"host": target, **params}, timeout=timeout)
+
+    def dns(
+        self,
+        name: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a DNS lookup query.
+
+        Args:
+            name: Hostname to resolve.
+            timeout: Max seconds to wait for result.
+            **params: Additional DNS parameters.
+
+        Returns:
+            Completed QueryResult with DNS output.
+        """
+        return self.run("dns", {"name": name, **params}, timeout=timeout)
+
+    def traceroute(
+        self,
+        target: str,
+        timeout: float = 60,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a traceroute query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+            **params: Additional traceroute parameters.
+
+        Returns:
+            Completed QueryResult with traceroute output.
+        """
+        return self.run("traceroute", {"host": target, **params}, timeout=timeout)
+
+    def tcpdump(
+        self,
+        timeout: float = 120,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a packet capture query.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: tcpdump parameters.
+
+        Returns:
+            Completed QueryResult with capture output.
+        """
+        return self.run("tcpdump", params if params else None, timeout=timeout)
+
+    def arp(self, timeout: float = 30) -> QueryResult:
+        """Get ARP table.
+
+        Args:
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with ARP table output.
+        """
+        return self.run("arp", timeout=timeout)
+
+    def smartctl(
+        self,
+        device: str,
+        timeout: float = 60,
+        **params: Any,
+    ) -> QueryResult:
+        """Run SMART diagnostics on a drive.
+
+        Args:
+            device: Device path (e.g. /dev/sda).
+            timeout: Max seconds to wait for result.
+            **params: Additional smartctl parameters.
+
+        Returns:
+            Completed QueryResult with SMART output.
+        """
+        return self.run("smartctl", {"device": device, **params}, timeout=timeout)
+
+    def lsblk(self, timeout: float = 30) -> QueryResult:
+        """List block devices.
+
+        Args:
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with block device listing.
+        """
+        return self.run("lsblk", timeout=timeout)
+
+    def dmidecode(self, timeout: float = 30) -> QueryResult:
+        """Get DMI/SMBIOS hardware information.
+
+        Args:
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with hardware info.
+        """
+        return self.run("dmidecode", timeout=timeout)
+
+
+class ServiceContainerQueryManager(QueryManager):
+    """Manager for service container diagnostic queries.
+
+    Supports 13 query types for diagnosing network issues
+    within service containers.
+    """
+
+    _endpoint = "service_container_queries"
+    _parent_field = "service_container"
+
+    def ping(
+        self,
+        target: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a ping query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with ping output.
+        """
+        return self.run("ping", {"host": target, **params}, timeout=timeout)
+
+    def dns(
+        self,
+        name: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a DNS lookup query.
+
+        Args:
+            name: Hostname to resolve.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with DNS output.
+        """
+        return self.run("dns", {"name": name, **params}, timeout=timeout)
+
+    def traceroute(
+        self,
+        target: str,
+        timeout: float = 60,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a traceroute query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with traceroute output.
+        """
+        return self.run("traceroute", {"host": target, **params}, timeout=timeout)
+
+
+class TenantNodeQueryManager(QueryManager):
+    """Manager for tenant node diagnostic queries.
+
+    Supports 12 query types for diagnosing network and system
+    issues within tenant nodes.
+    """
+
+    _endpoint = "tenant_node_queries"
+    _parent_field = "tenant_node"
+
+    def ping(
+        self,
+        target: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a ping query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with ping output.
+        """
+        return self.run("ping", {"host": target, **params}, timeout=timeout)
+
+    def dns(
+        self,
+        name: str,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a DNS lookup query.
+
+        Args:
+            name: Hostname to resolve.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with DNS output.
+        """
+        return self.run("dns", {"name": name, **params}, timeout=timeout)
+
+    def traceroute(
+        self,
+        target: str,
+        timeout: float = 60,
+        **params: Any,
+    ) -> QueryResult:
+        """Run a traceroute query.
+
+        Args:
+            target: Target host or IP address.
+            timeout: Max seconds to wait for result.
+
+        Returns:
+            Completed QueryResult with traceroute output.
+        """
+        return self.run("traceroute", {"host": target, **params}, timeout=timeout)

--- a/pyvergeos/resources/queries.py
+++ b/pyvergeos/resources/queries.py
@@ -133,15 +133,24 @@ class QueryResult(ResourceObject):
     """
 
     @property
-    def query_key(self) -> str:
-        """Query primary key (SHA1 string).
+    def key(self) -> str:  # type: ignore[override]
+        """Resource primary key (SHA1 string).
 
-        Query endpoints use string keys unlike most VergeOS resources.
+        Overrides ``ResourceObject.key`` because query endpoints use
+        40-char SHA1 hex strings as ``$key``, not integers.
+
+        Raises:
+            ValueError: If resource has no $key.
         """
         k = self.get("$key")
         if k is None:
-            raise ValueError("Query has no $key")
+            raise ValueError("Resource has no $key - may not be persisted")
         return str(k)
+
+    @property
+    def query_key(self) -> str:
+        """Alias for ``key`` — query primary key (SHA1 string)."""
+        return self.key
 
     @property
     def query_id(self) -> str:
@@ -376,7 +385,7 @@ class QueryManager(ResourceManager[QueryResult]):
             Completed QueryResult.
         """
         result = self.create(query, params)
-        return self.wait(result.query_key, timeout=timeout, poll_interval=poll_interval)
+        return self.wait(result.key, timeout=timeout, poll_interval=poll_interval)
 
 
 class VNetQueryManager(QueryManager):

--- a/tests/integration/test_network_diagnostics.py
+++ b/tests/integration/test_network_diagnostics.py
@@ -1,0 +1,386 @@
+"""Integration tests for network diagnostics resource managers.
+
+Tests against the dev environment defined in .claude/TESTENV.md.
+Run with: uv run python tests/integration/test_network_diagnostics.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+from pyvergeos import VergeClient
+
+
+def get_client() -> VergeClient:
+    """Connect to dev environment."""
+    return VergeClient(
+        host="192.168.10.74",
+        username="admin",
+        password="QueenBuda44",
+        verify_ssl=False,
+    )
+
+
+def test_connection(client: VergeClient) -> bool:
+    """Verify basic connection works."""
+    print(f"  Connected to: {client.cloud_name}")
+    print(f"  Version: {client.version}")
+    return True
+
+
+# =============================================================================
+# Query Manager Tests
+# =============================================================================
+
+
+def test_vnet_query_list(client: VergeClient) -> bool:
+    """Test listing networks and accessing query manager."""
+    networks = client.networks.list(limit=5)
+    print(f"  Found {len(networks)} networks")
+    if not networks:
+        print("  SKIP: No networks found")
+        return True
+
+    # Find a running network
+    running = [n for n in networks if n.is_running]
+    if not running:
+        # Try fetching more
+        all_nets = client.networks.list_running()
+        running = all_nets[:1] if all_nets else []
+
+    if not running:
+        print("  SKIP: No running networks to query")
+        return True
+
+    net = running[0]
+    print(f"  Using network: {net.name} (key={net.key})")
+
+    # Test list (should return empty or existing queries)
+    queries = net.queries.list()
+    print(f"  Existing queries: {len(queries)}")
+    return True
+
+
+def test_vnet_query_ping(client: VergeClient) -> bool:
+    """Test running a ping query on a network."""
+    running = client.networks.list_running()
+    if not running:
+        print("  SKIP: No running networks")
+        return True
+
+    net = running[0]
+    print(f"  Pinging from network: {net.name} (key={net.key})")
+
+    try:
+        result = net.queries.ping("127.0.0.1", timeout=30)
+        print(f"  Status: {result.status}")
+        print(f"  Query ID: {result.query_id}")
+        if result.result:
+            # Show first 200 chars of result
+            preview = result.result[:200]
+            print(f"  Result preview: {preview}")
+        return True
+    except Exception as e:
+        print(f"  Query failed (may be expected if network has no router): {e}")
+        return True  # Not a test failure - some networks can't ping
+
+
+def test_vnet_query_arp(client: VergeClient) -> bool:
+    """Test running an ARP query on a network."""
+    running = client.networks.list_running()
+    if not running:
+        print("  SKIP: No running networks")
+        return True
+
+    net = running[0]
+    print(f"  ARP table from network: {net.name}")
+
+    try:
+        result = net.queries.arp(timeout=30)
+        print(f"  Status: {result.status}")
+        if result.result:
+            preview = result.result[:200]
+            print(f"  Result preview: {preview}")
+        return True
+    except Exception as e:
+        print(f"  ARP query failed: {e}")
+        return True
+
+
+def test_node_query_list(client: VergeClient) -> bool:
+    """Test listing nodes and accessing query manager."""
+    nodes = client.nodes.list(limit=5)
+    print(f"  Found {len(nodes)} nodes")
+    if not nodes:
+        print("  SKIP: No nodes found")
+        return True
+
+    node = nodes[0]
+    print(f"  Using node: {node.name} (key={node.key})")
+
+    queries = node.queries.list()
+    print(f"  Existing queries: {len(queries)}")
+    return True
+
+
+def test_node_query_lsblk(client: VergeClient) -> bool:
+    """Test running lsblk query on a node."""
+    nodes = client.nodes.list(limit=1)
+    if not nodes:
+        print("  SKIP: No nodes found")
+        return True
+
+    node = nodes[0]
+    print(f"  lsblk on node: {node.name}")
+
+    try:
+        result = node.queries.lsblk(timeout=30)
+        print(f"  Status: {result.status}")
+        if result.result:
+            preview = result.result[:300]
+            print(f"  Result preview: {preview}")
+        return True
+    except Exception as e:
+        print(f"  lsblk query failed: {e}")
+        return False
+
+
+# =============================================================================
+# NIC Stats/Status/Fabric Tests
+# =============================================================================
+
+
+def test_machine_nic_stats_global(client: VergeClient) -> bool:
+    """Test global NIC stats listing."""
+    stats = client.machine_nic_stats.list(limit=5)
+    print(f"  Found {len(stats)} NIC stats records")
+    if stats:
+        s = stats[0]
+        print(
+            f"  First NIC stats: parent_nic={s.nic_key}, "
+            f"tx={s.tx_bps_display}, rx={s.rx_bps_display}"
+        )
+    return True
+
+
+def test_machine_nic_status_global(client: VergeClient) -> bool:
+    """Test global NIC status listing."""
+    statuses = client.machine_nic_status.list(limit=5)
+    print(f"  Found {len(statuses)} NIC status records")
+    if statuses:
+        s = statuses[0]
+        print(
+            f"  First NIC status: parent_nic={s.nic_key}, "
+            f"link={s.link_status_display}, speed={s.speed_display}"
+        )
+    return True
+
+
+def test_machine_nic_fabric_status_global(client: VergeClient) -> bool:
+    """Test global NIC fabric status listing."""
+    fabrics = client.machine_nic_fabric_status.list(limit=5)
+    print(f"  Found {len(fabrics)} NIC fabric status records")
+    if fabrics:
+        f = fabrics[0]
+        print(
+            f"  First fabric status: parent_nic={f.nic_key}, "
+            f"status={f.fabric_status_display}, "
+            f"score={f.min_score}-{f.max_score}"
+        )
+    return True
+
+
+def test_nic_stats_scoped(client: VergeClient) -> bool:
+    """Test NIC stats through scoped manager on a VM NIC."""
+    vms = client.vms.list(limit=3)
+    if not vms:
+        print("  SKIP: No VMs found")
+        return True
+
+    for vm in vms:
+        try:
+            nics = vm.nics.list()
+            if nics:
+                nic = nics[0]
+                print(f"  Testing NIC {nic.key} on VM {vm.get('name', '?')}")
+                try:
+                    stats = nic.nic_stats.get()
+                    print(
+                        f"    Stats: tx={stats.tx_bps_display}, "
+                        f"rx={stats.rx_bps_display}, "
+                        f"total={stats.total_bps_display}"
+                    )
+                    return True
+                except Exception as e:
+                    print(f"    Stats not available for this NIC: {e}")
+                try:
+                    status = nic.link_status.get()
+                    print(f"    Status: {status.link_status_display} at {status.speed_display}")
+                    return True
+                except Exception as e:
+                    print(f"    Status not available for this NIC: {e}")
+        except Exception as e:
+            print(f"  Error accessing VM NICs: {e}")
+            continue
+
+    print("  SKIP: No VM NICs with stats found")
+    return True
+
+
+# =============================================================================
+# LLDP Neighbor Tests
+# =============================================================================
+
+
+def test_lldp_neighbors_global(client: VergeClient) -> bool:
+    """Test global LLDP neighbor listing."""
+    neighbors = client.node_lldp_neighbors.list(limit=10)
+    print(f"  Found {len(neighbors)} LLDP neighbors")
+    if neighbors:
+        n = neighbors[0]
+        print(
+            f"  First neighbor: node={n.node_key}, nic={n.nic_key}, "
+            f"chassis={n.chassis_name}, port={n.port_id}"
+        )
+    else:
+        print("  (No LLDP neighbors - normal if no LLDP-capable switches)")
+    return True
+
+
+def test_lldp_neighbors_scoped(client: VergeClient) -> bool:
+    """Test LLDP neighbors scoped to a node."""
+    nodes = client.nodes.list(limit=1)
+    if not nodes:
+        print("  SKIP: No nodes found")
+        return True
+
+    node = nodes[0]
+    print(f"  LLDP neighbors for node: {node.name}")
+    neighbors = node.lldp_neighbors.list()
+    print(f"  Found {len(neighbors)} neighbors")
+    if neighbors:
+        for n in neighbors[:3]:
+            print(f"    NIC {n.nic_key}: chassis={n.chassis_name}, port={n.port_id}, via={n.via}")
+    return True
+
+
+# =============================================================================
+# System Diagnostics Tests
+# =============================================================================
+
+
+def test_system_diagnostics_list(client: VergeClient) -> bool:
+    """Test listing system diagnostics."""
+    diags = client.system_diagnostics.list()
+    print(f"  Found {len(diags)} existing diagnostics")
+    for d in diags[:3]:
+        print(f"    {d.name}: status={d.status}, file={d.file_key}")
+    return True
+
+
+def test_system_diagnostics_create(client: VergeClient) -> bool:
+    """Test creating a system diagnostic (and clean up after)."""
+    import time
+
+    name = f"sdk-inttest-{int(time.time())}"
+    print(f"  Creating diagnostic: {name}")
+
+    diag = client.system_diagnostics.create(
+        name=name,
+        description="Integration test - safe to delete",
+    )
+    print(f"  Created: key={diag.key}, status={diag.status}")
+
+    # Wait for it to complete (up to 120s)
+    try:
+        diag = client.system_diagnostics.wait(diag.key, timeout=120, poll_interval=5)
+        print(f"  Completed: status={diag.status}, file={diag.file_key}")
+    except Exception as e:
+        print(f"  Wait ended: {e}")
+        # Fetch latest status
+        diag = client.system_diagnostics.get(diag.key)
+        print(f"  Current status: {diag.status}")
+
+    # Clean up
+    try:
+        client.system_diagnostics.delete(diag.key)
+        print(f"  Cleaned up diagnostic {name}")
+    except Exception as e:
+        print(f"  Cleanup failed (manual delete needed): {e}")
+
+    return True
+
+
+# =============================================================================
+# Runner
+# =============================================================================
+
+
+def run_tests() -> None:
+    """Run all integration tests."""
+    print("=" * 60)
+    print("Network Diagnostics Integration Tests")
+    print("=" * 60)
+
+    print("\nConnecting to dev environment...")
+    try:
+        client = get_client()
+    except Exception as e:
+        print(f"FATAL: Cannot connect to dev environment: {e}")
+        sys.exit(1)
+
+    tests = [
+        ("Connection", test_connection),
+        ("VNet Query - List", test_vnet_query_list),
+        ("VNet Query - Ping", test_vnet_query_ping),
+        ("VNet Query - ARP", test_vnet_query_arp),
+        ("Node Query - List", test_node_query_list),
+        ("Node Query - lsblk", test_node_query_lsblk),
+        ("NIC Stats - Global", test_machine_nic_stats_global),
+        ("NIC Status - Global", test_machine_nic_status_global),
+        ("NIC Fabric Status - Global", test_machine_nic_fabric_status_global),
+        ("NIC Stats - Scoped", test_nic_stats_scoped),
+        ("LLDP Neighbors - Global", test_lldp_neighbors_global),
+        ("LLDP Neighbors - Scoped", test_lldp_neighbors_scoped),
+        ("System Diagnostics - List", test_system_diagnostics_list),
+        ("System Diagnostics - Create/Wait/Delete", test_system_diagnostics_create),
+    ]
+
+    passed = 0
+    failed = 0
+    errors = []
+
+    for name, test_fn in tests:
+        print(f"\n[TEST] {name}")
+        try:
+            result = test_fn(client)
+            if result:
+                print("  ✓ PASS")
+                passed += 1
+            else:
+                print("  ✗ FAIL")
+                failed += 1
+                errors.append(name)
+        except Exception as e:
+            print(f"  ✗ ERROR: {e}")
+            traceback.print_exc()
+            failed += 1
+            errors.append(f"{name}: {e}")
+
+    print("\n" + "=" * 60)
+    print(f"Results: {passed} passed, {failed} failed out of {len(tests)}")
+    if errors:
+        print("Failures:")
+        for err in errors:
+            print(f"  - {err}")
+    print("=" * 60)
+
+    client.disconnect()
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/integration/test_node_queries_detailed.py
+++ b/tests/integration/test_node_queries_detailed.py
@@ -1,0 +1,378 @@
+"""Detailed NodeQueryManager integration test against node1.
+
+Tests all 30+ query types from the API schema.
+
+Run: uv run python tests/integration/test_node_queries_detailed.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+from pyvergeos import VergeClient
+from pyvergeos.resources.queries import NodeQueryManager, QueryManager
+
+NODE_NAME = "node1"
+
+
+def get_client() -> VergeClient:
+    return VergeClient(
+        host="192.168.10.74",
+        username="admin",
+        password="QueenBuda44",
+        verify_ssl=False,
+    )
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+def test_class_structure() -> bool:
+    """Verify NodeQueryManager class attributes."""
+    print(f"  _endpoint: {NodeQueryManager._endpoint}")
+    assert NodeQueryManager._endpoint == "node_queries"
+    print(f"  _parent_field: {NodeQueryManager._parent_field}")
+    assert NodeQueryManager._parent_field == "node"
+    print(f"  Inherits QueryManager: {issubclass(NodeQueryManager, QueryManager)}")
+    assert issubclass(NodeQueryManager, QueryManager)
+
+    # Convenience methods
+    for m in ["ping", "dns", "traceroute", "tcpdump", "arp", "smartctl", "lsblk", "dmidecode"]:
+        assert hasattr(NodeQueryManager, m), f"Missing method: {m}"
+        print(f"  Method {m}(): ✓")
+
+    # Base methods
+    for m in ["list", "get", "create", "wait", "run"]:
+        assert hasattr(NodeQueryManager, m)
+        print(f"  Base method {m}(): ✓")
+
+    return True
+
+
+def test_node_lookup(client: VergeClient) -> tuple[bool, int]:
+    """Find node1 and return its key."""
+    node = client.nodes.get(name=NODE_NAME)
+    print(f"  Found: name={node.name}, key={node.key}")
+    print(f"  Status: {node.status}")
+    return True, node.key
+
+
+def test_nested_manager(client: VergeClient, node_key: int) -> bool:
+    """Verify node.queries returns NodeQueryManager."""
+    node = client.nodes.get(node_key)
+    qm = node.queries
+    print(f"  Type: {type(qm).__name__}")
+    assert isinstance(qm, NodeQueryManager)
+    print(f"  _parent_key: {qm._parent_key}")
+    assert qm._parent_key == node_key
+    return True
+
+
+def test_list(client: VergeClient, node_key: int) -> bool:
+    """Test list()."""
+    node = client.nodes.get(node_key)
+    queries = node.queries.list()
+    print(f"  Returned {len(queries)} existing queries")
+    for q in queries[:3]:
+        print(f"    key={q.query_key}, type={q.query_type}, status={q.status}")
+    return True
+
+
+def run_query(
+    client: VergeClient,
+    node_key: int,
+    query_type: str,
+    params: dict | None = None,
+    timeout: float = 30,
+) -> tuple[str, str, str]:
+    """Run a single query type and return (status, result_preview, error)."""
+    node = client.nodes.get(node_key)
+    try:
+        if params:
+            result = node.queries.run(query_type, params, timeout=timeout)
+        else:
+            result = node.queries.run(query_type, timeout=timeout)
+
+        preview = ""
+        if result.result:
+            preview = result.result[:200].replace("\n", " | ")
+        return result.status, preview, ""
+    except Exception as e:
+        return "EXCEPTION", "", str(e)
+
+
+def test_convenience_ping(client: VergeClient, node_key: int) -> bool:
+    """Test ping() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.ping("127.0.0.1", timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "ping"
+    if result.result:
+        print(f"  Result: {result.result[:200]}")
+    return True
+
+
+def test_convenience_dns(client: VergeClient, node_key: int) -> bool:
+    """Test dns() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.dns("verge.io", timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "dns"
+    if result.result:
+        print(f"  Result: {result.result[:200]}")
+    return True
+
+
+def test_convenience_traceroute(client: VergeClient, node_key: int) -> bool:
+    """Test traceroute() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.traceroute("8.8.8.8", timeout=60)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "traceroute"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_convenience_arp(client: VergeClient, node_key: int) -> bool:
+    """Test arp() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.arp(timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "arp"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_convenience_smartctl(client: VergeClient, node_key: int) -> bool:
+    """Test smartctl() convenience method."""
+    node = client.nodes.get(node_key)
+    # Use first nvme device which should exist on the dev env
+    result = node.queries.smartctl("/dev/nvme0", timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "smartctl"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_convenience_lsblk(client: VergeClient, node_key: int) -> bool:
+    """Test lsblk() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.lsblk(timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "lsblk"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_convenience_dmidecode(client: VergeClient, node_key: int) -> bool:
+    """Test dmidecode() convenience method."""
+    node = client.nodes.get(node_key)
+    result = node.queries.dmidecode(timeout=30)
+    print(f"  Status: {result.status}, type: {result.query_type}")
+    assert result.query_type == "dmidecode"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_all_query_types(client: VergeClient, node_key: int) -> bool:
+    """Test all 30+ query types via raw run()."""
+    # All query types from the API schema
+    all_types = [
+        ("logs", None),
+        ("top", None),
+        ("top_if", None),
+        ("tcpdump", {"count": "3"}),
+        ("ping", {"host": "127.0.0.1"}),
+        ("dns", {"name": "verge.io"}),
+        ("traceroute", {"host": "8.8.8.8"}),
+        ("ip", None),
+        ("bridge", None),
+        ("whatsmyip", None),
+        ("ipmi-sel", None),
+        ("ipmi-sensor", None),
+        ("ipmi-fru", None),
+        ("ipmi-lan", None),
+        ("ipmi-chassis", None),
+        ("ipmi-bmc", None),
+        ("ipmi-sdr", None),
+        # ("ipmi-reset", None),  # Skip — destructive action
+        ("dmidecode", None),
+        ("lsblk", None),
+        ("arp", None),
+        ("arp-scan", None),
+        ("smartctl", {"device": "/dev/nvme0"}),
+        # ("smartctl-test", ...),  # Skip — long-running test
+        # ("ledctl", None),  # Skip — hardware-dependent
+        ("openssl-speed", None),
+        ("tcp_connect", {"host": "127.0.0.1", "port": "22"}),
+        ("eth-tool", None),
+        ("fabric", None),
+        # ("clear-pstore", None),  # Skip — destructive
+        ("ras-mc-ctl", None),
+        ("bonding", None),
+    ]
+
+    passed = 0
+    failed = 0
+    results_table = []
+
+    for qtype, params in all_types:
+        status, preview, error = run_query(client, node_key, qtype, params, timeout=45)
+        marker = "✓" if status in ("complete", "error") else "✗"
+        if status == "EXCEPTION":
+            marker = "✗"
+            results_table.append((qtype, "EXCEPTION", error[:80]))
+            failed += 1
+        else:
+            results_table.append((qtype, status, preview[:80] if preview else "(empty)"))
+            passed += 1
+
+        print(
+            f"  {marker} {qtype:20s} status={status:10s} {preview[:60] if preview else error[:60] if error else ''}"
+        )
+
+    print(f"\n  Summary: {passed} completed, {failed} exceptions out of {len(all_types)}")
+    return failed == 0
+
+
+def test_query_key_handling(client: VergeClient, node_key: int) -> bool:
+    """Verify SHA1 string key handling."""
+    node = client.nodes.get(node_key)
+    result = node.queries.run("whatsmyip", timeout=30)
+
+    qk = result.query_key
+    qi = result.query_id
+    print(f"  query_key: {qk} (type: {type(qk).__name__}, len: {len(qk)})")
+    print(f"  query_id:  {qi}")
+    print(f"  Match: {qk == qi}")
+    assert isinstance(qk, str)
+    assert len(qk) == 40  # SHA1 hex
+
+    # Re-fetch by key
+    refetched = node.queries.get(qk)
+    print(f"  Re-fetched: status={refetched.status}")
+    assert refetched.query_type == "whatsmyip"
+
+    # Re-fetch by query_id
+    refetched2 = node.queries.get(query_id=qi)
+    print(f"  Re-fetched by query_id: status={refetched2.status}")
+    return True
+
+
+def run() -> None:
+    print("=" * 60)
+    print("NodeQueryManager Detailed Integration Test")
+    print(f"Node: {NODE_NAME}")
+    print("=" * 60)
+
+    client = get_client()
+    print(f"Connected to {client.cloud_name} v{client.version}")
+
+    tests = []
+    node_key = 0
+
+    # 1. Class structure
+    section("1. Class Structure")
+    try:
+        ok = test_class_structure()
+        tests.append(("Class structure", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Class structure", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # 2. Node lookup
+    section("2. Node Lookup")
+    try:
+        ok, node_key = test_node_lookup(client)
+        tests.append(("Node lookup", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Node lookup", f"ERROR: {e}"))
+        traceback.print_exc()
+        print("\nCANNOT CONTINUE. Aborting.")
+        client.disconnect()
+        sys.exit(1)
+
+    # 3. Nested manager
+    section("3. Nested Manager (node.queries)")
+    try:
+        ok = test_nested_manager(client, node_key)
+        tests.append(("Nested manager", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Nested manager", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # 4. list()
+    section("4. list()")
+    try:
+        ok = test_list(client, node_key)
+        tests.append(("list()", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("list()", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # 5. SHA1 key handling
+    section("5. query_key / query_id Handling")
+    try:
+        ok = test_query_key_handling(client, node_key)
+        tests.append(("query_key handling", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("query_key handling", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # 6. Convenience methods
+    convenience = [
+        ("6a. ping()", test_convenience_ping),
+        ("6b. dns()", test_convenience_dns),
+        ("6c. traceroute()", test_convenience_traceroute),
+        ("6d. arp()", test_convenience_arp),
+        ("6e. smartctl()", test_convenience_smartctl),
+        ("6f. lsblk()", test_convenience_lsblk),
+        ("6g. dmidecode()", test_convenience_dmidecode),
+    ]
+
+    for name, fn in convenience:
+        section(name)
+        try:
+            ok = fn(client, node_key)
+            tests.append((name, "PASS" if ok else "FAIL"))
+        except Exception as e:
+            tests.append((name, f"ERROR: {e}"))
+            traceback.print_exc()
+
+    # 7. All 30+ query types
+    section("7. All Query Types (30+)")
+    try:
+        ok = test_all_query_types(client, node_key)
+        tests.append(("All query types", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("All query types", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    passed = sum(1 for _, s in tests if s == "PASS")
+    failed = sum(1 for _, s in tests if s != "PASS")
+    for name, status in tests:
+        marker = "✓" if status == "PASS" else "✗"
+        print(f"  {marker} {name}: {status}")
+    print(f"\n  {passed} passed, {failed} failed out of {len(tests)}")
+    print("=" * 60)
+
+    client.disconnect()
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/integration/test_sc_queries_detailed.py
+++ b/tests/integration/test_sc_queries_detailed.py
@@ -1,0 +1,200 @@
+"""ServiceContainerQueryManager integration test.
+
+Tests all 12 query types against running service containers on dev env.
+
+Run: uv run python tests/integration/test_sc_queries_detailed.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+from pyvergeos import VergeClient
+from pyvergeos.resources.queries import (
+    QueryManager,
+    ServiceContainerQueryManager,
+)
+
+HOST = "192.168.10.74"
+
+
+def get_client() -> VergeClient:
+    return VergeClient(host=HOST, username="admin", password="QueenBuda44", verify_ssl=False)
+
+
+def find_service_containers(client: VergeClient) -> list[dict]:
+    """Find running service containers."""
+    response = client._request(
+        "GET",
+        "service_containers",
+        params={
+            "fields": "$key,name",
+            "limit": 20,
+        },
+    )
+    if response is None:
+        return []
+    if isinstance(response, dict):
+        return [response]
+    return response
+
+
+def run() -> None:
+    print("=" * 60)
+    print("ServiceContainerQueryManager Integration Test")
+    print(f"Host: {HOST}")
+    print("=" * 60)
+
+    client = get_client()
+    print(f"Connected to {client.cloud_name} v{client.version}")
+
+    tests = []
+
+    # 1. Class structure
+    print("\n=== 1. Class Structure ===")
+    assert ServiceContainerQueryManager._endpoint == "service_container_queries"
+    print(f"  _endpoint: {ServiceContainerQueryManager._endpoint}")
+    assert ServiceContainerQueryManager._parent_field == "service_container"
+    print(f"  _parent_field: {ServiceContainerQueryManager._parent_field}")
+    assert issubclass(ServiceContainerQueryManager, QueryManager)
+    print("  Inherits QueryManager: True")
+    for m in ["ping", "dns", "traceroute"]:
+        assert hasattr(ServiceContainerQueryManager, m)
+        print(f"  Convenience {m}(): ✓")
+    for m in ["list", "get", "create", "wait", "run"]:
+        assert hasattr(ServiceContainerQueryManager, m)
+        print(f"  Base {m}(): ✓")
+    tests.append(("Class structure", "PASS"))
+
+    # 2. Find service containers
+    print("\n=== 2. Service Containers ===")
+    scs = find_service_containers(client)
+    if not scs:
+        print("  ERROR: No running service containers found")
+        tests.append(("Service container lookup", "FAIL"))
+        sys.exit(1)
+
+    for sc in scs:
+        print(f"  key={sc.get('$key')} name={sc.get('name', '?')}")
+    test_scs = [(int(sc["$key"]), sc["name"]) for sc in scs]
+    print(f"  Found {len(test_scs)} running service containers")
+    tests.append(("Service container lookup", "PASS"))
+
+    # 3. Manager instantiation
+    print("\n=== 3. Manager Instantiation ===")
+    for sc_key, sc_name in test_scs:
+        mgr = ServiceContainerQueryManager(client, parent_key=sc_key)
+        assert isinstance(mgr, ServiceContainerQueryManager)
+        assert mgr._parent_key == sc_key
+        print(f'  SC "{sc_name}" (key={sc_key}): ✓')
+    tests.append(("Manager instantiation", "PASS"))
+
+    # 4. list()
+    print("\n=== 4. list() ===")
+    for sc_key, sc_name in test_scs:
+        mgr = ServiceContainerQueryManager(client, parent_key=sc_key)
+        queries = mgr.list()
+        assert isinstance(queries, list)
+        print(f'  SC "{sc_name}": {len(queries)} existing queries')
+    tests.append(("list()", "PASS"))
+
+    # 5. query_key handling
+    print("\n=== 5. query_key / query_id ===")
+    sc_key, sc_name = test_scs[0]
+    mgr = ServiceContainerQueryManager(client, parent_key=sc_key)
+    try:
+        r = mgr.run("whatsmyip", timeout=30)
+        print(f'  SC "{sc_name}": whatsmyip → status={r.status}')
+        print(f"  query_key: {r.query_key} (len={len(r.query_key)})")
+        assert isinstance(r.query_key, str) and len(r.query_key) == 40
+        rf = mgr.get(r.query_key)
+        print(f"  Re-fetched by key: status={rf.status}")
+        rf2 = mgr.get(query_id=r.query_id)
+        print(f"  Re-fetched by query_id: status={rf2.status}")
+        if r.result:
+            print(f"  Result: {r.result.strip()}")
+        tests.append(("query_key handling", "PASS"))
+    except Exception as e:
+        print(f"  ERROR: {e}")
+        traceback.print_exc()
+        tests.append(("query_key handling", f"ERROR: {e}"))
+
+    # 6. Convenience methods
+    print("\n=== 6. Convenience Methods ===")
+    sc_key, sc_name = test_scs[0]
+    mgr = ServiceContainerQueryManager(client, parent_key=sc_key)
+    conv_ok = True
+    for name, fn in [
+        ("ping", lambda: mgr.ping("127.0.0.1", timeout=30)),
+        ("dns", lambda: mgr.dns("verge.io", timeout=30)),
+        ("traceroute", lambda: mgr.traceroute("8.8.8.8", timeout=60)),
+    ]:
+        try:
+            r = fn()
+            preview = (r.result or "")[:120].replace("\n", " | ")
+            print(f"  {name}: status={r.status}, type={r.query_type} | {preview}")
+            assert r.query_type == name
+        except Exception as e:
+            print(f"  {name}: ERROR: {e}")
+            conv_ok = False
+    tests.append(("Convenience methods", "PASS" if conv_ok else "FAIL"))
+
+    # 7. All 12 query types against BOTH service containers
+    print("\n=== 7. All Query Types (per service container) ===")
+
+    all_types = [
+        ("logs", None),
+        ("top", None),
+        ("top_if", None),
+        ("tcpdump", {"count": "3"}),
+        ("ping", {"host": "127.0.0.1"}),
+        ("dns", {"name": "verge.io"}),
+        ("traceroute", {"host": "8.8.8.8"}),
+        ("ip", None),
+        ("arp", None),
+        ("arp-scan", None),
+        ("whatsmyip", None),
+        # dhcp_release_renew skipped — would disrupt networking
+        ("tcp_connect", {"host": "127.0.0.1", "port": "22"}),
+    ]
+
+    all_ok = True
+    for sc_key, sc_name in test_scs:
+        print(f'\n  --- SC: "{sc_name}" (key={sc_key}) ---')
+        mgr = ServiceContainerQueryManager(client, parent_key=sc_key)
+        sc_passed = 0
+        sc_total = len(all_types)
+        for qtype, params in all_types:
+            try:
+                r = mgr.run(qtype, params, timeout=45) if params else mgr.run(qtype, timeout=45)
+                preview = (r.result or "")[:80].replace("\n", " | ")
+                print(f"  ✓ {qtype:20s} {r.status:10s} {preview}")
+                sc_passed += 1
+            except Exception as e:
+                print(f"  ✗ {qtype:20s} EXCEPTION  {str(e)[:80]}")
+                all_ok = False
+        print(f"  {sc_passed}/{sc_total} types executed")
+
+    print("\n  (skipped dhcp_release_renew — would disrupt active networking)")
+    tests.append(("All query types", "PASS" if all_ok else "FAIL"))
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    passed = sum(1 for _, s in tests if s == "PASS")
+    failed = sum(1 for _, s in tests if s != "PASS")
+    for name, status in tests:
+        marker = "✓" if status == "PASS" else "✗"
+        print(f"  {marker} {name}: {status}")
+    print(f"\n  {passed} passed, {failed} failed out of {len(tests)}")
+    print("=" * 60)
+
+    client.disconnect()
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/integration/test_vnet_queries_detailed.py
+++ b/tests/integration/test_vnet_queries_detailed.py
@@ -1,0 +1,422 @@
+"""Detailed VNetQueryManager integration test against network 'fghdfgh454'.
+
+Verifies:
+1. VNetQueryManager class exists with correct _endpoint and _parent_field
+2. Network lookup by name works
+3. network.queries accessor works (nested manager wiring)
+4. list() — lists existing queries for the network
+5. create() + get() — raw query submission and retrieval
+6. wait() — async polling
+7. run() — convenience create+wait
+8. query_key property — SHA1 string key handling
+9. Convenience methods: ping, dns, traceroute, arp, firewall, trace, tcpdump
+10. Raw create for additional query types: logs, top, ip, whatsmyip, etc.
+
+Run: uv run python tests/integration/test_vnet_queries_detailed.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+from pyvergeos import VergeClient
+from pyvergeos.resources.queries import QueryManager, QueryResult, VNetQueryManager
+
+NETWORK_NAME = "fghdfgh454"
+
+
+def get_client() -> VergeClient:
+    return VergeClient(
+        host="192.168.10.74",
+        username="admin",
+        password="QueenBuda44",
+        verify_ssl=False,
+    )
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+def test_class_structure() -> bool:
+    """Verify VNetQueryManager class attributes."""
+    print("  _endpoint:", VNetQueryManager._endpoint)
+    assert VNetQueryManager._endpoint == "vnet_queries", "Wrong endpoint"
+    print("  _parent_field:", VNetQueryManager._parent_field)
+    assert VNetQueryManager._parent_field == "vnet", "Wrong parent field"
+    print("  Inherits from QueryManager:", issubclass(VNetQueryManager, QueryManager))
+    assert issubclass(VNetQueryManager, QueryManager)
+
+    # Verify convenience methods exist
+    methods = ["ping", "dns", "traceroute", "tcpdump", "arp", "firewall", "trace"]
+    for m in methods:
+        assert hasattr(VNetQueryManager, m), f"Missing method: {m}"
+        print(f"  Method {m}(): ✓")
+
+    # Verify base methods exist
+    base_methods = ["list", "get", "create", "wait", "run"]
+    for m in base_methods:
+        assert hasattr(VNetQueryManager, m), f"Missing base method: {m}"
+        print(f"  Base method {m}(): ✓")
+
+    return True
+
+
+def test_network_lookup(client: VergeClient) -> tuple[bool, int]:
+    """Find network 'fghdfgh454' and return its key."""
+    net = client.networks.get(name=NETWORK_NAME)
+    print(f"  Found network: name={net.name}, key={net.key}")
+    print(f"  Running: {net.is_running}")
+    print(f"  Status: {net.status}")
+    return True, net.key
+
+
+def test_nested_manager_access(client: VergeClient, net_key: int) -> bool:
+    """Verify network.queries returns a VNetQueryManager."""
+    net = client.networks.get(net_key)
+    qm = net.queries
+    print(f"  Type: {type(qm).__name__}")
+    assert isinstance(qm, VNetQueryManager), f"Expected VNetQueryManager, got {type(qm)}"
+    print(f"  _parent_key: {qm._parent_key}")
+    assert qm._parent_key == net_key
+    return True
+
+
+def test_list(client: VergeClient, net_key: int) -> bool:
+    """Test list() — should return list of QueryResult objects."""
+    net = client.networks.get(net_key)
+    queries = net.queries.list()
+    print(f"  Returned {len(queries)} existing queries")
+    assert isinstance(queries, list)
+    for q in queries[:3]:
+        assert isinstance(q, QueryResult), f"Expected QueryResult, got {type(q)}"
+        print(f"    query_key={q.query_key}, type={q.query_type}, status={q.status}")
+    return True
+
+
+def test_create_and_get(client: VergeClient, net_key: int) -> bool:
+    """Test raw create() then get() by key."""
+    net = client.networks.get(net_key)
+
+    # Create a simple query
+    result = net.queries.create("whatsmyip")
+    print(f"  Created query: query_key={result.query_key}")
+    print(f"  query_id={result.query_id}")
+    print(f"  query_type={result.query_type}")
+    print(f"  status={result.status}")
+    assert isinstance(result, QueryResult)
+    assert result.query_key  # Should be a non-empty string
+
+    # Verify query_key is a SHA1 string (40 hex chars)
+    key = result.query_key
+    assert isinstance(key, str), f"query_key should be str, got {type(key)}"
+    print(f"  query_key type: {type(key).__name__}, length: {len(key)}")
+
+    # Get by key
+    fetched = net.queries.get(key)
+    print(f"  Fetched by key: status={fetched.status}, type={fetched.query_type}")
+    assert isinstance(fetched, QueryResult)
+
+    return True
+
+
+def test_wait(client: VergeClient, net_key: int) -> bool:
+    """Test create() + wait() — poll until complete."""
+    net = client.networks.get(net_key)
+
+    result = net.queries.create("whatsmyip")
+    print(f"  Created: key={result.query_key}, status={result.status}")
+
+    waited = net.queries.wait(result.query_key, timeout=30, poll_interval=1.0)
+    print(f"  After wait: status={waited.status}")
+    if waited.result:
+        print(f"  Result: {waited.result[:200]}")
+    assert waited.status in ("complete", "error")
+    return True
+
+
+def test_run(client: VergeClient, net_key: int) -> bool:
+    """Test run() — convenience create+wait in one call."""
+    net = client.networks.get(net_key)
+
+    result = net.queries.run("whatsmyip", timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_key: {result.query_key}")
+    if result.result:
+        print(f"  Result: {result.result[:200]}")
+    assert result.status in ("complete", "error")
+    return True
+
+
+def test_ping(client: VergeClient, net_key: int) -> bool:
+    """Test ping() convenience method."""
+    net = client.networks.get(net_key)
+    result = net.queries.ping("127.0.0.1", timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "ping"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_dns(client: VergeClient, net_key: int) -> bool:
+    """Test dns() convenience method."""
+    net = client.networks.get(net_key)
+    result = net.queries.dns("google.com", timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "dns"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_traceroute(client: VergeClient, net_key: int) -> bool:
+    """Test traceroute() convenience method."""
+    net = client.networks.get(net_key)
+    result = net.queries.traceroute("8.8.8.8", timeout=60)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "traceroute"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_arp(client: VergeClient, net_key: int) -> bool:
+    """Test arp() convenience method."""
+    net = client.networks.get(net_key)
+    result = net.queries.arp(timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "arp"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_firewall(client: VergeClient, net_key: int) -> bool:
+    """Test firewall() convenience method."""
+    net = client.networks.get(net_key)
+    result = net.queries.firewall(timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "firewall"
+    if result.result:
+        print(f"  Result: {result.result[:500]}")
+    return True
+
+
+def test_trace(client: VergeClient, net_key: int) -> bool:
+    """Test trace() convenience method (nftables trace)."""
+    net = client.networks.get(net_key)
+    result = net.queries.trace(timeout=30)
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "trace"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_tcpdump(client: VergeClient, net_key: int) -> bool:
+    """Test tcpdump() convenience method (short capture)."""
+    net = client.networks.get(net_key)
+    # Use count=5 to limit capture and ensure it completes
+    result = net.queries.tcpdump(timeout=30, count="5")
+    print(f"  Status: {result.status}")
+    print(f"  query_type: {result.query_type}")
+    assert result.query_type == "tcpdump"
+    if result.result:
+        print(f"  Result: {result.result[:300]}")
+    return True
+
+
+def test_remaining_query_types(client: VergeClient, net_key: int) -> bool:
+    """Test additional query types via raw create/wait."""
+    net = client.networks.get(net_key)
+
+    # Test a selection of the remaining query types
+    test_types = ["logs", "top", "ip"]
+
+    for qtype in test_types:
+        print(f"\n  --- {qtype} ---")
+        try:
+            result = net.queries.run(qtype, timeout=30)
+            print(f"  Status: {result.status}")
+            if result.result:
+                preview = result.result[:200].replace("\n", "\n    ")
+                print(f"  Result: {preview}")
+        except Exception as e:
+            print(f"  Error (may be expected): {e}")
+
+    return True
+
+
+def test_query_key_properties(client: VergeClient, net_key: int) -> bool:
+    """Verify query_key and query_id properties on a live result."""
+    net = client.networks.get(net_key)
+    result = net.queries.run("whatsmyip", timeout=30)
+
+    # query_key should be str
+    qk = result.query_key
+    print(f"  query_key: {qk}")
+    print(f"  query_key type: {type(qk).__name__}")
+    assert isinstance(qk, str)
+
+    # query_id should also be str (the 'id' field)
+    qi = result.query_id
+    print(f"  query_id: {qi}")
+    print(f"  query_id type: {type(qi).__name__}")
+    assert isinstance(qi, str)
+
+    # Both should be the same SHA1
+    print(f"  query_key == query_id: {qk == qi}")
+
+    # Verify we can re-fetch by this key
+    refetched = net.queries.get(qk)
+    print(f"  Re-fetched by query_key: status={refetched.status}")
+    assert refetched.query_type == "whatsmyip"
+
+    # Also test get by query_id
+    refetched2 = net.queries.get(query_id=qi)
+    print(f"  Re-fetched by query_id: status={refetched2.status}")
+
+    return True
+
+
+def run() -> None:
+    print("=" * 60)
+    print("VNetQueryManager Detailed Integration Test")
+    print(f"Network: {NETWORK_NAME}")
+    print("=" * 60)
+
+    client = get_client()
+    print(f"Connected to {client.cloud_name} v{client.version}")
+
+    tests: list[tuple[str, ...]] = []
+    net_key = 0
+
+    # Phase 1: Structure verification (no network needed)
+    section("1. Class Structure Verification")
+    try:
+        ok = test_class_structure()
+        tests.append(("Class structure", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Class structure", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # Phase 2: Find the network
+    section("2. Network Lookup")
+    try:
+        ok, net_key = test_network_lookup(client)
+        tests.append(("Network lookup", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Network lookup", f"ERROR: {e}"))
+        traceback.print_exc()
+        print("\nCANNOT CONTINUE without network. Aborting.")
+        client.disconnect()
+        sys.exit(1)
+
+    # Phase 3: Manager wiring
+    section("3. Nested Manager Access (network.queries)")
+    try:
+        ok = test_nested_manager_access(client, net_key)
+        tests.append(("Nested manager access", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Nested manager access", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # Phase 4: Core CRUD operations
+    section("4. list()")
+    try:
+        ok = test_list(client, net_key)
+        tests.append(("list()", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("list()", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    section("5. create() + get()")
+    try:
+        ok = test_create_and_get(client, net_key)
+        tests.append(("create() + get()", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("create() + get()", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    section("6. wait()")
+    try:
+        ok = test_wait(client, net_key)
+        tests.append(("wait()", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("wait()", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    section("7. run() (create+wait)")
+    try:
+        ok = test_run(client, net_key)
+        tests.append(("run()", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("run()", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    section("8. query_key / query_id Properties")
+    try:
+        ok = test_query_key_properties(client, net_key)
+        tests.append(("query_key/query_id", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("query_key/query_id", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # Phase 5: Convenience methods
+    convenience_tests = [
+        ("9. ping()", test_ping),
+        ("10. dns()", test_dns),
+        ("11. traceroute()", test_traceroute),
+        ("12. arp()", test_arp),
+        ("13. firewall()", test_firewall),
+        ("14. trace()", test_trace),
+        ("15. tcpdump()", test_tcpdump),
+    ]
+
+    for name, fn in convenience_tests:
+        section(name)
+        try:
+            ok = fn(client, net_key)
+            tests.append((name, "PASS" if ok else "FAIL"))
+        except Exception as e:
+            tests.append((name, f"ERROR: {e}"))
+            traceback.print_exc()
+
+    # Phase 6: Additional query types
+    section("16. Additional Query Types (logs, top, ip)")
+    try:
+        ok = test_remaining_query_types(client, net_key)
+        tests.append(("Additional query types", "PASS" if ok else "FAIL"))
+    except Exception as e:
+        tests.append(("Additional query types", f"ERROR: {e}"))
+        traceback.print_exc()
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    passed = sum(1 for _, s in tests if s == "PASS")
+    failed = sum(1 for _, s in tests if s != "PASS")
+    for name, status in tests:
+        marker = "✓" if status == "PASS" else "✗"
+        print(f"  {marker} {name}: {status}")
+    print(f"\n  {passed} passed, {failed} failed out of {len(tests)}")
+    print("=" * 60)
+
+    client.disconnect()
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,264 @@
+"""Unit tests for system diagnostic resource managers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError, VergeTimeoutError
+from pyvergeos.resources.diagnostics import (
+    SystemDiagnostic,
+    SystemDiagnosticManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def sample_diag_data() -> dict[str, Any]:
+    """Sample diagnostic data from API."""
+    return {
+        "$key": 1,
+        "name": "issue-2024-01",
+        "description": "Network connectivity issue",
+        "status": "complete",
+        "status_info": "Bundle ready",
+        "file": 42,
+        "send2support": False,
+        "timestamp": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_building_diag() -> dict[str, Any]:
+    """Sample building diagnostic data."""
+    return {
+        "$key": 2,
+        "name": "issue-2024-02",
+        "description": "",
+        "status": "building",
+        "status_info": "Collecting logs...",
+        "file": None,
+        "send2support": False,
+        "timestamp": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_error_diag() -> dict[str, Any]:
+    """Sample error diagnostic data."""
+    return {
+        "$key": 3,
+        "name": "issue-2024-03",
+        "description": "",
+        "status": "error",
+        "status_info": "Failed to collect data",
+        "file": None,
+        "send2support": False,
+        "timestamp": 1704067200,
+    }
+
+
+# =============================================================================
+# SystemDiagnostic Tests
+# =============================================================================
+
+
+class TestSystemDiagnostic:
+    """Tests for SystemDiagnostic resource object."""
+
+    def test_name(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.name == "issue-2024-01"
+
+    def test_description(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.description == "Network connectivity issue"
+
+    def test_status_complete(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.status == "complete"
+        assert diag.is_complete is True
+        assert diag.is_error is False
+        assert diag.is_building is False
+
+    def test_status_building(self, sample_building_diag: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_building_diag, MagicMock())
+        assert diag.status == "building"
+        assert diag.is_building is True
+        assert diag.is_complete is False
+
+    def test_status_error(self, sample_error_diag: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_error_diag, MagicMock())
+        assert diag.status == "error"
+        assert diag.is_error is True
+
+    def test_status_info(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.status_info == "Bundle ready"
+
+    def test_file_key(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.file_key == 42
+
+    def test_file_key_none(self, sample_building_diag: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_building_diag, MagicMock())
+        assert diag.file_key is None
+
+    def test_timestamp(self, sample_diag_data: dict[str, Any]) -> None:
+        diag = SystemDiagnostic(sample_diag_data, MagicMock())
+        assert diag.timestamp == 1704067200
+
+    def test_defaults_when_empty(self) -> None:
+        diag = SystemDiagnostic({}, MagicMock())
+        assert diag.name == ""
+        assert diag.description == ""
+        assert diag.status == "initializing"
+        assert diag.status_info is None
+        assert diag.file_key is None
+        assert diag.timestamp is None
+
+
+# =============================================================================
+# SystemDiagnosticManager Tests
+# =============================================================================
+
+
+class TestSystemDiagnosticManager:
+    """Tests for SystemDiagnosticManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = SystemDiagnosticManager(mock_client)
+        assert manager._endpoint == "system_diagnostics"
+
+    def test_list(
+        self,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_diag_data]
+        manager = SystemDiagnosticManager(mock_client)
+        results = manager.list()
+        assert len(results) == 1
+        assert isinstance(results[0], SystemDiagnostic)
+
+    def test_list_empty(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = None
+        manager = SystemDiagnosticManager(mock_client)
+        assert manager.list() == []
+
+    def test_get_by_key(
+        self,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_diag_data
+        manager = SystemDiagnosticManager(mock_client)
+        diag = manager.get(1)
+        assert isinstance(diag, SystemDiagnostic)
+        assert diag.name == "issue-2024-01"
+
+    def test_get_by_name(
+        self,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_diag_data]
+        manager = SystemDiagnosticManager(mock_client)
+        diag = manager.get(name="issue-2024-01")
+        assert diag.name == "issue-2024-01"
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = None
+        manager = SystemDiagnosticManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(999)
+
+    def test_get_by_name_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = SystemDiagnosticManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(name="nonexistent")
+
+    def test_get_no_args(self, mock_client: MagicMock) -> None:
+        manager = SystemDiagnosticManager(mock_client)
+        with pytest.raises(ValueError, match="Either key or name"):
+            manager.get()
+
+    def test_create(
+        self,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_diag_data
+        manager = SystemDiagnosticManager(mock_client)
+        manager.create(
+            name="issue-2024-01",
+            description="Network connectivity issue",
+        )
+
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call.args[0] == "POST"
+        assert post_call.args[1] == "system_diagnostics"
+        body = post_call.kwargs["json_data"]
+        assert body["name"] == "issue-2024-01"
+        assert body["description"] == "Network connectivity issue"
+
+    def test_create_with_send2support(
+        self,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_diag_data
+        manager = SystemDiagnosticManager(mock_client)
+        manager.create(name="test", send2support=True)
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call.kwargs["json_data"]
+        assert body["send2support"] is True
+
+    @patch("pyvergeos.resources.diagnostics.time.sleep")
+    def test_wait_complete(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_diag_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_diag_data
+        manager = SystemDiagnosticManager(mock_client)
+        diag = manager.wait(1, timeout=10)
+        assert diag.is_complete
+
+    @patch("pyvergeos.resources.diagnostics.time.sleep")
+    @patch("pyvergeos.resources.diagnostics.time.monotonic")
+    def test_wait_timeout(
+        self,
+        mock_monotonic: MagicMock,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_building_diag: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_building_diag
+        mock_monotonic.side_effect = [0.0, 0.0, 11.0]
+        manager = SystemDiagnosticManager(mock_client)
+        with pytest.raises(VergeTimeoutError, match="did not complete"):
+            manager.wait(2, timeout=10)
+
+    def test_send_to_support(self, mock_client: MagicMock) -> None:
+        manager = SystemDiagnosticManager(mock_client)
+        manager.send_to_support(1)
+
+        call_args = mock_client._request.call_args
+        assert call_args.args[0] == "POST"
+        assert call_args.args[1] == "system_diagnostic_actions"
+        body = call_args.kwargs["json_data"]
+        assert body["system_diagnostic"] == 1
+        assert body["action"] == "send2support"

--- a/tests/unit/test_lldp.py
+++ b/tests/unit/test_lldp.py
@@ -1,0 +1,189 @@
+"""Unit tests for LLDP neighbor resource manager."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.resources.lldp import NodeLLDPNeighbor, NodeLLDPNeighborManager
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def sample_lldp_data() -> dict[str, Any]:
+    """Sample LLDP neighbor data from API."""
+    return {
+        "$key": 1,
+        "node": 5,
+        "nic": 42,
+        "rid": "1",
+        "via": "LLDP",
+        "age": "0 day, 00:05:30",
+        "chassis": {
+            "name": "switch01.example.com",
+            "ChassisID": "aa:bb:cc:dd:ee:ff",
+            "descr": "Arista Networks EOS",
+        },
+        "port": {
+            "PortID": "Ethernet1/1",
+            "descr": "Server Port 1",
+        },
+        "vlan": {"vlan-id": 100, "pvid": "yes"},
+        "other": {"mfs": 9216},
+    }
+
+
+# =============================================================================
+# NodeLLDPNeighbor Tests
+# =============================================================================
+
+
+class TestNodeLLDPNeighbor:
+    """Tests for NodeLLDPNeighbor resource object."""
+
+    def test_node_key(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.node_key == 5
+
+    def test_nic_key(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.nic_key == 42
+
+    def test_remote_id(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.remote_id == "1"
+
+    def test_via(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.via == "LLDP"
+
+    def test_age(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.age == "0 day, 00:05:30"
+
+    def test_chassis(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert isinstance(neighbor.chassis, dict)
+        assert neighbor.chassis["name"] == "switch01.example.com"
+
+    def test_port(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert isinstance(neighbor.port, dict)
+        assert neighbor.port["PortID"] == "Ethernet1/1"
+
+    def test_vlan(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert isinstance(neighbor.vlan, dict)
+        assert neighbor.vlan["vlan-id"] == 100
+
+    def test_other(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert isinstance(neighbor.other, dict)
+
+    def test_chassis_name(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.chassis_name == "switch01.example.com"
+
+    def test_chassis_name_fallback(self) -> None:
+        neighbor = NodeLLDPNeighbor(
+            {"$key": 1, "chassis": {"ChassisID": "aa:bb:cc:dd:ee:ff"}},
+            MagicMock(),
+        )
+        assert neighbor.chassis_name == "aa:bb:cc:dd:ee:ff"
+
+    def test_chassis_name_none(self) -> None:
+        neighbor = NodeLLDPNeighbor({"$key": 1}, MagicMock())
+        assert neighbor.chassis_name is None
+
+    def test_port_id(self, sample_lldp_data: dict[str, Any]) -> None:
+        neighbor = NodeLLDPNeighbor(sample_lldp_data, MagicMock())
+        assert neighbor.port_id == "Ethernet1/1"
+
+    def test_port_id_none(self) -> None:
+        neighbor = NodeLLDPNeighbor({"$key": 1}, MagicMock())
+        assert neighbor.port_id is None
+
+    def test_defaults_when_empty(self) -> None:
+        neighbor = NodeLLDPNeighbor({}, MagicMock())
+        assert neighbor.node_key == 0
+        assert neighbor.nic_key == 0
+        assert neighbor.remote_id is None
+        assert neighbor.via is None
+        assert neighbor.age is None
+        assert neighbor.chassis is None
+        assert neighbor.port is None
+        assert neighbor.vlan is None
+
+
+# =============================================================================
+# NodeLLDPNeighborManager Tests
+# =============================================================================
+
+
+class TestNodeLLDPNeighborManager:
+    """Tests for NodeLLDPNeighborManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        assert manager._endpoint == "node_lldp_neighbors"
+
+    def test_list_scoped(
+        self,
+        mock_client: MagicMock,
+        sample_lldp_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_lldp_data]
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        results = manager.list()
+        assert len(results) == 1
+        assert isinstance(results[0], NodeLLDPNeighbor)
+
+    def test_list_filters_by_node(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        manager.list()
+        call_args = mock_client._request.call_args
+        assert "node eq 5" in call_args.kwargs["params"]["filter"]
+
+    def test_list_global(
+        self,
+        mock_client: MagicMock,
+        sample_lldp_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_lldp_data]
+        manager = NodeLLDPNeighborManager(mock_client)
+        results = manager.list()
+        assert len(results) == 1
+        # No filter should be set for global
+        call_args = mock_client._request.call_args
+        assert "filter" not in call_args.kwargs["params"]
+
+    def test_list_empty(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = None
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        assert manager.list() == []
+
+    def test_list_by_nic(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        manager.list_by_nic(42)
+        call_args = mock_client._request.call_args
+        assert "nic eq 42" in call_args.kwargs["params"]["filter"]
+
+    def test_list_with_additional_filter(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = NodeLLDPNeighborManager(mock_client, node_key=5)
+        manager.list(filter="nic eq 42")
+        call_args = mock_client._request.call_args
+        filter_str = call_args.kwargs["params"]["filter"]
+        assert "node eq 5" in filter_str
+        assert "nic eq 42" in filter_str

--- a/tests/unit/test_nic_stats.py
+++ b/tests/unit/test_nic_stats.py
@@ -1,0 +1,403 @@
+"""Unit tests for machine NIC stats, status, and fabric status managers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError
+from pyvergeos.resources.nic_stats import (
+    MachineNicFabricStatus,
+    MachineNicFabricStatusManager,
+    MachineNicStats,
+    MachineNicStatsManager,
+    MachineNicStatus,
+    MachineNicStatusManager,
+    _format_bps,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+# =============================================================================
+# Sample Data Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_nic_stats_data() -> dict[str, Any]:
+    """Sample NIC stats data from API."""
+    return {
+        "$key": 1,
+        "parent_nic": 42,
+        "txpps": 1000,
+        "rxpps": 2000,
+        "txbps": 8000000,
+        "rxbps": 16000000,
+        "totalxbps": 24000000,
+        "tx_pckts": 50000,
+        "rx_pckts": 100000,
+        "tx_bytes": 40000000,
+        "rx_bytes": 80000000,
+        "tx_pckts_cur": 500,
+        "rx_pckts_cur": 1000,
+        "tx_bytes_cur": 400000,
+        "rx_bytes_cur": 800000,
+        "last_update": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_nic_status_data() -> dict[str, Any]:
+    """Sample NIC status data from API."""
+    return {
+        "$key": 1,
+        "parent_nic": 42,
+        "status": "up",
+        "state": "online",
+        "speed": 10000,
+        "last_update": 1704067200,
+    }
+
+
+@pytest.fixture
+def sample_nic_fabric_data() -> dict[str, Any]:
+    """Sample NIC fabric status data from API."""
+    return {
+        "$key": 1,
+        "parent_nic": 42,
+        "status": "confirmed",
+        "state": "online",
+        "max_score": 100.0,
+        "min_score": 95.0,
+        "paths": [{"node": 1, "score": 100}, {"node": 2, "score": 95}],
+        "created": 1704000000,
+        "modified": 1704067200,
+    }
+
+
+# =============================================================================
+# MachineNicStats Tests
+# =============================================================================
+
+
+class TestMachineNicStats:
+    """Tests for MachineNicStats resource object."""
+
+    def test_nic_key(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.nic_key == 42
+
+    def test_tx_pps(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.tx_pps == 1000
+
+    def test_rx_pps(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.rx_pps == 2000
+
+    def test_tx_bps(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.tx_bps == 8000000
+
+    def test_rx_bps(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.rx_bps == 16000000
+
+    def test_total_bps(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.total_bps == 24000000
+
+    def test_tx_packets(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.tx_packets == 50000
+
+    def test_rx_packets(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.rx_packets == 100000
+
+    def test_tx_bytes(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.tx_bytes == 40000000
+
+    def test_rx_bytes(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.rx_bytes == 80000000
+
+    def test_current_counters(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert stats.tx_packets_current == 500
+        assert stats.rx_packets_current == 1000
+        assert stats.tx_bytes_current == 400000
+        assert stats.rx_bytes_current == 800000
+
+    def test_display_properties(self, sample_nic_stats_data: dict[str, Any]) -> None:
+        stats = MachineNicStats(sample_nic_stats_data, MagicMock())
+        assert "Mbps" in stats.tx_bps_display
+        assert "Mbps" in stats.rx_bps_display
+        assert "Mbps" in stats.total_bps_display
+
+    def test_defaults_when_empty(self) -> None:
+        stats = MachineNicStats({}, MagicMock())
+        assert stats.nic_key == 0
+        assert stats.tx_pps == 0
+        assert stats.rx_pps == 0
+        assert stats.tx_bps == 0
+        assert stats.tx_bps_display == "0 bps"
+
+
+# =============================================================================
+# MachineNicStatus Tests
+# =============================================================================
+
+
+class TestMachineNicStatus:
+    """Tests for MachineNicStatus resource object."""
+
+    def test_nic_key(self, sample_nic_status_data: dict[str, Any]) -> None:
+        status = MachineNicStatus(sample_nic_status_data, MagicMock())
+        assert status.nic_key == 42
+
+    def test_link_status(self, sample_nic_status_data: dict[str, Any]) -> None:
+        status = MachineNicStatus(sample_nic_status_data, MagicMock())
+        assert status.link_status == "up"
+        assert status.link_status_display == "Up"
+
+    def test_state(self, sample_nic_status_data: dict[str, Any]) -> None:
+        status = MachineNicStatus(sample_nic_status_data, MagicMock())
+        assert status.state == "online"
+        assert status.state_display == "Online"
+
+    def test_is_up(self, sample_nic_status_data: dict[str, Any]) -> None:
+        status = MachineNicStatus(sample_nic_status_data, MagicMock())
+        assert status.is_up is True
+
+    def test_is_not_up(self) -> None:
+        status = MachineNicStatus(
+            {"$key": 1, "parent_nic": 42, "status": "down", "state": "offline"},
+            MagicMock(),
+        )
+        assert status.is_up is False
+
+    def test_speed(self, sample_nic_status_data: dict[str, Any]) -> None:
+        status = MachineNicStatus(sample_nic_status_data, MagicMock())
+        assert status.speed == 10000
+        assert status.speed_display == "10 Gbps"
+
+    def test_speed_mbps(self) -> None:
+        status = MachineNicStatus({"$key": 1, "parent_nic": 42, "speed": 100}, MagicMock())
+        assert status.speed_display == "100 Mbps"
+
+    def test_speed_unknown(self) -> None:
+        status = MachineNicStatus({"$key": 1, "parent_nic": 42, "speed": 0}, MagicMock())
+        assert status.speed_display == "Unknown"
+
+    def test_lowerlayerdown(self) -> None:
+        status = MachineNicStatus(
+            {
+                "$key": 1,
+                "parent_nic": 42,
+                "status": "lowerlayerdown",
+                "state": "error",
+            },
+            MagicMock(),
+        )
+        assert status.link_status_display == "Lower Layer Down"
+        assert status.state_display == "Error"
+
+
+# =============================================================================
+# MachineNicFabricStatus Tests
+# =============================================================================
+
+
+class TestMachineNicFabricStatus:
+    """Tests for MachineNicFabricStatus resource object."""
+
+    def test_nic_key(self, sample_nic_fabric_data: dict[str, Any]) -> None:
+        fabric = MachineNicFabricStatus(sample_nic_fabric_data, MagicMock())
+        assert fabric.nic_key == 42
+
+    def test_fabric_status_confirmed(self, sample_nic_fabric_data: dict[str, Any]) -> None:
+        fabric = MachineNicFabricStatus(sample_nic_fabric_data, MagicMock())
+        assert fabric.fabric_status == "confirmed"
+        assert fabric.fabric_status_display == "Confirmed"
+        assert fabric.is_healthy is True
+        assert fabric.is_degraded is False
+
+    def test_fabric_status_degraded(self) -> None:
+        fabric = MachineNicFabricStatus(
+            {"$key": 1, "parent_nic": 42, "status": "degraded", "state": "warning"},
+            MagicMock(),
+        )
+        assert fabric.is_healthy is False
+        assert fabric.is_degraded is True
+        assert fabric.fabric_status_display == "Degraded"
+
+    def test_scores(self, sample_nic_fabric_data: dict[str, Any]) -> None:
+        fabric = MachineNicFabricStatus(sample_nic_fabric_data, MagicMock())
+        assert fabric.max_score == 100.0
+        assert fabric.min_score == 95.0
+
+    def test_paths(self, sample_nic_fabric_data: dict[str, Any]) -> None:
+        fabric = MachineNicFabricStatus(sample_nic_fabric_data, MagicMock())
+        assert isinstance(fabric.paths, list)
+        assert len(fabric.paths) == 2
+
+
+# =============================================================================
+# MachineNicStatsManager Tests
+# =============================================================================
+
+
+class TestMachineNicStatsManager:
+    """Tests for MachineNicStatsManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = MachineNicStatsManager(mock_client, nic_key=42)
+        assert manager._endpoint == "machine_nic_stats"
+
+    def test_get_scoped(
+        self,
+        mock_client: MagicMock,
+        sample_nic_stats_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_nic_stats_data]
+        manager = MachineNicStatsManager(mock_client, nic_key=42)
+        stats = manager.get()
+        assert isinstance(stats, MachineNicStats)
+        assert stats.nic_key == 42
+
+    def test_get_scoped_filters_by_nic(
+        self,
+        mock_client: MagicMock,
+        sample_nic_stats_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_nic_stats_data]
+        manager = MachineNicStatsManager(mock_client, nic_key=42)
+        manager.get()
+        call_args = mock_client._request.call_args
+        assert "parent_nic eq 42" in call_args.kwargs["params"]["filter"]
+
+    def test_get_by_key(
+        self,
+        mock_client: MagicMock,
+        sample_nic_stats_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_nic_stats_data
+        manager = MachineNicStatsManager(mock_client, nic_key=42)
+        stats = manager.get(key=1)
+        assert stats.key == 1
+
+    def test_get_scoped_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = MachineNicStatsManager(mock_client, nic_key=999)
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+    def test_get_no_scope_no_key(self, mock_client: MagicMock) -> None:
+        manager = MachineNicStatsManager(mock_client)
+        with pytest.raises(ValueError, match="Either key or scoped nic_key"):
+            manager.get()
+
+    def test_global_list(
+        self,
+        mock_client: MagicMock,
+        sample_nic_stats_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_nic_stats_data]
+        manager = MachineNicStatsManager(mock_client)
+        results = manager.list(filter="parent_nic eq 42")
+        assert len(results) == 1
+
+
+# =============================================================================
+# MachineNicStatusManager Tests
+# =============================================================================
+
+
+class TestMachineNicStatusManager:
+    """Tests for MachineNicStatusManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = MachineNicStatusManager(mock_client, nic_key=42)
+        assert manager._endpoint == "machine_nic_status"
+
+    def test_get_scoped(
+        self,
+        mock_client: MagicMock,
+        sample_nic_status_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_nic_status_data]
+        manager = MachineNicStatusManager(mock_client, nic_key=42)
+        status = manager.get()
+        assert isinstance(status, MachineNicStatus)
+        assert status.is_up is True
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = MachineNicStatusManager(mock_client, nic_key=999)
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+
+# =============================================================================
+# MachineNicFabricStatusManager Tests
+# =============================================================================
+
+
+class TestMachineNicFabricStatusManager:
+    """Tests for MachineNicFabricStatusManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = MachineNicFabricStatusManager(mock_client, nic_key=42)
+        assert manager._endpoint == "machine_nic_fabric_status"
+
+    def test_get_scoped(
+        self,
+        mock_client: MagicMock,
+        sample_nic_fabric_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_nic_fabric_data]
+        manager = MachineNicFabricStatusManager(mock_client, nic_key=42)
+        fabric = manager.get()
+        assert isinstance(fabric, MachineNicFabricStatus)
+        assert fabric.is_healthy is True
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = MachineNicFabricStatusManager(mock_client, nic_key=999)
+        with pytest.raises(NotFoundError):
+            manager.get()
+
+
+# =============================================================================
+# Helper Function Tests
+# =============================================================================
+
+
+class TestFormatBps:
+    """Tests for _format_bps helper."""
+
+    def test_zero(self) -> None:
+        assert _format_bps(0) == "0 bps"
+
+    def test_bps(self) -> None:
+        assert _format_bps(500) == "500.00 bps"
+
+    def test_kbps(self) -> None:
+        assert _format_bps(5000) == "5.00 Kbps"
+
+    def test_mbps(self) -> None:
+        assert _format_bps(8000000) == "8.00 Mbps"
+
+    def test_gbps(self) -> None:
+        assert _format_bps(10000000000) == "10.00 Gbps"

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -800,9 +800,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         post_call = mock_client._request.call_args_list[0]
         assert post_call[0][0] == "POST"
-        assert "node_actions/enable_maintenance" in post_call[0][1]
-        assert post_call[1]["json_data"]["node"] == 1
-        assert post_call[1]["json_data"]["action"] == "maintenance"
+        assert post_call[0][1] == "nodes/1/enable_maintenance"
+        assert post_call[1]["json_data"] == {}
 
     def test_disable_maintenance(self) -> None:
         """Test disable_maintenance method."""
@@ -819,9 +818,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         post_call = mock_client._request.call_args_list[0]
         assert post_call[0][0] == "POST"
-        assert "node_actions/disable_maintenance" in post_call[0][1]
-        assert post_call[1]["json_data"]["node"] == 1
-        assert post_call[1]["json_data"]["action"] == "leavemaintenance"
+        assert post_call[0][1] == "nodes/1/disable_maintenance"
+        assert post_call[1]["json_data"] == {}
 
     def test_restart(self) -> None:
         """Test restart method."""
@@ -835,9 +833,8 @@ class TestNodeManagerMaintenance:
         # Verify POST was called
         call_args = mock_client._request.call_args
         assert call_args[0][0] == "POST"
-        assert "node_actions/maintenance_reboot" in call_args[0][1]
-        assert call_args[1]["json_data"]["node"] == 1
-        assert call_args[1]["json_data"]["action"] == "maintenance_reboot"
+        assert call_args[0][1] == "nodes/1/maintenance_reboot"
+        assert call_args[1]["json_data"] == {}
 
 
 class TestNodeManagerDeviceManagers:

--- a/tests/unit/test_queries.py
+++ b/tests/unit/test_queries.py
@@ -206,7 +206,7 @@ class TestVNetQueryManager:
         manager = VNetQueryManager(mock_client, parent_key=10)
         result = manager.get(1)
         assert isinstance(result, QueryResult)
-        assert result.key == 1
+        assert result.key == "1"  # QueryResult.key returns str (SHA1 keys)
 
     def test_get_by_query_id(
         self,

--- a/tests/unit/test_queries.py
+++ b/tests/unit/test_queries.py
@@ -1,0 +1,489 @@
+"""Unit tests for async query resource managers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyvergeos.exceptions import NotFoundError, VergeTimeoutError
+from pyvergeos.resources.queries import (
+    NodeQueryManager,
+    QueryResult,
+    ServiceContainerQueryManager,
+    TenantNodeQueryManager,
+    VNetQueryManager,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock VergeClient."""
+    client = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+# =============================================================================
+# Sample Data Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_query_data() -> dict[str, Any]:
+    """Sample query result data from API."""
+    return {
+        "$key": 1,
+        "id": "abc123def456",
+        "query": "ping",
+        "params": {"host": "8.8.8.8"},
+        "status": "complete",
+        "result": "PING 8.8.8.8: 64 bytes, time=10ms",
+        "command": "ping -c 4 8.8.8.8",
+        "created": 1704067200000000,
+        "modified": 1704067210,
+        "expires": 1704070800,
+    }
+
+
+@pytest.fixture
+def sample_running_query() -> dict[str, Any]:
+    """Sample running query data."""
+    return {
+        "$key": 2,
+        "id": "def789ghi012",
+        "query": "tcpdump",
+        "params": {"interface": "eth0"},
+        "status": "running",
+        "result": None,
+        "command": "tcpdump -i eth0",
+        "created": 1704067200000000,
+        "modified": 1704067200,
+        "expires": 1704070800,
+    }
+
+
+@pytest.fixture
+def sample_error_query() -> dict[str, Any]:
+    """Sample error query data."""
+    return {
+        "$key": 3,
+        "id": "err456xyz789",
+        "query": "ping",
+        "params": {"host": "invalid"},
+        "status": "error",
+        "result": "ping: unknown host invalid",
+        "command": "ping -c 4 invalid",
+        "created": 1704067200000000,
+        "modified": 1704067205,
+        "expires": 1704070800,
+    }
+
+
+# =============================================================================
+# QueryResult Tests
+# =============================================================================
+
+
+class TestQueryResult:
+    """Tests for QueryResult resource object."""
+
+    def test_query_id(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.query_id == "abc123def456"
+
+    def test_query_type(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.query_type == "ping"
+
+    def test_status_complete(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.status == "complete"
+        assert result.is_complete is True
+        assert result.is_error is False
+        assert result.is_running is False
+
+    def test_status_running(self, sample_running_query: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_running_query, manager)
+        assert result.status == "running"
+        assert result.is_running is True
+        assert result.is_complete is False
+
+    def test_status_error(self, sample_error_query: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_error_query, manager)
+        assert result.status == "error"
+        assert result.is_error is True
+        assert result.is_complete is False
+
+    def test_result_text(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.result == "PING 8.8.8.8: 64 bytes, time=10ms"
+
+    def test_result_none_when_running(self, sample_running_query: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_running_query, manager)
+        assert result.result is None
+
+    def test_command(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.command == "ping -c 4 8.8.8.8"
+
+    def test_params(self, sample_query_data: dict[str, Any]) -> None:
+        manager = MagicMock()
+        result = QueryResult(sample_query_data, manager)
+        assert result.params == {"host": "8.8.8.8"}
+
+    def test_defaults_when_empty(self) -> None:
+        manager = MagicMock()
+        result = QueryResult({}, manager)
+        assert result.query_id == ""
+        assert result.query_type == ""
+        assert result.status == "running"
+        assert result.result is None
+        assert result.command is None
+        assert result.params is None
+
+
+# =============================================================================
+# VNetQueryManager Tests
+# =============================================================================
+
+
+class TestVNetQueryManager:
+    """Tests for VNetQueryManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        assert manager._endpoint == "vnet_queries"
+        assert manager._parent_field == "vnet"
+        assert manager._parent_key == 10
+
+    def test_list_filters_by_parent(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        manager.list()
+        call_args = mock_client._request.call_args
+        assert "vnet eq 10" in call_args.kwargs["params"]["filter"]
+
+    def test_list_returns_query_results(
+        self,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_query_data]
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        results = manager.list()
+        assert len(results) == 1
+        assert isinstance(results[0], QueryResult)
+        assert results[0].query_type == "ping"
+
+    def test_list_with_additional_filter(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = []
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        manager.list(filter="status eq 'running'")
+        call_args = mock_client._request.call_args
+        assert "vnet eq 10 and (status eq 'running')" in call_args.kwargs["params"]["filter"]
+
+    def test_list_empty(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = None
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        assert manager.list() == []
+
+    def test_get_by_key(
+        self,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.get(1)
+        assert isinstance(result, QueryResult)
+        assert result.key == 1
+
+    def test_get_by_query_id(
+        self,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = [sample_query_data]
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.get(query_id="abc123def456")
+        assert isinstance(result, QueryResult)
+
+    def test_get_not_found(self, mock_client: MagicMock) -> None:
+        mock_client._request.return_value = None
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        with pytest.raises(NotFoundError):
+            manager.get(999)
+
+    def test_get_no_args(self, mock_client: MagicMock) -> None:
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        with pytest.raises(ValueError, match="Either key or query_id"):
+            manager.get()
+
+    def test_create(
+        self,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        manager.create("ping", params={"host": "8.8.8.8"})
+
+        # Verify POST was called correctly
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call.args[0] == "POST"
+        assert post_call.args[1] == "vnet_queries"
+        body = post_call.kwargs["json_data"]
+        assert body["vnet"] == 10
+        assert body["query"] == "ping"
+        assert body["params"] == {"host": "8.8.8.8"}
+
+    def test_create_no_params(
+        self,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        manager.create("arp")
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call.kwargs["json_data"]
+        assert "params" not in body
+        assert body["query"] == "arp"
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_wait_complete(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.wait(1, timeout=10)
+        assert result.is_complete
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    @patch("pyvergeos.resources.queries.time.monotonic")
+    def test_wait_timeout(
+        self,
+        mock_monotonic: MagicMock,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_running_query: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_running_query
+        mock_monotonic.side_effect = [0.0, 0.0, 11.0]
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        with pytest.raises(VergeTimeoutError, match="did not complete"):
+            manager.wait(2, timeout=10)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_wait_error_returns(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_error_query: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_error_query
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.wait(3, timeout=10)
+        assert result.is_error
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_run_creates_and_waits(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.run("ping", {"host": "8.8.8.8"})
+        assert result.is_complete
+
+    # Convenience method tests
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_ping(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.ping("8.8.8.8")
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_dns(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.dns("example.com")
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_traceroute(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.traceroute("8.8.8.8")
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_arp(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.arp()
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_firewall(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.firewall()
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_trace(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = VNetQueryManager(mock_client, parent_key=10)
+        result = manager.trace()
+        assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# NodeQueryManager Tests
+# =============================================================================
+
+
+class TestNodeQueryManager:
+    """Tests for NodeQueryManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = NodeQueryManager(mock_client, parent_key=5)
+        assert manager._endpoint == "node_queries"
+        assert manager._parent_field == "node"
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_smartctl(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = NodeQueryManager(mock_client, parent_key=5)
+        result = manager.smartctl("/dev/sda")
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_lsblk(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = NodeQueryManager(mock_client, parent_key=5)
+        result = manager.lsblk()
+        assert isinstance(result, QueryResult)
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_dmidecode(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = NodeQueryManager(mock_client, parent_key=5)
+        result = manager.dmidecode()
+        assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# ServiceContainerQueryManager Tests
+# =============================================================================
+
+
+class TestServiceContainerQueryManager:
+    """Tests for ServiceContainerQueryManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = ServiceContainerQueryManager(mock_client, parent_key=3)
+        assert manager._endpoint == "service_container_queries"
+        assert manager._parent_field == "service_container"
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_ping(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = ServiceContainerQueryManager(mock_client, parent_key=3)
+        result = manager.ping("8.8.8.8")
+        assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# TenantNodeQueryManager Tests
+# =============================================================================
+
+
+class TestTenantNodeQueryManager:
+    """Tests for TenantNodeQueryManager."""
+
+    def test_endpoint(self, mock_client: MagicMock) -> None:
+        manager = TenantNodeQueryManager(mock_client, parent_key=7)
+        assert manager._endpoint == "tenant_node_queries"
+        assert manager._parent_field == "tenant_node"
+
+    @patch("pyvergeos.resources.queries.time.sleep")
+    def test_dns(
+        self,
+        mock_sleep: MagicMock,
+        mock_client: MagicMock,
+        sample_query_data: dict[str, Any],
+    ) -> None:
+        mock_client._request.return_value = sample_query_data
+        manager = TenantNodeQueryManager(mock_client, parent_key=7)
+        result = manager.dns("example.com")
+        assert isinstance(result, QueryResult)

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "pyvergeos"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- **Network diagnostics resource managers** — new modules for diagnostics, LLDP, NIC stats, and queries (PR #58)
- **Fix node maintenance endpoints** — switched from broken `node_actions` dispatch table to row-action pattern `nodes/<key>/<action>` (PR #59)
- **Fix ResourceObject.key for SHA1 string keys** — `QueryResult` now correctly overrides `.key` for string-keyed results
- **Version bump to 1.2.0**

## Test plan

- [x] Unit tests pass (PR #58, #59)
- [x] Integration tested `enable_maintenance`, `disable_maintenance`, and `maintenance_reboot` against live VergeOS system
- [x] Ruff lint + format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)