### PR TITLE
feat: add MachineNICManager and Node.nics for node NIC access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
         MachineNicStatsManager,
         MachineNicStatusManager,
     )
+    from pyvergeos.resources.nics import MachineNICManager
     from pyvergeos.resources.nodes import NodeManager
     from pyvergeos.resources.oidc_applications import (
         OidcApplicationGroupManager,
@@ -284,6 +285,7 @@ class VergeClient:
         self._update_dashboard: UpdateDashboardManager | None = None
         self._system_diagnostics: SystemDiagnosticManager | None = None
         self._node_lldp_neighbors: NodeLLDPNeighborManager | None = None
+        self._machine_nics: MachineNICManager | None = None
         self._machine_nic_stats: MachineNicStatsManager | None = None
         self._machine_nic_status: MachineNicStatusManager | None = None
         self._machine_nic_fabric_status: MachineNicFabricStatusManager | None = None
@@ -1917,6 +1919,25 @@ class VergeClient:
 
             self._node_lldp_neighbors = NodeLLDPNeighborManager(self)
         return self._node_lldp_neighbors
+
+    @property
+    def machine_nics(self) -> MachineNICManager:
+        """Access machine NICs globally.
+
+        List NICs across all machines (VMs, nodes, etc.) with optional
+        OData filtering. For node-scoped access, use ``node.nics`` instead.
+
+        Example:
+            >>> all_nics = client.machine_nics.list()
+            >>> node_nics = client.machine_nics.list(
+            ...     filter="machine eq 42"
+            ... )
+        """
+        if self._machine_nics is None:
+            from pyvergeos.resources.nics import MachineNICManager
+
+            self._machine_nics = MachineNICManager(self)
+        return self._machine_nics
 
     @property
     def machine_nic_stats(self) -> MachineNicStatsManager:

--- a/pyvergeos/resources/__init__.py
+++ b/pyvergeos/resources/__init__.py
@@ -106,6 +106,7 @@ from pyvergeos.resources.nic_stats import (
     MachineNicStatus,
     MachineNicStatusManager,
 )
+from pyvergeos.resources.nics import NIC, MachineNICManager, NICManager
 from pyvergeos.resources.nodes import (
     Node,
     NodeDriver,
@@ -282,6 +283,9 @@ __all__ = [
     "QueryResult",
     "MachineLog",
     "MachineLogManager",
+    "MachineNICManager",
+    "NIC",
+    "NICManager",
     "MachineNicFabricStatus",
     "MachineNicFabricStatusManager",
     "MachineNicStats",

--- a/pyvergeos/resources/nics.py
+++ b/pyvergeos/resources/nics.py
@@ -157,6 +157,144 @@ class NIC(ResourceObject):
         return MachineNicFabricStatusManager(self._manager._client, self.key)
 
 
+class MachineNICManager(ResourceManager[NIC]):
+    """Manager for machine NIC operations (not scoped to a specific VM).
+
+    Can list/get NICs across all machines, or scoped to a specific machine
+    by passing a machine_key filter. This is the manager exposed on the
+    client and on Node objects.
+
+    Examples:
+        List all NICs::
+
+            all_nics = client.machine_nics.list()
+
+        List NICs for a specific machine::
+
+            nics = client.machine_nics.list(filter="machine eq 42")
+
+        Access from a node::
+
+            nics = node.nics.list()
+    """
+
+    _endpoint = "machine_nics"
+    _default_fields = NIC_DEFAULT_FIELDS
+
+    def __init__(self, client: VergeClient, machine_key: int | None = None) -> None:
+        super().__init__(client)
+        self._machine_key = machine_key
+
+    def _to_model(self, data: dict[str, Any]) -> NIC:
+        return NIC(data, self)
+
+    def list(  # type: ignore[override]  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[NIC]:
+        """List NICs with optional filtering.
+
+        When scoped to a machine (via machine_key), automatically filters
+        to that machine's NICs. Additional filters can be combined.
+
+        Args:
+            filter: Additional OData filter string.
+            fields: List of fields to return.
+            **kwargs: Additional filter arguments.
+
+        Returns:
+            List of NIC objects.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        # Scope to machine if set
+        machine_filter: str | None = None
+        if self._machine_key is not None:
+            machine_filter = f"machine eq {self._machine_key}"
+
+        combined: str | None
+        if machine_filter and filter:
+            combined = f"{machine_filter} and ({filter})"
+        elif machine_filter:
+            combined = machine_filter
+        else:
+            combined = filter
+
+        params: dict[str, Any] = {"fields": ",".join(fields)}
+        if combined:
+            params["filter"] = combined
+        if kwargs:
+            from pyvergeos.filters import build_filter
+
+            extra = build_filter(**kwargs)
+            if "filter" in params:
+                params["filter"] = f"{params['filter']} and ({extra})"
+            else:
+                params["filter"] = extra
+
+        params["sort"] = "+orderid"
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(
+        self,
+        key: int | None = None,
+        *,
+        name: str | None = None,
+        fields: builtins.list[str] | None = None,
+    ) -> NIC:
+        """Get a NIC by key or name.
+
+        Args:
+            key: NIC $key (ID).
+            name: NIC name.
+            fields: List of fields to return.
+
+        Returns:
+            NIC object.
+
+        Raises:
+            NotFoundError: If NIC not found.
+            ValueError: If neither key nor name provided.
+        """
+        if fields is None:
+            fields = self._default_fields
+
+        if key is not None:
+            params: dict[str, Any] = {"fields": ",".join(fields)}
+            response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
+            if response is None:
+                from pyvergeos.exceptions import NotFoundError
+
+                raise NotFoundError(f"NIC {key} not found")
+            if not isinstance(response, dict):
+                from pyvergeos.exceptions import NotFoundError
+
+                raise NotFoundError(f"NIC {key} returned invalid response")
+            return self._to_model(response)
+
+        if name is not None:
+            nics = self.list(filter=f"name eq '{name}'", fields=fields)
+            if not nics:
+                from pyvergeos.exceptions import NotFoundError
+
+                raise NotFoundError(f"NIC with name '{name}' not found")
+            return nics[0]
+
+        raise ValueError("Either key or name must be provided")
+
+
 class NICManager(ResourceManager[NIC]):
     """Manager for VM NIC operations.
 

--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         MachineStatsManager,
         MachineStatusManager,
     )
+    from pyvergeos.resources.nics import MachineNICManager
     from pyvergeos.resources.queries import NodeQueryManager
 
 
@@ -488,6 +489,28 @@ class Node(ResourceObject):
 
         manager = cast("NodeManager", self._manager)
         return manager.sriov_nics(self.key)
+
+    @property
+    def nics(self) -> MachineNICManager:
+        """Access NICs attached to this node.
+
+        Returns:
+            MachineNICManager scoped to this node's machine key.
+
+        Example:
+            >>> for nic in node.nics.list():
+            ...     print(f"{nic['name']}: {nic.mac_address}")
+            ...     stats = nic.nic_stats.get()
+            ...     print(f"  TX: {stats.tx_bps_display}")
+
+        Raises:
+            ValueError: If node has no associated machine.
+        """
+        from pyvergeos.resources.nics import MachineNICManager
+
+        if self.machine_key is None:
+            raise ValueError("Node has no associated machine")
+        return MachineNICManager(self._manager._client, self.machine_key)
 
     @property
     def queries(self) -> NodeQueryManager:

--- a/tests/unit/test_nics.py
+++ b/tests/unit/test_nics.py
@@ -12,8 +12,10 @@ from pyvergeos.exceptions import NotFoundError
 from pyvergeos.resources.nics import (
     INTERFACE_DISPLAY_MAP,
     NIC,
+    MachineNICManager,
     NICManager,
 )
+from pyvergeos.resources.nodes import Node
 from pyvergeos.resources.vms import VM
 
 
@@ -286,6 +288,198 @@ class TestNIC:
         """Test tx_bytes property."""
         nic = NIC(nic_data, mock_nic_manager)
         assert nic.tx_bytes == 536870912
+
+
+class TestMachineNICManager:
+    """Unit tests for MachineNICManager (standalone, not VM-scoped)."""
+
+    def test_list_all_nics(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
+        """Test listing all NICs without machine scope."""
+        mock_session.request.return_value.json.return_value = [
+            {"$key": 1, "name": "enp3s0", "macaddress": "aa:bb:cc:dd:ee:01", "machine": 2},
+            {"$key": 2, "name": "enp4s0", "macaddress": "aa:bb:cc:dd:ee:02", "machine": 2},
+            {"$key": 3, "name": "eth0", "macaddress": "aa:bb:cc:dd:ee:03", "machine": 100},
+        ]
+
+        manager = MachineNICManager(mock_client)
+        nics = manager.list()
+
+        assert len(nics) == 3
+        # Should NOT have a machine filter in params
+        call_args = mock_session.request.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "machine eq" not in params.get("filter", "")
+
+    def test_list_scoped_to_machine(
+        self, mock_client: VergeClient, mock_session: MagicMock
+    ) -> None:
+        """Test listing NICs scoped to a specific machine key."""
+        mock_session.request.return_value.json.return_value = [
+            {"$key": 1, "name": "enp3s0", "macaddress": "aa:bb:cc:dd:ee:01"},
+            {"$key": 2, "name": "enp4s0", "macaddress": "aa:bb:cc:dd:ee:02"},
+        ]
+
+        manager = MachineNICManager(mock_client, machine_key=42)
+        nics = manager.list()
+
+        assert len(nics) == 2
+        call_args = mock_session.request.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "machine eq 42" in params.get("filter", "")
+
+    def test_list_scoped_with_additional_filter(
+        self, mock_client: VergeClient, mock_session: MagicMock
+    ) -> None:
+        """Test machine-scoped list with additional OData filter."""
+        mock_session.request.return_value.json.return_value = [
+            {"$key": 1, "name": "enp3s0"},
+        ]
+
+        manager = MachineNICManager(mock_client, machine_key=42)
+        manager.list(filter="name eq 'enp3s0'")
+
+        call_args = mock_session.request.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "machine eq 42" in params["filter"]
+        assert "name eq 'enp3s0'" in params["filter"]
+
+    def test_list_empty_result(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
+        """Test listing with no results."""
+        mock_session.request.return_value.json.return_value = None
+        mock_session.request.return_value.status_code = 204
+        mock_session.request.return_value.text = ""
+
+        manager = MachineNICManager(mock_client, machine_key=42)
+        nics = manager.list()
+
+        assert nics == []
+
+    def test_get_by_key(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
+        """Test getting a NIC by key."""
+        mock_session.request.return_value.json.return_value = {
+            "$key": 7,
+            "name": "enp3s0",
+            "macaddress": "58:47:ca:7f:d8:10",
+        }
+
+        manager = MachineNICManager(mock_client)
+        nic = manager.get(7)
+
+        assert nic.key == 7
+        assert nic.name == "enp3s0"
+        assert nic.mac_address == "58:47:ca:7f:d8:10"
+
+    def test_get_by_name(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
+        """Test getting a NIC by name."""
+        mock_session.request.return_value.json.return_value = [
+            {"$key": 7, "name": "enp3s0", "macaddress": "58:47:ca:7f:d8:10"},
+        ]
+
+        manager = MachineNICManager(mock_client)
+        nic = manager.get(name="enp3s0")
+
+        assert nic.name == "enp3s0"
+
+    def test_get_not_found(self, mock_client: VergeClient, mock_session: MagicMock) -> None:
+        """Test NotFoundError when NIC not found by name."""
+        mock_session.request.return_value.json.return_value = []
+
+        manager = MachineNICManager(mock_client)
+        with pytest.raises(NotFoundError):
+            manager.get(name="nonexistent")
+
+    def test_get_requires_key_or_name(
+        self, mock_client: VergeClient, mock_session: MagicMock
+    ) -> None:
+        """Test ValueError when neither key nor name provided."""
+        manager = MachineNICManager(mock_client)
+        with pytest.raises(ValueError, match="Either key or name"):
+            manager.get()
+
+    def test_client_machine_nics_property(
+        self, mock_client: VergeClient, mock_session: MagicMock
+    ) -> None:
+        """Test client.machine_nics returns a MachineNICManager."""
+        manager = mock_client.machine_nics
+        assert isinstance(manager, MachineNICManager)
+
+    def test_client_machine_nics_cached(
+        self, mock_client: VergeClient, mock_session: MagicMock
+    ) -> None:
+        """Test client.machine_nics returns the same instance."""
+        manager1 = mock_client.machine_nics
+        manager2 = mock_client.machine_nics
+        assert manager1 is manager2
+
+
+class TestNodeNics:
+    """Unit tests for Node.nics property."""
+
+    @pytest.fixture
+    def node(self, mock_client: VergeClient) -> Node:
+        """Create a mock Node with a machine key."""
+        return Node(
+            {"$key": 1, "name": "node1", "machine": 42},
+            mock_client.nodes,
+        )
+
+    @pytest.fixture
+    def node_no_machine(self, mock_client: VergeClient) -> Node:
+        """Create a mock Node without a machine key."""
+        return Node(
+            {"$key": 2, "name": "node2"},
+            mock_client.nodes,
+        )
+
+    def test_node_nics_returns_manager(self, node: Node) -> None:
+        """Test that node.nics returns a MachineNICManager."""
+        manager = node.nics
+        assert isinstance(manager, MachineNICManager)
+
+    def test_node_nics_scoped_to_machine(self, node: Node, mock_session: MagicMock) -> None:
+        """Test that node.nics filters by the node's machine key."""
+        mock_session.request.return_value.json.return_value = [
+            {"$key": 7, "name": "enp3s0"},
+        ]
+
+        node.nics.list()
+
+        call_args = mock_session.request.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "machine eq 42" in params.get("filter", "")
+
+    def test_node_nics_no_machine_raises(self, node_no_machine: Node) -> None:
+        """Test that node.nics raises ValueError when no machine key."""
+        with pytest.raises(ValueError, match="no associated machine"):
+            _ = node_no_machine.nics
+
+    def test_node_nics_list_with_stats(self, node: Node, mock_session: MagicMock) -> None:
+        """Test listing node NICs and accessing stats via NIC objects."""
+        mock_session.request.return_value.json.return_value = [
+            {
+                "$key": 7,
+                "name": "enp3s0",
+                "macaddress": "58:47:ca:7f:d8:10",
+                "machine": 42,
+            },
+        ]
+
+        nics = node.nics.list()
+        assert len(nics) == 1
+        nic = nics[0]
+        assert nic.key == 7
+        assert nic.mac_address == "58:47:ca:7f:d8:10"
+
+        # Verify the NIC can produce stats/status/fabric managers
+        from pyvergeos.resources.nic_stats import (
+            MachineNicFabricStatusManager,
+            MachineNicStatsManager,
+            MachineNicStatusManager,
+        )
+
+        assert isinstance(nic.nic_stats, MachineNicStatsManager)
+        assert isinstance(nic.link_status, MachineNicStatusManager)
+        assert isinstance(nic.fabric_status, MachineNicFabricStatusManager)
 
 
 class TestNICInterfaceMaps:

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "pyvergeos"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- Adds `MachineNICManager` — a standalone NIC manager (not VM-scoped) that supports OData filtering and optional machine-key scoping
- Adds `Node.nics` property returning a `MachineNICManager` scoped to the node's machine key, with full access to stats/status/fabric via NIC objects
- Adds `client.machine_nics` property for global NIC access
- Bumps version to 1.2.1

Previously, `NICManager` was only accessible through VM objects, making it impossible to list NICs belonging to a node. This blocked CLI tooling that needs per-node NIC stats, link status, and fabric status.

## Usage

```python
# List all NICs for a node
for nic in node.nics.list():
    stats = nic.nic_stats.get()
    status = nic.link_status.get()
    fabric = nic.fabric_status.get()
    print(f"{nic['name']}: {status.link_status_display} @ {status.speed_display}")
    print(f"  TX: {stats.tx_bps_display}, RX: {stats.rx_bps_display}")

# Global access with filtering
nics = client.machine_nics.list(filter="machine eq 42")
```

## Test plan

- [x] All 4225 unit tests pass (14 new tests added)
- [x] Type checking passes (`mypy`)
- [x] Linting passes (`ruff`)
- [x] Integration test against live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)