### PR TITLE
feat: add resource managers for vrg doctor blockers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
         MachineNicStatusManager,
     )
     from pyvergeos.resources.nics import MachineNICManager
+    from pyvergeos.resources.node_memory import NodeMemoryManager
     from pyvergeos.resources.nodes import NodeManager
     from pyvergeos.resources.oidc_applications import (
         OidcApplicationGroupManager,
@@ -83,6 +84,7 @@ if TYPE_CHECKING:
         OidcApplicationUserManager,
     )
     from pyvergeos.resources.permissions import PermissionManager
+    from pyvergeos.resources.physical_drives import PhysicalDriveManager
     from pyvergeos.resources.recipe_common import (
         RecipeQuestionManager,
         RecipeSectionManager,
@@ -129,6 +131,7 @@ if TYPE_CHECKING:
         VmRecipeManager,
     )
     from pyvergeos.resources.vms import VMManager
+    from pyvergeos.resources.vsan_queries import VsanQueryManager
     from pyvergeos.resources.volume_vm_exports import (
         VolumeVmExportManager,
         VolumeVmExportStatManager,
@@ -289,6 +292,9 @@ class VergeClient:
         self._machine_nic_stats: MachineNicStatsManager | None = None
         self._machine_nic_status: MachineNicStatusManager | None = None
         self._machine_nic_fabric_status: MachineNicFabricStatusManager | None = None
+        self._physical_drives: PhysicalDriveManager | None = None
+        self._node_memory: NodeMemoryManager | None = None
+        self._vsan_queries: VsanQueryManager | None = None
 
         if auto_connect:
             self.connect()
@@ -1983,3 +1989,47 @@ class VergeClient:
 
             self._machine_nic_fabric_status = MachineNicFabricStatusManager(self)
         return self._machine_nic_fabric_status
+
+    @property
+    def physical_drives(self) -> PhysicalDriveManager:
+        """Access physical drive SMART health data.
+
+        Example:
+            >>> for drive in client.physical_drives.list():
+            ...     if drive.has_warnings:
+            ...         print(f"ALERT: {drive.model} @ {drive.location}")
+        """
+        if self._physical_drives is None:
+            from pyvergeos.resources.physical_drives import PhysicalDriveManager
+
+            self._physical_drives = PhysicalDriveManager(self)
+        return self._physical_drives
+
+    @property
+    def node_memory(self) -> NodeMemoryManager:
+        """Access node DIMM health data.
+
+        Example:
+            >>> for dimm in client.node_memory.list():
+            ...     if dimm.status != "online":
+            ...         print(f"DIMM {dimm.locator}: {dimm.status}")
+        """
+        if self._node_memory is None:
+            from pyvergeos.resources.node_memory import NodeMemoryManager
+
+            self._node_memory = NodeMemoryManager(self)
+        return self._node_memory
+
+    @property
+    def vsan_queries(self) -> VsanQueryManager:
+        """Access vSAN diagnostic queries.
+
+        Example:
+            >>> result = client.vsan_queries.run("getjournalstatus")
+            >>> print(result.result)
+        """
+        if self._vsan_queries is None:
+            from pyvergeos.resources.vsan_queries import VsanQueryManager
+
+            self._vsan_queries = VsanQueryManager(self)
+        return self._vsan_queries

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -131,11 +131,11 @@ if TYPE_CHECKING:
         VmRecipeManager,
     )
     from pyvergeos.resources.vms import VMManager
-    from pyvergeos.resources.vsan_queries import VsanQueryManager
     from pyvergeos.resources.volume_vm_exports import (
         VolumeVmExportManager,
         VolumeVmExportStatManager,
     )
+    from pyvergeos.resources.vsan_queries import VsanQueryManager
     from pyvergeos.resources.webhooks import WebhookManager
 
 logger = logging.getLogger(__name__)

--- a/pyvergeos/resources/node_memory.py
+++ b/pyvergeos/resources/node_memory.py
@@ -183,9 +183,7 @@ class NodeMemoryManager(ResourceManager[NodeMemory]):
         "modified",
     ]
 
-    def __init__(
-        self, client: VergeClient, node_key: int | None = None
-    ) -> None:
+    def __init__(self, client: VergeClient, node_key: int | None = None) -> None:
         super().__init__(client)
         self._node_key = node_key
 
@@ -273,9 +271,7 @@ class NodeMemoryManager(ResourceManager[NodeMemory]):
         if fields:
             params["fields"] = ",".join(fields)
 
-        response = self._client._request(
-            "GET", f"{self._endpoint}/{key}", params=params
-        )
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
 
         if response is None or not isinstance(response, dict):
             from pyvergeos.exceptions import NotFoundError

--- a/pyvergeos/resources/node_memory.py
+++ b/pyvergeos/resources/node_memory.py
@@ -1,0 +1,285 @@
+"""Node memory (DIMM health) resource manager."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class NodeMemory(ResourceObject):
+    """Node memory (DIMM) resource object.
+
+    Represents a physical memory module with health status.
+
+    Example:
+        >>> for dimm in client.node_memory.list():
+        ...     if not dimm.is_healthy:
+        ...         print(f"DIMM {dimm.locator} on node {dimm.node_key}: {dimm.status}")
+        ...         print(f"  {dimm.status_info}")
+    """
+
+    @property
+    def node_key(self) -> int | None:
+        """Parent node key."""
+        node = self.get("node")
+        if node is not None:
+            return int(node)
+        return None
+
+    @property
+    def status(self) -> str:
+        """DIMM status (online, error, warning, offline)."""
+        return str(self.get("status", ""))
+
+    @property
+    def status_info(self) -> str:
+        """Status details."""
+        return str(self.get("status_info", ""))
+
+    @property
+    def label(self) -> str:
+        """DIMM label."""
+        return str(self.get("label", ""))
+
+    @property
+    def locator(self) -> str:
+        """Slot locator (e.g. DIMM 0)."""
+        return str(self.get("locator", ""))
+
+    @property
+    def bank_locator(self) -> str:
+        """Bank locator (e.g. P0 CHANNEL A)."""
+        return str(self.get("bank_locator", ""))
+
+    @property
+    def memory_type(self) -> str:
+        """Memory type (DDR4, DDR5, etc.)."""
+        return str(self.get("type", ""))
+
+    @property
+    def type_detail(self) -> str:
+        """Memory type detail."""
+        return str(self.get("type_detail", ""))
+
+    @property
+    def size(self) -> str:
+        """DIMM size (e.g. '48 GB')."""
+        return str(self.get("size", ""))
+
+    @property
+    def speed(self) -> str:
+        """Memory speed (e.g. '5600 MT/s')."""
+        return str(self.get("speed", ""))
+
+    @property
+    def configured_memory_speed(self) -> str:
+        """Configured memory speed."""
+        return str(self.get("configured_memory_speed", ""))
+
+    @property
+    def form_factor(self) -> str:
+        """Form factor (DIMM, SODIMM, etc.)."""
+        return str(self.get("form_factor", ""))
+
+    @property
+    def manufacturer(self) -> str:
+        """DIMM manufacturer."""
+        return str(self.get("manufacturer", ""))
+
+    @property
+    def serial_number(self) -> str:
+        """DIMM serial number."""
+        return str(self.get("serial_number", ""))
+
+    @property
+    def part_number(self) -> str:
+        """Part number."""
+        return str(self.get("part_number", ""))
+
+    @property
+    def asset_tag(self) -> str:
+        """Asset tag."""
+        return str(self.get("asset_tag", ""))
+
+    @property
+    def rank(self) -> str:
+        """Memory rank."""
+        return str(self.get("rank", ""))
+
+    @property
+    def data_width(self) -> str:
+        """Data width."""
+        return str(self.get("data_width", ""))
+
+    @property
+    def total_width(self) -> str:
+        """Total width (includes ECC bits if present)."""
+        return str(self.get("total_width", ""))
+
+    @property
+    def memory_technology(self) -> str:
+        """Memory technology (DRAM, etc.)."""
+        return str(self.get("memory_technology", ""))
+
+    @property
+    def is_healthy(self) -> bool:
+        """Whether the DIMM is in a healthy state."""
+        return self.status == "online"
+
+    def __repr__(self) -> str:
+        return (
+            f"<NodeMemory key={self.get('$key', '?')} "
+            f"locator={self.locator!r} status={self.status!r} "
+            f"size={self.size!r}>"
+        )
+
+
+class NodeMemoryManager(ResourceManager[NodeMemory]):
+    """Manager for node memory (DIMM) health data.
+
+    Provides access to DIMM status across the cluster. Can be
+    scoped to a specific node or used globally.
+
+    Example:
+        >>> # List all DIMMs
+        >>> dimms = client.node_memory.list()
+
+        >>> # Find unhealthy DIMMs
+        >>> for dimm in dimms:
+        ...     if not dimm.is_healthy:
+        ...         print(f"ALERT: {dimm.locator} is {dimm.status}")
+    """
+
+    _endpoint = "node_memory"
+
+    _default_fields = [
+        "$key",
+        "node",
+        "status",
+        "status_info",
+        "label",
+        "locator",
+        "bank_locator",
+        "type",
+        "type_detail",
+        "size",
+        "speed",
+        "configured_memory_speed",
+        "form_factor",
+        "manufacturer",
+        "serial_number",
+        "part_number",
+        "asset_tag",
+        "rank",
+        "data_width",
+        "total_width",
+        "memory_technology",
+        "modified",
+    ]
+
+    def __init__(
+        self, client: VergeClient, node_key: int | None = None
+    ) -> None:
+        super().__init__(client)
+        self._node_key = node_key
+
+    def _to_model(self, data: dict[str, Any]) -> NodeMemory:
+        return NodeMemory(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[NodeMemory]:
+        """List node memory DIMMs with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of NodeMemory objects.
+        """
+        params: dict[str, Any] = {}
+        filters = []
+
+        if filter:
+            filters.append(filter)
+
+        if self._node_key is not None:
+            filters.append(f"node eq {self._node_key}")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> NodeMemory:
+        """Get a DIMM by key.
+
+        Args:
+            key: DIMM $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            NodeMemory object.
+
+        Raises:
+            NotFoundError: If DIMM not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+
+        if response is None or not isinstance(response, dict):
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Node memory {key} not found")
+
+        return self._to_model(response)

--- a/pyvergeos/resources/nodes.py
+++ b/pyvergeos/resources/nodes.py
@@ -200,6 +200,11 @@ class Node(ResourceObject):
         return bool(self.get("need_restart", False))
 
     @property
+    def reload_drivers_required(self) -> bool:
+        """Check if node requires a driver reload (maintenance window)."""
+        return bool(self.get("reload_drivers_required", False))
+
+    @property
     def restart_reason(self) -> str:
         """Reason for needing reboot."""
         return str(self.get("restart_reason", ""))

--- a/pyvergeos/resources/physical_drives.py
+++ b/pyvergeos/resources/physical_drives.py
@@ -1,0 +1,374 @@
+"""Physical drive (SMART health) resource manager."""
+
+from __future__ import annotations
+
+import builtins
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.filters import build_filter
+from pyvergeos.resources.base import ResourceManager, ResourceObject
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class PhysicalDrive(ResourceObject):
+    """Physical drive resource object.
+
+    Represents a physical drive with SMART health data and vSAN status.
+
+    Example:
+        >>> for drive in client.physical_drives.list():
+        ...     if drive.has_warnings:
+        ...         print(f"{drive.model} ({drive.location}): SMART warning")
+        ...     if drive.has_vsan_errors:
+        ...         print(f"  vSAN errors: R={drive.vsan_read_errors} W={drive.vsan_write_errors}")
+    """
+
+    @property
+    def model(self) -> str:
+        """Drive model."""
+        return str(self.get("model", ""))
+
+    @property
+    def serial(self) -> str:
+        """Drive serial number."""
+        return str(self.get("serial", ""))
+
+    @property
+    def firmware(self) -> str:
+        """Firmware version."""
+        return str(self.get("fw", ""))
+
+    @property
+    def path(self) -> str:
+        """Device path (e.g. /dev/nvme0n1)."""
+        return str(self.get("path", ""))
+
+    @property
+    def location(self) -> str:
+        """Drive location (e.g. nvme0, sata0)."""
+        return str(self.get("location", ""))
+
+    @property
+    def size_bytes(self) -> int:
+        """Drive size in bytes."""
+        return int(self.get("size") or 0)
+
+    @property
+    def temperature(self) -> int:
+        """Current temperature in Celsius."""
+        return int(self.get("temp") or 0)
+
+    @property
+    def temp_warn(self) -> bool:
+        """Temperature warning flag."""
+        return bool(self.get("temp_warn", False))
+
+    @property
+    def realloc_sectors(self) -> int:
+        """Reallocated sector count."""
+        return int(self.get("realloc_sectors") or 0)
+
+    @property
+    def realloc_sectors_warn(self) -> bool:
+        """Reallocated sectors warning flag."""
+        return bool(self.get("realloc_sectors_warn", False))
+
+    @property
+    def wear_level(self) -> int:
+        """SSD wear level percentage."""
+        return int(self.get("wear_level") or 0)
+
+    @property
+    def wear_level_warn(self) -> bool:
+        """SSD wear level warning flag."""
+        return bool(self.get("wear_level_warn", False))
+
+    @property
+    def current_pending_sector(self) -> int:
+        """Current pending sector count."""
+        return int(self.get("current_pending_sector") or 0)
+
+    @property
+    def current_pending_sector_warn(self) -> bool:
+        """Current pending sector warning flag."""
+        return bool(self.get("current_pending_sector_warn", False))
+
+    @property
+    def offline_uncorrectable(self) -> int:
+        """Offline uncorrectable sector count."""
+        return int(self.get("offline_uncorrectable") or 0)
+
+    @property
+    def offline_uncorrectable_warn(self) -> bool:
+        """Offline uncorrectable sectors warning flag."""
+        return bool(self.get("offline_uncorrectable_warn", False))
+
+    @property
+    def hours(self) -> int:
+        """Power-on hours."""
+        return int(self.get("hours") or 0)
+
+    @property
+    def hours_warn(self) -> bool:
+        """Power-on hours warning flag."""
+        return bool(self.get("hours_warn", False))
+
+    @property
+    def smart_enabled(self) -> bool:
+        """Whether SMART monitoring is enabled."""
+        return bool(self.get("smart", False))
+
+    @property
+    def vsan_read_errors(self) -> int:
+        """vSAN read error count."""
+        return int(self.get("vsan_read_errors") or 0)
+
+    @property
+    def vsan_write_errors(self) -> int:
+        """vSAN write error count."""
+        return int(self.get("vsan_write_errors") or 0)
+
+    @property
+    def vsan_last_error(self) -> str:
+        """Last vSAN error message."""
+        return str(self.get("vsan_last_error", ""))
+
+    @property
+    def vsan_throttle(self) -> int:
+        """Write throttle in bytes/sec (0 = no throttle)."""
+        return int(self.get("vsan_throttle") or 0)
+
+    @property
+    def vsan_tier(self) -> int:
+        """vSAN tier number."""
+        return int(self.get("vsan_tier") or 0)
+
+    @property
+    def vsan_repairing(self) -> bool:
+        """Whether the drive is currently being repaired."""
+        return bool(self.get("vsan_repairing", 0))
+
+    @property
+    def vsan_repair_estimate(self) -> int:
+        """Estimated repair time remaining in seconds."""
+        return int(self.get("vsan_repair_estimate") or 0)
+
+    @property
+    def vsan_online_since(self) -> datetime | None:
+        """Timestamp when drive came online in vSAN."""
+        ts = self.get("vsan_online_since")
+        if ts and int(ts) > 0:
+            return datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        return None
+
+    @property
+    def is_boot(self) -> bool:
+        """Whether this is a boot drive."""
+        return bool(self.get("boot", False))
+
+    @property
+    def is_spare(self) -> bool:
+        """Whether this is a spare drive."""
+        return bool(self.get("spare", False))
+
+    @property
+    def is_encrypted(self) -> bool:
+        """Whether the drive is encrypted."""
+        return bool(self.get("encrypted", False))
+
+    @property
+    def has_warnings(self) -> bool:
+        """Whether any SMART warning flag is set."""
+        return any([
+            self.temp_warn,
+            self.realloc_sectors_warn,
+            self.wear_level_warn,
+            self.current_pending_sector_warn,
+            self.offline_uncorrectable_warn,
+            self.hours_warn,
+        ])
+
+    @property
+    def has_vsan_errors(self) -> bool:
+        """Whether there are any vSAN read or write errors."""
+        return self.vsan_read_errors > 0 or self.vsan_write_errors > 0
+
+    def __repr__(self) -> str:
+        return (
+            f"<PhysicalDrive key={self.get('$key', '?')} "
+            f"model={self.model!r} location={self.location!r}>"
+        )
+
+
+class PhysicalDriveManager(ResourceManager[PhysicalDrive]):
+    """Manager for physical drive SMART health data.
+
+    Provides fleet-wide view of drive health. Can be scoped to a
+    specific node or used globally.
+
+    Example:
+        >>> # List all drives
+        >>> drives = client.physical_drives.list()
+
+        >>> # Find drives with warnings
+        >>> for drive in drives:
+        ...     if drive.has_warnings or drive.has_vsan_errors:
+        ...         print(f"ALERT: {drive.model} @ {drive.location}")
+    """
+
+    _endpoint = "machine_drive_phys"
+
+    _default_fields = [
+        "$key",
+        "model",
+        "serial",
+        "fw",
+        "path",
+        "location",
+        "size",
+        "temp",
+        "temp_warn",
+        "realloc_sectors",
+        "realloc_sectors_warn",
+        "wear_level",
+        "wear_level_warn",
+        "current_pending_sector",
+        "current_pending_sector_warn",
+        "offline_uncorrectable",
+        "offline_uncorrectable_warn",
+        "hours",
+        "hours_warn",
+        "smart",
+        "vsan_read_errors",
+        "vsan_write_errors",
+        "vsan_last_error",
+        "vsan_throttle",
+        "vsan_tier",
+        "vsan_repairing",
+        "vsan_repair_estimate",
+        "vsan_online_since",
+        "boot",
+        "swap",
+        "spare",
+        "encrypted",
+        "parent_drive",
+        "modified",
+    ]
+
+    def __init__(
+        self, client: VergeClient, node_key: int | None = None
+    ) -> None:
+        super().__init__(client)
+        self._node_key = node_key
+
+    def _to_model(self, data: dict[str, Any]) -> PhysicalDrive:
+        return PhysicalDrive(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        *,
+        warnings_only: bool = False,
+        **filter_kwargs: Any,
+    ) -> builtins.list[PhysicalDrive]:
+        """List physical drives with optional filtering.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+            warnings_only: If True, only return drives with SMART warnings.
+            **filter_kwargs: Additional filter arguments.
+
+        Returns:
+            List of PhysicalDrive objects.
+        """
+        params: dict[str, Any] = {}
+        filters = []
+
+        if filter:
+            filters.append(filter)
+
+        if self._node_key is not None:
+            filters.append(f"node eq {self._node_key}")
+
+        if warnings_only:
+            warn_conditions = [
+                "temp_warn eq true",
+                "realloc_sectors_warn eq true",
+                "wear_level_warn eq true",
+                "current_pending_sector_warn eq true",
+                "offline_uncorrectable_warn eq true",
+                "hours_warn eq true",
+            ]
+            filters.append(f"({' or '.join(warn_conditions)})")
+
+        if filter_kwargs:
+            filters.append(build_filter(**filter_kwargs))
+
+        if filters:
+            params["filter"] = " and ".join(filters)
+
+        if fields:
+            params["fields"] = ",".join(fields)
+        else:
+            params["fields"] = ",".join(self._default_fields)
+
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+
+        if response is None:
+            return []
+
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> PhysicalDrive:
+        """Get a physical drive by key.
+
+        Args:
+            key: Drive $key (ID).
+            fields: List of fields to return.
+
+        Returns:
+            PhysicalDrive object.
+
+        Raises:
+            NotFoundError: If drive not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("key must be provided")
+
+        params: dict[str, Any] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+
+        if response is None or not isinstance(response, dict):
+            from pyvergeos.exceptions import NotFoundError
+
+            raise NotFoundError(f"Physical drive {key} not found")
+
+        return self._to_model(response)

--- a/pyvergeos/resources/physical_drives.py
+++ b/pyvergeos/resources/physical_drives.py
@@ -182,14 +182,16 @@ class PhysicalDrive(ResourceObject):
     @property
     def has_warnings(self) -> bool:
         """Whether any SMART warning flag is set."""
-        return any([
-            self.temp_warn,
-            self.realloc_sectors_warn,
-            self.wear_level_warn,
-            self.current_pending_sector_warn,
-            self.offline_uncorrectable_warn,
-            self.hours_warn,
-        ])
+        return any(
+            [
+                self.temp_warn,
+                self.realloc_sectors_warn,
+                self.wear_level_warn,
+                self.current_pending_sector_warn,
+                self.offline_uncorrectable_warn,
+                self.hours_warn,
+            ]
+        )
 
     @property
     def has_vsan_errors(self) -> bool:
@@ -258,9 +260,7 @@ class PhysicalDriveManager(ResourceManager[PhysicalDrive]):
         "modified",
     ]
 
-    def __init__(
-        self, client: VergeClient, node_key: int | None = None
-    ) -> None:
+    def __init__(self, client: VergeClient, node_key: int | None = None) -> None:
         super().__init__(client)
         self._node_key = node_key
 
@@ -362,9 +362,7 @@ class PhysicalDriveManager(ResourceManager[PhysicalDrive]):
         if fields:
             params["fields"] = ",".join(fields)
 
-        response = self._client._request(
-            "GET", f"{self._endpoint}/{key}", params=params
-        )
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
 
         if response is None or not isinstance(response, dict):
             from pyvergeos.exceptions import NotFoundError

--- a/pyvergeos/resources/vsan_queries.py
+++ b/pyvergeos/resources/vsan_queries.py
@@ -109,9 +109,7 @@ class VsanQueryManager(ResourceManager[QueryResult]):
             fields = QUERY_DEFAULT_FIELDS
 
         params: dict[str, Any] = {"fields": ",".join(fields)}
-        response = self._client._request(
-            "GET", f"{self._endpoint}/{key}", params=params
-        )
+        response = self._client._request("GET", f"{self._endpoint}/{key}", params=params)
 
         if response is None or not isinstance(response, dict):
             raise NotFoundError(f"vSAN query {key} not found")
@@ -136,9 +134,7 @@ class VsanQueryManager(ResourceManager[QueryResult]):
         if params:
             body["params"] = params
 
-        response = self._client._request(
-            "POST", self._endpoint, json_data=body
-        )
+        response = self._client._request("POST", self._endpoint, json_data=body)
         if response is None or not isinstance(response, dict):
             raise ValueError("No response from vSAN query creation")
 
@@ -173,8 +169,7 @@ class VsanQueryManager(ResourceManager[QueryResult]):
                 return result
             if time.monotonic() >= deadline:
                 raise VergeTimeoutError(
-                    f"vSAN query {key} did not complete within {timeout}s "
-                    f"(status: {result.status})"
+                    f"vSAN query {key} did not complete within {timeout}s (status: {result.status})"
                 )
             time.sleep(poll_interval)
 

--- a/pyvergeos/resources/vsan_queries.py
+++ b/pyvergeos/resources/vsan_queries.py
@@ -1,0 +1,262 @@
+"""vSAN query resource manager for journal, tier, and repair status."""
+
+from __future__ import annotations
+
+import builtins
+import time
+from typing import TYPE_CHECKING, Any
+
+from pyvergeos.exceptions import NotFoundError, VergeTimeoutError
+from pyvergeos.resources.base import ResourceManager
+from pyvergeos.resources.queries import QUERY_DEFAULT_FIELDS, QueryResult
+
+if TYPE_CHECKING:
+    from pyvergeos.client import VergeClient
+
+
+class VsanQueryManager(ResourceManager[QueryResult]):
+    """Manager for vSAN diagnostic queries.
+
+    Supports async POST-and-poll queries for vSAN health:
+    journal status, tier status, and repair status.
+
+    Examples:
+        Check journal health::
+
+            result = client.vsan_queries.journal_status()
+            print(result.result)
+
+        Check tier status::
+
+            result = client.vsan_queries.tier_status()
+            print(result.result)
+
+        Check repair status for a node::
+
+            result = client.vsan_queries.repair_status(node_key=1)
+            print(result.result)
+    """
+
+    _endpoint = "vsan_queries"
+
+    def __init__(self, client: VergeClient) -> None:
+        super().__init__(client)
+
+    def _to_model(self, data: dict[str, Any]) -> QueryResult:
+        return QueryResult(data, self)
+
+    def list(  # noqa: A003
+        self,
+        filter: str | None = None,  # noqa: A002
+        fields: builtins.list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        **filter_kwargs: Any,
+    ) -> builtins.list[QueryResult]:
+        """List vSAN queries.
+
+        Args:
+            filter: OData filter string.
+            fields: List of fields to return.
+            limit: Maximum number of results.
+            offset: Skip this many results.
+
+        Returns:
+            List of QueryResult objects.
+        """
+        if fields is None:
+            fields = QUERY_DEFAULT_FIELDS
+
+        params: dict[str, Any] = {"fields": ",".join(fields)}
+
+        if filter:
+            params["filter"] = filter
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        response = self._client._request("GET", self._endpoint, params=params)
+        if response is None:
+            return []
+        if not isinstance(response, list):
+            return [self._to_model(response)]
+        return [self._to_model(item) for item in response]
+
+    def get(  # type: ignore[override]
+        self,
+        key: str | int | None = None,
+        *,
+        fields: builtins.list[str] | None = None,
+    ) -> QueryResult:
+        """Get a vSAN query by key.
+
+        Args:
+            key: Query $key (SHA1 string or integer).
+            fields: List of fields to return.
+
+        Returns:
+            QueryResult object.
+
+        Raises:
+            NotFoundError: If query not found.
+            ValueError: If key not provided.
+        """
+        if key is None:
+            raise ValueError("key must be provided")
+
+        if fields is None:
+            fields = QUERY_DEFAULT_FIELDS
+
+        params: dict[str, Any] = {"fields": ",".join(fields)}
+        response = self._client._request(
+            "GET", f"{self._endpoint}/{key}", params=params
+        )
+
+        if response is None or not isinstance(response, dict):
+            raise NotFoundError(f"vSAN query {key} not found")
+
+        return self._to_model(response)
+
+    def create(  # type: ignore[override]
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+    ) -> QueryResult:
+        """Submit a new vSAN query.
+
+        Args:
+            query: Query type (e.g. "getjournalstatus").
+            params: Query parameters (e.g. {"node": 1}).
+
+        Returns:
+            QueryResult object.
+        """
+        body: dict[str, Any] = {"query": query}
+        if params:
+            body["params"] = params
+
+        response = self._client._request(
+            "POST", self._endpoint, json_data=body
+        )
+        if response is None or not isinstance(response, dict):
+            raise ValueError("No response from vSAN query creation")
+
+        key = response.get("$key")
+        if key is not None:
+            return self.get(key)
+        return self._to_model(response)
+
+    def wait(
+        self,
+        key: str | int,
+        timeout: float = 120,
+        poll_interval: float = 1.0,
+    ) -> QueryResult:
+        """Poll a vSAN query until it completes or errors.
+
+        Args:
+            key: Query $key to poll.
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            Completed QueryResult.
+
+        Raises:
+            VergeTimeoutError: If query doesn't complete within timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            result = self.get(key)
+            if result.status in ("complete", "error"):
+                return result
+            if time.monotonic() >= deadline:
+                raise VergeTimeoutError(
+                    f"vSAN query {key} did not complete within {timeout}s "
+                    f"(status: {result.status})"
+                )
+            time.sleep(poll_interval)
+
+    def run(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 120,
+        poll_interval: float = 1.0,
+    ) -> QueryResult:
+        """Submit a vSAN query and wait for completion.
+
+        Args:
+            query: Query type string.
+            params: Query parameters.
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            Completed QueryResult.
+        """
+        result = self.create(query, params)
+        return self.wait(result.key, timeout=timeout, poll_interval=poll_interval)
+
+    def journal_status(
+        self,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Get vSAN journal status.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: Additional query parameters.
+
+        Returns:
+            Completed QueryResult with journal status.
+        """
+        return self.run(
+            "getjournalstatus",
+            params if params else None,
+            timeout=timeout,
+        )
+
+    def tier_status(
+        self,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Get vSAN tier status.
+
+        Args:
+            timeout: Max seconds to wait for result.
+            **params: Additional query parameters.
+
+        Returns:
+            Completed QueryResult with tier status.
+        """
+        return self.run(
+            "gettierstatus",
+            params if params else None,
+            timeout=timeout,
+        )
+
+    def repair_status(
+        self,
+        node_key: int,
+        timeout: float = 30,
+        **params: Any,
+    ) -> QueryResult:
+        """Get vSAN repair status for a node.
+
+        Args:
+            node_key: Node key to check repair status for.
+            timeout: Max seconds to wait for result.
+            **params: Additional query parameters.
+
+        Returns:
+            Completed QueryResult with repair status.
+        """
+        return self.run(
+            "getrepairstatus",
+            {"node": node_key, **params},
+            timeout=timeout,
+        )

--- a/tests/unit/test_node_memory.py
+++ b/tests/unit/test_node_memory.py
@@ -1,0 +1,213 @@
+"""Unit tests for node memory (DIMM health) operations."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.resources.node_memory import (
+    NodeMemory,
+    NodeMemoryManager,
+)
+
+
+SAMPLE_DIMM = {
+    "$key": 1,
+    "node": 1,
+    "handle": "0x0014",
+    "status": "online",
+    "status_info": "",
+    "label": "",
+    "locator": "DIMM 0",
+    "bank_locator": "P0 CHANNEL A",
+    "type": "DDR5",
+    "type_detail": "Synchronous Unbuffered (Unregistered)",
+    "size": "48 GB",
+    "speed": "5600 MT/s",
+    "configured_memory_speed": "5600 MT/s",
+    "form_factor": "SODIMM",
+    "manufacturer": "Micron Technology",
+    "serial_number": "EB687597",
+    "part_number": "CT48G56C46S5.M16C1",
+    "asset_tag": "Not Specified",
+    "rank": "2",
+    "data_width": "64 bits",
+    "total_width": "64 bits",
+    "memory_technology": "DRAM",
+    "created": 1774203413,
+    "modified": 1774716042,
+}
+
+SAMPLE_ERROR_DIMM = {
+    "$key": 5,
+    "node": 2,
+    "handle": "0x0020",
+    "status": "error",
+    "status_info": "Correctable ECC errors detected",
+    "label": "DIMM_A1",
+    "locator": "DIMM 2",
+    "bank_locator": "P1 CHANNEL A",
+    "type": "DDR4",
+    "type_detail": "Registered (Buffered)",
+    "size": "32 GB",
+    "speed": "3200 MT/s",
+    "configured_memory_speed": "3200 MT/s",
+    "form_factor": "DIMM",
+    "manufacturer": "Samsung",
+    "serial_number": "ABC123",
+    "part_number": "M393A4K40DB3",
+    "asset_tag": "DIMM-A1-SLOT2",
+    "rank": "2",
+    "data_width": "64 bits",
+    "total_width": "72 bits",
+    "memory_technology": "DRAM",
+    "created": 1774000000,
+    "modified": 1774500000,
+}
+
+
+class TestNodeMemory:
+    """Tests for NodeMemory resource object."""
+
+    def test_key_property(self) -> None:
+        dimm = NodeMemory({"$key": 1}, MagicMock())
+        assert dimm.key == 1
+
+    def test_node_key(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.node_key == 1
+
+    def test_node_key_missing(self) -> None:
+        dimm = NodeMemory({"$key": 1}, MagicMock())
+        assert dimm.node_key is None
+
+    def test_status_online(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.status == "online"
+
+    def test_status_error(self) -> None:
+        dimm = NodeMemory(SAMPLE_ERROR_DIMM, MagicMock())
+        assert dimm.status == "error"
+
+    def test_status_info(self) -> None:
+        dimm = NodeMemory(SAMPLE_ERROR_DIMM, MagicMock())
+        assert dimm.status_info == "Correctable ECC errors detected"
+
+    def test_status_info_empty(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.status_info == ""
+
+    def test_label(self) -> None:
+        dimm = NodeMemory(SAMPLE_ERROR_DIMM, MagicMock())
+        assert dimm.label == "DIMM_A1"
+
+    def test_locator(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.locator == "DIMM 0"
+
+    def test_bank_locator(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.bank_locator == "P0 CHANNEL A"
+
+    def test_memory_type(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.memory_type == "DDR5"
+
+    def test_size(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.size == "48 GB"
+
+    def test_speed(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.speed == "5600 MT/s"
+
+    def test_form_factor(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.form_factor == "SODIMM"
+
+    def test_manufacturer(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.manufacturer == "Micron Technology"
+
+    def test_serial_number(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.serial_number == "EB687597"
+
+    def test_part_number(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.part_number == "CT48G56C46S5.M16C1"
+
+    def test_is_healthy_true(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        assert dimm.is_healthy is True
+
+    def test_is_healthy_false_error(self) -> None:
+        dimm = NodeMemory(SAMPLE_ERROR_DIMM, MagicMock())
+        assert dimm.is_healthy is False
+
+    def test_is_healthy_false_warning(self) -> None:
+        data = {**SAMPLE_DIMM, "status": "warning"}
+        dimm = NodeMemory(data, MagicMock())
+        assert dimm.is_healthy is False
+
+    def test_repr(self) -> None:
+        dimm = NodeMemory(SAMPLE_DIMM, MagicMock())
+        r = repr(dimm)
+        assert "NodeMemory" in r
+        assert "DIMM 0" in r
+        assert "online" in r
+
+
+class TestNodeMemoryManager:
+    """Tests for NodeMemoryManager."""
+
+    def test_list_returns_node_memory(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = [SAMPLE_DIMM, SAMPLE_ERROR_DIMM]
+        manager = NodeMemoryManager(mock_client)
+
+        dimms = manager.list()
+
+        assert len(dimms) == 2
+        assert all(isinstance(d, NodeMemory) for d in dimms)
+
+    def test_list_empty(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = []
+        manager = NodeMemoryManager(mock_client)
+
+        assert manager.list() == []
+
+    def test_list_none_response(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = None
+        manager = NodeMemoryManager(mock_client)
+
+        assert manager.list() == []
+
+    def test_list_with_node_filter(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = [SAMPLE_DIMM]
+        manager = NodeMemoryManager(mock_client, node_key=1)
+
+        _ = manager.list()
+
+        call_args = mock_client._request.call_args
+        params = call_args[1].get("params") or call_args[0][2]
+        assert "node eq 1" in params.get("filter", "")
+
+    def test_get_by_key(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = SAMPLE_DIMM
+        manager = NodeMemoryManager(mock_client)
+
+        dimm = manager.get(key=1)
+
+        assert isinstance(dimm, NodeMemory)
+        assert dimm.key == 1
+
+    def test_endpoint(self) -> None:
+        mock_client = MagicMock()
+        manager = NodeMemoryManager(mock_client)
+        assert manager._endpoint == "node_memory"

--- a/tests/unit/test_node_memory.py
+++ b/tests/unit/test_node_memory.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from pyvergeos.resources.node_memory import (
     NodeMemory,
     NodeMemoryManager,
 )
-
 
 SAMPLE_DIMM = {
     "$key": 1,

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -210,6 +210,23 @@ class TestNode:
         node = Node(data, MagicMock())
         assert node.needs_restart is False
 
+    def test_reload_drivers_required_true(self) -> None:
+        """Test reload_drivers_required property when true."""
+        data = {"$key": 1, "reload_drivers_required": True}
+        node = Node(data, MagicMock())
+        assert node.reload_drivers_required is True
+
+    def test_reload_drivers_required_false(self) -> None:
+        """Test reload_drivers_required property when false."""
+        data = {"$key": 1, "reload_drivers_required": False}
+        node = Node(data, MagicMock())
+        assert node.reload_drivers_required is False
+
+    def test_reload_drivers_required_missing(self) -> None:
+        """Test reload_drivers_required defaults to False when missing."""
+        node = Node({"$key": 1}, MagicMock())
+        assert node.reload_drivers_required is False
+
     def test_restart_reason_property(self) -> None:
         """Test restart_reason property."""
         data = {"$key": 1, "restart_reason": "Kernel update pending"}

--- a/tests/unit/test_physical_drives.py
+++ b/tests/unit/test_physical_drives.py
@@ -1,0 +1,320 @@
+"""Unit tests for physical drive (SMART health) operations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyvergeos.resources.physical_drives import (
+    PhysicalDrive,
+    PhysicalDriveManager,
+)
+
+
+SAMPLE_DRIVE = {
+    "$key": 1,
+    "model": "SOLIDIGM SSDPFKKW020X7",
+    "serial": "SJC7N44291180790B",
+    "fw": "001C",
+    "path": "/dev/nvme0n1",
+    "location": "nvme0",
+    "size": 2048408248320,
+    "temp": 63,
+    "temp_warn": False,
+    "realloc_sectors": 0,
+    "realloc_sectors_warn": False,
+    "wear_level": 1,
+    "wear_level_warn": False,
+    "current_pending_sector": 0,
+    "current_pending_sector_warn": False,
+    "offline_uncorrectable": 0,
+    "offline_uncorrectable_warn": False,
+    "hours": 5892,
+    "hours_warn": False,
+    "smart": True,
+    "vsan_read_errors": 0,
+    "vsan_write_errors": 0,
+    "vsan_last_error": "",
+    "vsan_throttle": 0,
+    "vsan_tier": 1,
+    "vsan_used": 443225735168,
+    "vsan_max": 2042034651136,
+    "vsan_online_since": 1774716017,
+    "vsan_driveid": 0,
+    "vsan_avg_latency": 0,
+    "vsan_max_latency": 0,
+    "vsan_repairing": 0,
+    "vsan_repair_estimate": 0,
+    "boot": True,
+    "swap": True,
+    "spare": False,
+    "encrypted": False,
+    "parent_drive": 1,
+    "modified": 1776387996,
+}
+
+SAMPLE_WARN_DRIVE = {
+    "$key": 2,
+    "model": "WDC WD40EFRX",
+    "serial": "WD-WCC4E1234567",
+    "fw": "82.00A82",
+    "path": "/dev/sda",
+    "location": "sata0",
+    "size": 4000787030016,
+    "temp": 45,
+    "temp_warn": True,
+    "realloc_sectors": 8,
+    "realloc_sectors_warn": True,
+    "wear_level": 0,
+    "wear_level_warn": False,
+    "current_pending_sector": 2,
+    "current_pending_sector_warn": True,
+    "offline_uncorrectable": 1,
+    "offline_uncorrectable_warn": True,
+    "hours": 43000,
+    "hours_warn": True,
+    "smart": True,
+    "vsan_read_errors": 5,
+    "vsan_write_errors": 3,
+    "vsan_last_error": "I/O error on sector 12345",
+    "vsan_throttle": 104857600,
+    "vsan_tier": 1,
+    "vsan_used": 0,
+    "vsan_max": 0,
+    "vsan_online_since": 0,
+    "vsan_driveid": 1,
+    "vsan_avg_latency": 15,
+    "vsan_max_latency": 200,
+    "vsan_repairing": 1,
+    "vsan_repair_estimate": 3600,
+    "boot": False,
+    "swap": False,
+    "spare": True,
+    "encrypted": True,
+    "parent_drive": 2,
+    "modified": 1776300000,
+}
+
+
+class TestPhysicalDrive:
+    """Tests for PhysicalDrive resource object."""
+
+    def test_key_property(self) -> None:
+        data = {"$key": 1}
+        drive = PhysicalDrive(data, MagicMock())
+        assert drive.key == 1
+
+    def test_model_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.model == "SOLIDIGM SSDPFKKW020X7"
+
+    def test_serial_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.serial == "SJC7N44291180790B"
+
+    def test_firmware_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.firmware == "001C"
+
+    def test_path_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.path == "/dev/nvme0n1"
+
+    def test_location_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.location == "nvme0"
+
+    def test_size_bytes_property(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.size_bytes == 2048408248320
+
+    def test_temperature(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.temperature == 63
+
+    def test_temp_warn_false(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.temp_warn is False
+
+    def test_temp_warn_true(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.temp_warn is True
+
+    def test_realloc_sectors(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.realloc_sectors == 8
+
+    def test_realloc_sectors_warn(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.realloc_sectors_warn is True
+
+    def test_wear_level(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.wear_level == 1
+
+    def test_wear_level_warn(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.wear_level_warn is False
+
+    def test_current_pending_sector(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.current_pending_sector == 2
+
+    def test_current_pending_sector_warn(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.current_pending_sector_warn is True
+
+    def test_offline_uncorrectable(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.offline_uncorrectable == 1
+
+    def test_offline_uncorrectable_warn(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.offline_uncorrectable_warn is True
+
+    def test_hours(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.hours == 5892
+
+    def test_hours_warn(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.hours_warn is True
+
+    def test_smart_enabled(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.smart_enabled is True
+
+    def test_vsan_read_errors(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_read_errors == 5
+
+    def test_vsan_write_errors(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_write_errors == 3
+
+    def test_vsan_last_error(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_last_error == "I/O error on sector 12345"
+
+    def test_vsan_last_error_empty(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.vsan_last_error == ""
+
+    def test_vsan_throttle(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_throttle == 104857600
+
+    def test_vsan_tier(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.vsan_tier == 1
+
+    def test_vsan_repairing(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_repairing is True
+
+    def test_vsan_repairing_false(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.vsan_repairing is False
+
+    def test_vsan_online_since(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.vsan_online_since == datetime(
+            2026, 3, 28, 16, 40, 17, tzinfo=timezone.utc
+        )
+
+    def test_vsan_online_since_zero(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.vsan_online_since is None
+
+    def test_is_boot(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.is_boot is True
+
+    def test_is_spare(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.is_spare is True
+
+    def test_is_encrypted(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.is_encrypted is True
+
+    def test_has_warnings_false(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.has_warnings is False
+
+    def test_has_warnings_true(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.has_warnings is True
+
+    def test_has_vsan_errors_false(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        assert drive.has_vsan_errors is False
+
+    def test_has_vsan_errors_true(self) -> None:
+        drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())
+        assert drive.has_vsan_errors is True
+
+    def test_repr(self) -> None:
+        drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
+        r = repr(drive)
+        assert "PhysicalDrive" in r
+        assert "SOLIDIGM" in r
+        assert "nvme0" in r
+
+
+class TestPhysicalDriveManager:
+    """Tests for PhysicalDriveManager."""
+
+    def test_list_returns_physical_drives(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = [SAMPLE_DRIVE, SAMPLE_WARN_DRIVE]
+        manager = PhysicalDriveManager(mock_client)
+
+        drives = manager.list()
+
+        assert len(drives) == 2
+        assert all(isinstance(d, PhysicalDrive) for d in drives)
+
+    def test_list_empty(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = []
+        manager = PhysicalDriveManager(mock_client)
+
+        drives = manager.list()
+        assert drives == []
+
+    def test_list_none_response(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = None
+        manager = PhysicalDriveManager(mock_client)
+
+        drives = manager.list()
+        assert drives == []
+
+    def test_get_by_key(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = SAMPLE_DRIVE
+        manager = PhysicalDriveManager(mock_client)
+
+        drive = manager.get(key=1)
+
+        assert isinstance(drive, PhysicalDrive)
+        assert drive.key == 1
+
+    def test_list_with_node_filter(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = [SAMPLE_DRIVE]
+        manager = PhysicalDriveManager(mock_client, node_key=1)
+
+        _ = manager.list()
+
+        call_args = mock_client._request.call_args
+        params = call_args[1].get("params") or call_args[0][2]
+        assert "node eq 1" in params.get("filter", "")
+
+    def test_endpoint(self) -> None:
+        mock_client = MagicMock()
+        manager = PhysicalDriveManager(mock_client)
+        assert manager._endpoint == "machine_drive_phys"

--- a/tests/unit/test_physical_drives.py
+++ b/tests/unit/test_physical_drives.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
-import pytest
-
 from pyvergeos.resources.physical_drives import (
     PhysicalDrive,
     PhysicalDriveManager,
 )
-
 
 SAMPLE_DRIVE = {
     "$key": 1,
@@ -220,9 +217,7 @@ class TestPhysicalDrive:
 
     def test_vsan_online_since(self) -> None:
         drive = PhysicalDrive(SAMPLE_DRIVE, MagicMock())
-        assert drive.vsan_online_since == datetime(
-            2026, 3, 28, 16, 40, 17, tzinfo=timezone.utc
-        )
+        assert drive.vsan_online_since == datetime(2026, 3, 28, 16, 40, 17, tzinfo=timezone.utc)
 
     def test_vsan_online_since_zero(self) -> None:
         drive = PhysicalDrive(SAMPLE_WARN_DRIVE, MagicMock())

--- a/tests/unit/test_vsan_queries.py
+++ b/tests/unit/test_vsan_queries.py
@@ -10,7 +10,6 @@ from pyvergeos.exceptions import VergeTimeoutError
 from pyvergeos.resources.queries import QueryResult
 from pyvergeos.resources.vsan_queries import VsanQueryManager
 
-
 SAMPLE_QUERY_CREATED = {
     "$key": "abc123def456",
     "location": "/v4/vsan_queries/abc123def456",
@@ -73,10 +72,7 @@ SAMPLE_REPAIR_COMPLETE = {
     "query": "getrepairstatus",
     "params": {"node": 1},
     "status": "complete",
-    "result": (
-        "0) device_0 = (uint64) 0\r\n"
-        "1) device_1 = (uint64) 0\r\n"
-    ),
+    "result": ("0) device_0 = (uint64) 0\r\n1) device_1 = (uint64) 0\r\n"),
     "command": "vcmd getrepairstatus",
     "created": 1776388451693922,
     "modified": 1776388451,
@@ -100,7 +96,7 @@ class TestVsanQueryManager:
         ]
         manager = VsanQueryManager(mock_client)
 
-        result = manager.create("getjournalstatus")
+        _ = manager.create("getjournalstatus")
 
         # Verify POST was called with correct body
         post_call = mock_client._request.call_args_list[0]
@@ -117,7 +113,7 @@ class TestVsanQueryManager:
         ]
         manager = VsanQueryManager(mock_client)
 
-        result = manager.create("getrepairstatus", params={"node": 1})
+        _ = manager.create("getrepairstatus", params={"node": 1})
 
         post_call = mock_client._request.call_args_list[0]
         body = post_call[1].get("json_data") or post_call[0][2]
@@ -154,9 +150,11 @@ class TestVsanQueryManager:
         mock_client._request.return_value = SAMPLE_QUERY_RUNNING
         manager = VsanQueryManager(mock_client)
 
-        with patch("time.monotonic", side_effect=[0, 0.5, 1.0, 2.0, 3.0]):
-            with pytest.raises(VergeTimeoutError):
-                manager.wait("abc123def456", timeout=2, poll_interval=0.01)
+        with (
+            patch("time.monotonic", side_effect=[0, 0.5, 1.0, 2.0, 3.0]),
+            pytest.raises(VergeTimeoutError),
+        ):
+            manager.wait("abc123def456", timeout=2, poll_interval=0.01)
 
     def test_run_creates_and_waits(self) -> None:
         mock_client = MagicMock()

--- a/tests/unit/test_vsan_queries.py
+++ b/tests/unit/test_vsan_queries.py
@@ -1,0 +1,246 @@
+"""Unit tests for vSAN query operations."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyvergeos.exceptions import VergeTimeoutError
+from pyvergeos.resources.queries import QueryResult
+from pyvergeos.resources.vsan_queries import VsanQueryManager
+
+
+SAMPLE_QUERY_CREATED = {
+    "$key": "abc123def456",
+    "location": "/v4/vsan_queries/abc123def456",
+    "dbpath": "vsan_queries/abc123def456",
+    "$row": 1,
+}
+
+SAMPLE_QUERY_RUNNING = {
+    "$key": "abc123def456",
+    "id": "abc123def456",
+    "query": "getjournalstatus",
+    "params": [],
+    "status": "running",
+    "result": "",
+    "command": "vcmd getjournalstatus",
+    "created": 1776388317910047,
+    "modified": 1776388317,
+    "expires": 1776391917,
+}
+
+SAMPLE_JOURNAL_COMPLETE = {
+    "$key": "abc123def456",
+    "id": "abc123def456",
+    "query": "getjournalstatus",
+    "params": [],
+    "status": "complete",
+    "result": (
+        '0) status = (string) "flushing open files"\r\n'
+        "1) alive = (bool) true\r\n"
+        "2) cur_transaction = (uint64) 270326\r\n"
+        "3) redundant = (bool) true\r\n"
+    ),
+    "command": "vcmd getjournalstatus",
+    "created": 1776388317910047,
+    "modified": 1776388318,
+    "expires": 1776391917,
+}
+
+SAMPLE_TIER_COMPLETE = {
+    "$key": "def789",
+    "id": "def789",
+    "query": "gettierstatus",
+    "params": [],
+    "status": "complete",
+    "result": (
+        "0) tier_1 = (serstring)\r\n{\r\n"
+        "     0) tier = (int) 1\r\n"
+        "     1) redundancy = (int) 2\r\n"
+        "     2) redundant = (bool) true\r\n}\r\n"
+    ),
+    "command": "vcmd gettierstatus",
+    "created": 1776388337777135,
+    "modified": 1776388337,
+    "expires": 1776391937,
+}
+
+SAMPLE_REPAIR_COMPLETE = {
+    "$key": "ghi012",
+    "id": "ghi012",
+    "query": "getrepairstatus",
+    "params": {"node": 1},
+    "status": "complete",
+    "result": (
+        "0) device_0 = (uint64) 0\r\n"
+        "1) device_1 = (uint64) 0\r\n"
+    ),
+    "command": "vcmd getrepairstatus",
+    "created": 1776388451693922,
+    "modified": 1776388451,
+    "expires": 1776392051,
+}
+
+
+class TestVsanQueryManager:
+    """Tests for VsanQueryManager."""
+
+    def test_endpoint(self) -> None:
+        mock_client = MagicMock()
+        manager = VsanQueryManager(mock_client)
+        assert manager._endpoint == "vsan_queries"
+
+    def test_create_journal_query(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_JOURNAL_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        result = manager.create("getjournalstatus")
+
+        # Verify POST was called with correct body
+        post_call = mock_client._request.call_args_list[0]
+        assert post_call[0][0] == "POST"
+        assert post_call[0][1] == "vsan_queries"
+        body = post_call[1].get("json_data") or post_call[0][2]
+        assert body["query"] == "getjournalstatus"
+
+    def test_create_repair_query_with_params(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_REPAIR_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        result = manager.create("getrepairstatus", params={"node": 1})
+
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1].get("json_data") or post_call[0][2]
+        assert body["query"] == "getrepairstatus"
+        assert body["params"] == {"node": 1}
+
+    def test_wait_returns_completed(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = SAMPLE_JOURNAL_COMPLETE
+        manager = VsanQueryManager(mock_client)
+
+        result = manager.wait("abc123def456")
+
+        assert isinstance(result, QueryResult)
+        assert result.status == "complete"
+
+    def test_wait_polls_until_complete(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_RUNNING,
+            SAMPLE_QUERY_RUNNING,
+            SAMPLE_JOURNAL_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.sleep"):
+            result = manager.wait("abc123def456", poll_interval=0.01)
+
+        assert result.status == "complete"
+        assert mock_client._request.call_count == 3
+
+    def test_wait_timeout(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = SAMPLE_QUERY_RUNNING
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.monotonic", side_effect=[0, 0.5, 1.0, 2.0, 3.0]):
+            with pytest.raises(VergeTimeoutError):
+                manager.wait("abc123def456", timeout=2, poll_interval=0.01)
+
+    def test_run_creates_and_waits(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_JOURNAL_COMPLETE,  # From get() inside create()
+            SAMPLE_JOURNAL_COMPLETE,  # From wait()
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.sleep"):
+            result = manager.run("getjournalstatus")
+
+        assert isinstance(result, QueryResult)
+        assert result.status == "complete"
+
+    def test_journal_status(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_JOURNAL_COMPLETE,
+            SAMPLE_JOURNAL_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.sleep"):
+            result = manager.journal_status()
+
+        assert result.status == "complete"
+        assert "flushing open files" in result.result
+
+    def test_tier_status(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_TIER_COMPLETE,
+            SAMPLE_TIER_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.sleep"):
+            result = manager.tier_status()
+
+        assert result.status == "complete"
+        assert "tier_1" in result.result
+
+    def test_repair_status(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [
+            SAMPLE_QUERY_CREATED,
+            SAMPLE_REPAIR_COMPLETE,
+            SAMPLE_REPAIR_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        with patch("time.sleep"):
+            result = manager.repair_status(node_key=1)
+
+        assert result.status == "complete"
+
+        # Verify node param was passed
+        post_call = mock_client._request.call_args_list[0]
+        body = post_call[1].get("json_data") or post_call[0][2]
+        assert body["params"] == {"node": 1}
+
+    def test_list(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = [
+            SAMPLE_JOURNAL_COMPLETE,
+            SAMPLE_TIER_COMPLETE,
+        ]
+        manager = VsanQueryManager(mock_client)
+
+        results = manager.list()
+
+        assert len(results) == 2
+        assert all(isinstance(r, QueryResult) for r in results)
+
+    def test_get_by_key(self) -> None:
+        mock_client = MagicMock()
+        mock_client._request.return_value = SAMPLE_JOURNAL_COMPLETE
+        manager = VsanQueryManager(mock_client)
+
+        result = manager.get(key="abc123def456")
+
+        assert isinstance(result, QueryResult)
+        assert result.key == "abc123def456"

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "pyvergeos"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

Resolves the four SDK blockers tracked in verge-io/vrg#10 that `vrg doctor` needs:

- **`PhysicalDriveManager`** (`machine_drive_phys`) — Fleet-wide SMART health view with `has_warnings`/`has_vsan_errors` convenience properties and `warnings_only` filter
- **`NodeMemoryManager`** (`node_memory`) — DIMM health status with `is_healthy` property
- **`VsanQueryManager`** (`vsan_queries`) — Async POST/poll queries with `journal_status()`, `tier_status()`, `repair_status(node_key)` convenience methods
- **`Node.reload_drivers_required`** — Boolean property for driver reload state (distinct from `needs_restart`)

All three new managers registered on `VergeClient` as lazy properties. Version bumped to 1.2.2.

## Test plan

- [x] 87 new unit tests (45 + 27 + 12 + 3), full suite 4312 passed
- [x] Coverage 81.78% (above 80% threshold)
- [x] All endpoints verified against dev system
- [x] Lint clean (`ruff check` + `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)