### PR TITLE
Add caller-supplied session support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changed
 ^^^^^^^
 
 - ``VergeConnection`` now exposes its session as the public ``session`` field.
+  The previous private ``_session`` attribute has been removed.
 - Caller-supplied sessions are not closed by default on disconnect, and
   VergeOS auth/content headers are restored to their pre-connect values.
 - Retry and ``verify_ssl`` connection options are ignored with a warning when

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ All notable changes to pyvergeos will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-[1.3.0] - 2026-05-21
+[1.2.3] - 2026-05-21
 --------------------
 
 Added

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,25 @@ All notable changes to pyvergeos will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+[1.3.0] - 2026-05-21
+--------------------
+
+Added
+^^^^^
+
+- Added ``session=`` and ``close_session=`` kwargs to ``VergeClient`` for
+  caller-managed ``requests.Session`` support.
+
+Changed
+^^^^^^^
+
+- ``VergeConnection`` now exposes its session as the public ``session`` field.
+- Caller-supplied sessions are not closed by default on disconnect, and
+  VergeOS auth/content headers are restored to their pre-connect values.
+- Retry and ``verify_ssl`` connection options are ignored with a warning when
+  a caller-supplied session is used; configure those behaviors on the supplied
+  session instead.
+
 [1.0.0] - 2026-02-01
 --------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ Changed
 - Retry and ``verify_ssl`` connection options are ignored with a warning when
   a caller-supplied session is used; configure those behaviors on the supplied
   session instead.
+- Caller-supplied sessions must not be shared by multiple active
+  ``VergeClient`` instances because authentication is stored in session headers
+  while connected.
 
 [1.0.0] - 2026-02-01
 --------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Changed
 - Caller-supplied sessions must not be shared by multiple active
   ``VergeClient`` instances because authentication is stored in session headers
   while connected.
+- ``close_session=False`` now requires a caller-supplied session to avoid
+  leaking SDK-created connection pools.
 
 [1.0.0] - 2026-02-01
 --------------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -377,7 +377,7 @@ For advanced debugging, use a requests hook:
 
 .. code-block:: python
 
-   from pyvergeos.connection import Connection
+   from pyvergeos.connection import VergeConnection
 
    def log_response(response, *args, **kwargs):
        print(f"Request: {response.request.method} {response.request.url}")
@@ -385,7 +385,7 @@ For advanced debugging, use a requests hook:
        print(f"Body: {response.text[:500]}")
 
    # Add hook to connection
-   client._connection._session.hooks["response"].append(log_response)
+   client._connection.session.hooks["response"].append(log_response)
 
 Getting Help
 ------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ Before running any example:
 
 | Example | Description |
 |---------|-------------|
-| [connection_example.py](connection_example.py) | Various ways to connect to VergeOS (basic auth, environment variables, context managers) |
+| [connection_example.py](connection_example.py) | Various ways to connect to VergeOS (basic auth, environment variables, context managers, caller-managed sessions) |
 
 ### Virtual Machines
 

--- a/examples/connection_example.py
+++ b/examples/connection_example.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Example: Connection management with pyvergeos.
 
-This example demonstrates various ways to connect to a VergeOS system.
+This example demonstrates various ways to connect to a VergeOS system,
+including using a caller-managed requests.Session.
 """
 
 import os
+
+import requests
+from requests.adapters import HTTPAdapter
 
 from pyvergeos import VergeClient
 from pyvergeos.exceptions import AuthenticationError, VergeConnectionError
@@ -60,6 +64,35 @@ def context_manager() -> None:
 
     # Client is automatically disconnected when exiting the 'with' block
     print(f"After context: Connected = {client.is_connected}")
+
+
+def byo_session() -> None:
+    """Connect using a caller-managed requests.Session."""
+    print("\n=== Bring Your Own Session ===")
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": "my-automation/1.0"})
+    # session.verify = "/path/to/ca-bundle.pem"
+
+    my_adapter = HTTPAdapter(pool_connections=4, pool_maxsize=20)
+    session.mount("https://", my_adapter)
+
+    client = VergeClient(
+        host="192.168.1.100",
+        username="admin",
+        password="your-password",
+        session=session,
+        auto_connect=False,
+    )
+    client.connect()
+
+    print(f"Connected: {client.is_connected}")
+    assert session.get_adapter("https://") is my_adapter
+
+    client.disconnect()
+    # The caller still owns the session. VergeOS auth headers have been
+    # restored, the custom adapter is still mounted, and the session remains
+    # open for other requests.
 
 
 def from_environment() -> None:
@@ -142,6 +175,7 @@ if __name__ == "__main__":
     # basic_connection()
     # token_connection()
     # context_manager()
+    # byo_session()
     # from_environment()
     # error_handling()
     # deferred_connection()
@@ -150,6 +184,7 @@ if __name__ == "__main__":
     print("  - Basic username/password connection")
     print("  - API token connection")
     print("  - Context manager (with statement)")
+    print("  - Caller-managed requests.Session")
     print("  - Environment variable configuration")
     print("  - Error handling")
     print("  - Deferred connection")

--- a/examples/connection_example.py
+++ b/examples/connection_example.py
@@ -92,7 +92,8 @@ def byo_session() -> None:
     client.disconnect()
     # The caller still owns the session. VergeOS auth headers have been
     # restored, the custom adapter is still mounted, and the session remains
-    # open for other requests.
+    # open for other requests. Use a separate session for each active
+    # VergeClient because auth is stored in session headers while connected.
 
 
 def from_environment() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.2.2"
+version = "1.3.0"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvergeos"
-version = "1.3.0"
+version = "1.2.3"
 description = "Python SDK for the VergeOS REST API"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.2.2"
+__version__ = "1.3.0"

--- a/pyvergeos/__version__.py
+++ b/pyvergeos/__version__.py
@@ -1,3 +1,3 @@
 """Version information for pyvergeos."""
 
-__version__ = "1.3.0"
+__version__ = "1.2.3"

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -215,11 +215,15 @@ class VergeClient:
                 VergeClient instances.
             close_session: Override whether disconnect closes the underlying
                 session. None closes SDK-created sessions and leaves
-                caller-supplied sessions open.
+                caller-supplied sessions open. close_session=False requires a
+                caller-supplied session.
 
         Raises:
             ValueError: If neither token nor username/password provided.
         """
+        if session is None and close_session is False:
+            raise ValueError("close_session=False requires a caller-supplied session")
+
         self.host = host
         self._username = username
         self._password = password
@@ -409,19 +413,9 @@ class VergeClient:
             if session is None:
                 raise NotConnectedError("Session not initialized")
 
-            if not self._connection._owns_session:
-                self._connection._pre_connect_headers = {
-                    key: cast("str | None", session.headers.get(key))
-                    for key in (
-                        "Authorization",
-                        HEADER_CONTENT_TYPE,
-                        HEADER_ACCEPT,
-                    )
-                }
-
-            session.headers.update(auth_header)
-            session.headers.update(
+            self._connection.apply_auth_headers(
                 {
+                    **auth_header,
                     HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON,
                     HEADER_ACCEPT: CONTENT_TYPE_JSON,
                 }
@@ -430,7 +424,10 @@ class VergeClient:
             # Validate connection
             self._validate_connection()
         except Exception:
-            self.disconnect()
+            try:
+                self.disconnect()
+            except Exception:
+                logger.exception("Error while cleaning up failed connection")
             raise
 
         return self
@@ -486,9 +483,12 @@ class VergeClient:
 
     def disconnect(self) -> None:
         """Disconnect from VergeOS and cleanup resources."""
-        if self._connection:
-            self._connection.disconnect()
-            self._connection = None
+        connection = self._connection
+        if connection:
+            try:
+                connection.disconnect()
+            finally:
+                self._connection = None
 
     @property
     def is_connected(self) -> bool:

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import requests
 
@@ -163,6 +163,13 @@ class VergeClient:
 
         # Or from environment variables
         >>> client = VergeClient.from_env()
+
+        # Or reuse a caller-managed requests session
+        >>> import requests
+        >>> session = requests.Session()
+        >>> session.headers.update({"User-Agent": "my-automation/1.0"})
+        >>> client = VergeClient(host="...", token="...", session=session)
+        >>> client.disconnect()  # session remains open by default
     """
 
     def __init__(
@@ -177,6 +184,8 @@ class VergeClient:
         retry_total: int = RETRY_TOTAL,
         retry_backoff_factor: float = RETRY_BACKOFF_FACTOR,
         retry_status_codes: frozenset[int] | None = None,
+        session: requests.Session | None = None,
+        close_session: bool | None = None,
     ) -> None:
         """Initialize VergeClient.
 
@@ -193,6 +202,14 @@ class VergeClient:
                 Delay = backoff_factor * (2 ** retry_count). Default: 1.
             retry_status_codes: HTTP status codes that trigger automatic retry.
                 Default: 429, 500, 502, 503, 504.
+            session: Optional caller-supplied requests session. When supplied,
+                pyvergeos will not mount its own adapter, change session TLS
+                verification, or close the session on disconnect by default.
+                VergeClient temporarily applies auth and JSON headers during
+                the connection and restores their previous values on disconnect.
+            close_session: Override whether disconnect closes the underlying
+                session. None closes SDK-created sessions and leaves
+                caller-supplied sessions open.
 
         Raises:
             ValueError: If neither token nor username/password provided.
@@ -208,6 +225,8 @@ class VergeClient:
         self._retry_status_codes = (
             retry_status_codes if retry_status_codes is not None else RETRY_STATUS_CODES
         )
+        self._session = session
+        self._close_session = close_session
 
         self._connection: VergeConnection | None = None
 
@@ -359,35 +378,51 @@ class VergeClient:
             retry_total=self._retry_total,
             retry_backoff_factor=self._retry_backoff_factor,
             retry_status_codes=self._retry_status_codes,
+            session=self._session,
+            close_session=self._close_session,
         )
 
-        # Determine auth method and build header
-        if self._token:
-            auth_header = build_auth_header(AuthMethod.TOKEN, token=self._token)
-            self._connection.token = self._token
-        elif self._username and self._password:
-            auth_header = build_auth_header(
-                AuthMethod.BASIC,
-                username=self._username,
-                password=self._password,
+        try:
+            # Determine auth method and build header
+            if self._token:
+                auth_header = build_auth_header(AuthMethod.TOKEN, token=self._token)
+                self._connection.token = self._token
+            elif self._username and self._password:
+                auth_header = build_auth_header(
+                    AuthMethod.BASIC,
+                    username=self._username,
+                    password=self._password,
+                )
+            else:
+                raise ValueError("Either token or username/password required")
+
+            session = self._connection.session
+            if session is None:
+                raise NotConnectedError("Session not initialized")
+
+            if not self._connection._owns_session:
+                self._connection._pre_connect_headers = {
+                    key: cast("str | None", session.headers.get(key))
+                    for key in (
+                        "Authorization",
+                        HEADER_CONTENT_TYPE,
+                        HEADER_ACCEPT,
+                    )
+                }
+
+            session.headers.update(auth_header)
+            session.headers.update(
+                {
+                    HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON,
+                    HEADER_ACCEPT: CONTENT_TYPE_JSON,
+                }
             )
-        else:
-            raise ValueError("Either token or username/password required")
 
-        session = self._connection._session
-        if session is None:
-            raise NotConnectedError("Session not initialized")
-
-        session.headers.update(auth_header)
-        session.headers.update(
-            {
-                HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON,
-                HEADER_ACCEPT: CONTENT_TYPE_JSON,
-            }
-        )
-
-        # Validate connection
-        self._validate_connection()
+            # Validate connection
+            self._validate_connection()
+        except Exception:
+            self.disconnect()
+            raise
 
         return self
 
@@ -402,7 +437,7 @@ class VergeClient:
             url = f"{self._connection.api_base_url}/system"
             params = {"fields": "$key,yb_version,os_version,cloud_name"}
 
-            session = self._connection._session
+            session = self._connection.session
             if session is None:
                 raise NotConnectedError("Session not initialized")
 
@@ -514,7 +549,7 @@ class VergeClient:
         if not self._connection or not self._connection.is_connected:
             raise NotConnectedError("Not connected to VergeOS")
 
-        session = self._connection._session
+        session = self._connection.session
         if session is None:
             raise NotConnectedError("Session not initialized")
 

--- a/pyvergeos/client.py
+++ b/pyvergeos/client.py
@@ -170,6 +170,10 @@ class VergeClient:
         >>> session.headers.update({"User-Agent": "my-automation/1.0"})
         >>> client = VergeClient(host="...", token="...", session=session)
         >>> client.disconnect()  # session remains open by default
+
+        Caller-managed sessions must not be shared by multiple active
+        VergeClient instances because authentication is applied to session
+        headers while connected.
     """
 
     def __init__(
@@ -207,6 +211,8 @@ class VergeClient:
                 verification, or close the session on disconnect by default.
                 VergeClient temporarily applies auth and JSON headers during
                 the connection and restores their previous values on disconnect.
+                Do not share one supplied session across multiple active
+                VergeClient instances.
             close_session: Override whether disconnect closes the underlying
                 session. None closes SDK-created sessions and leaves
                 caller-supplied sessions open.
@@ -371,6 +377,9 @@ class VergeClient:
             AuthenticationError: If authentication fails.
             ValueError: If credentials not provided.
         """
+        if self._connection is not None:
+            self.disconnect()
+
         self._connection = VergeConnection(
             host=self.host,
             username=self._username or "",

--- a/pyvergeos/connection.py
+++ b/pyvergeos/connection.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional, cast
+from typing import Optional, Union
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -19,6 +19,9 @@ from pyvergeos.constants import (
     RETRY_STATUS_CODES,
     RETRY_TOTAL,
 )
+
+HeaderValue = Union[str, bytes]
+HeaderSnapshot = tuple[str, Optional[HeaderValue]]
 
 
 class AuthMethod(Enum):
@@ -77,13 +80,14 @@ class VergeConnection:
     close_session: Optional[bool] = None
 
     _owns_session: bool = field(init=False, default=True, repr=False)
-    _pre_connect_headers: Optional[dict[str, Optional[str]]] = field(
+    _pre_connect_headers: Optional[dict[str, HeaderSnapshot]] = field(
         init=False, default=None, repr=False
     )
 
     def __post_init__(self) -> None:
         self.api_base_url = f"https://{self.host}/api/{API_VERSION}"
         self._owns_session = self.session is None
+        self.retry_status_codes = frozenset(self.retry_status_codes)
 
         if self._owns_session and self.close_session is False:
             raise ValueError("close_session=False requires a caller-supplied session")
@@ -155,11 +159,26 @@ class VergeConnection:
                 self._pre_connect_headers = {}
             for key in headers:
                 if key not in self._pre_connect_headers:
-                    self._pre_connect_headers[key] = cast(
-                        Optional[str], self.session.headers.get(key)
+                    prior_key = self._matching_header_key(key)
+                    prior_value = (
+                        self.session.headers.get(prior_key)
+                        if prior_key in self.session.headers
+                        else None
                     )
+                    self._pre_connect_headers[key] = (prior_key, prior_value)
 
         self.session.headers.update(headers)
+
+    def _matching_header_key(self, key: str) -> str:
+        """Return the current header spelling matching key, if present."""
+        if self.session is None:
+            raise RuntimeError("Session not initialized")
+
+        key_lower = key.lower()
+        for existing_key in self.session.headers:
+            if existing_key.lower() == key_lower:
+                return existing_key
+        return key
 
     def is_token_valid(self) -> bool:
         """Check if the current token/credentials are valid.
@@ -189,11 +208,10 @@ class VergeConnection:
         self.is_connected = False
 
         if self.session and not self._owns_session and self._pre_connect_headers is not None:
-            for key, prior_value in self._pre_connect_headers.items():
-                if prior_value is None:
-                    self.session.headers.pop(key, None)
-                else:
-                    self.session.headers[key] = prior_value
+            for key, (prior_key, prior_value) in self._pre_connect_headers.items():
+                self.session.headers.pop(key, None)
+                if prior_value is not None:
+                    self.session.headers[prior_key] = prior_value
             self._pre_connect_headers = None
 
         should_close = self.close_session if self.close_session is not None else self._owns_session

--- a/pyvergeos/connection.py
+++ b/pyvergeos/connection.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import Optional, cast
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -53,6 +53,7 @@ class VergeConnection:
             authentication is stored in session headers while connected.
         close_session: Override for disconnect lifecycle. None closes
             SDK-created sessions and leaves caller-supplied sessions open.
+            close_session=False requires a caller-supplied session.
         connected_at: Timestamp when connection was established.
         vergeos_version: VergeOS version from system endpoint.
         is_connected: Whether connection is active.
@@ -83,6 +84,9 @@ class VergeConnection:
     def __post_init__(self) -> None:
         self.api_base_url = f"https://{self.host}/api/{API_VERSION}"
         self._owns_session = self.session is None
+
+        if self._owns_session and self.close_session is False:
+            raise ValueError("close_session=False requires a caller-supplied session")
 
         # Create session (done here so it can be mocked in tests)
         if self.session is None:
@@ -135,6 +139,27 @@ class VergeConnection:
                 message="Unverified HTTPS request",
                 category=urllib3.exceptions.InsecureRequestWarning,
             )
+
+    def apply_auth_headers(self, headers: dict[str, str]) -> None:
+        """Apply connection auth headers and snapshot caller-owned headers.
+
+        VergeClient mutates session-level headers while connected. Keeping the
+        snapshot and mutation in this class ensures disconnect() owns the full
+        restore lifecycle for caller-supplied sessions.
+        """
+        if self.session is None:
+            raise RuntimeError("Session not initialized")
+
+        if not self._owns_session:
+            if self._pre_connect_headers is None:
+                self._pre_connect_headers = {}
+            for key in headers:
+                if key not in self._pre_connect_headers:
+                    self._pre_connect_headers[key] = cast(
+                        Optional[str], self.session.headers.get(key)
+                    )
+
+        self.session.headers.update(headers)
 
     def is_token_valid(self) -> bool:
         """Check if the current token/credentials are valid.

--- a/pyvergeos/connection.py
+++ b/pyvergeos/connection.py
@@ -1,5 +1,6 @@
 """Connection and session management for VergeOS API."""
 
+import warnings
 from base64 import b64encode
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -44,6 +45,12 @@ class VergeConnection:
         retry_total: Number of retry attempts for transient failures.
         retry_backoff_factor: Backoff factor for retry delay calculation.
         retry_status_codes: HTTP status codes that trigger automatic retry.
+        session: Optional caller-supplied requests session. When supplied, the
+            SDK does not mount adapters, change TLS verification, or close it
+            on disconnect by default. Header snapshots for VergeClient-managed
+            authentication are populated by VergeClient.connect().
+        close_session: Override for disconnect lifecycle. None closes
+            SDK-created sessions and leaves caller-supplied sessions open.
         connected_at: Timestamp when connection was established.
         vergeos_version: VergeOS version from system endpoint.
         is_connected: Whether connection is active.
@@ -63,15 +70,42 @@ class VergeConnection:
     os_version: Optional[str] = None
     cloud_name: Optional[str] = None
     is_connected: bool = False
+    session: Optional[requests.Session] = field(default=None, repr=False)
+    close_session: Optional[bool] = None
 
-    _session: Optional[requests.Session] = field(default=None, repr=False)
+    _owns_session: bool = field(init=False, default=True, repr=False)
+    _pre_connect_headers: Optional[dict[str, Optional[str]]] = field(
+        init=False, default=None, repr=False
+    )
 
     def __post_init__(self) -> None:
         self.api_base_url = f"https://{self.host}/api/{API_VERSION}"
+        self._owns_session = self.session is None
 
         # Create session (done here so it can be mocked in tests)
-        if self._session is None:
-            self._session = requests.Session()
+        if self.session is None:
+            self.session = requests.Session()
+
+        if not self._owns_session:
+            ignored_config = []
+            if self.retry_total != RETRY_TOTAL:
+                ignored_config.append("retry_total")
+            if self.retry_backoff_factor != RETRY_BACKOFF_FACTOR:
+                ignored_config.append("retry_backoff_factor")
+            if set(self.retry_status_codes) != set(RETRY_STATUS_CODES):
+                ignored_config.append("retry_status_codes")
+            if not self.verify_ssl:
+                ignored_config.append("verify_ssl")
+
+            if ignored_config:
+                warnings.warn(
+                    "VergeConnection received a caller-supplied session; "
+                    f"{', '.join(ignored_config)} will be ignored. Configure retry "
+                    "and TLS behavior on the supplied session instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return
 
         # Configure retry strategy with configurable parameters
         retry_strategy = Retry(
@@ -85,15 +119,13 @@ class VergeConnection:
             pool_connections=1,
             pool_maxsize=10,
         )
-        self._session.mount("https://", adapter)
+        self.session.mount("https://", adapter)
 
         if not self.verify_ssl:
-            self._session.verify = False
+            self.session.verify = False
             # Suppress InsecureRequestWarning. Note: this is process-global —
             # setting verify_ssl=False on any client silences warnings for all
             # clients in the same process.
-            import warnings
-
             import urllib3
 
             warnings.filterwarnings(
@@ -116,8 +148,9 @@ class VergeConnection:
         """Clear connection state and close the HTTP session.
 
         Resets all authentication and connection state including token,
-        expiration time, and connection timestamp. The underlying requests
-        session is also closed to release network resources.
+        expiration time, and connection timestamp. SDK-owned requests sessions
+        are closed to release network resources. Caller-supplied session
+        headers are restored and the session is left open by default.
 
         Note:
             After calling disconnect(), the connection object can be reused
@@ -127,8 +160,18 @@ class VergeConnection:
         self.token_expires = None
         self.connected_at = None
         self.is_connected = False
-        if self._session:
-            self._session.close()
+
+        if self.session and not self._owns_session and self._pre_connect_headers is not None:
+            for key, prior_value in self._pre_connect_headers.items():
+                if prior_value is None:
+                    self.session.headers.pop(key, None)
+                else:
+                    self.session.headers[key] = prior_value
+            self._pre_connect_headers = None
+
+        should_close = self.close_session if self.close_session is not None else self._owns_session
+        if self.session and should_close:
+            self.session.close()
 
 
 def build_auth_header(

--- a/pyvergeos/connection.py
+++ b/pyvergeos/connection.py
@@ -48,7 +48,9 @@ class VergeConnection:
         session: Optional caller-supplied requests session. When supplied, the
             SDK does not mount adapters, change TLS verification, or close it
             on disconnect by default. Header snapshots for VergeClient-managed
-            authentication are populated by VergeClient.connect().
+            authentication are populated by VergeClient.connect(). Do not share
+            one supplied session across multiple active VergeClient instances;
+            authentication is stored in session headers while connected.
         close_session: Override for disconnect lifecycle. None closes
             SDK-created sessions and leaves caller-supplied sessions open.
         connected_at: Timestamp when connection was established.

--- a/pyvergeos/resources/cloudinit_files.py
+++ b/pyvergeos/resources/cloudinit_files.py
@@ -517,7 +517,7 @@ class CloudInitFileManager(ResourceManager[CloudInitFile]):
 
             raise NotConnectedError("Not connected to VergeOS")
 
-        session = self._client._connection._session
+        session = self._client._connection.session
         if session is None:
             from pyvergeos.exceptions import NotConnectedError
 

--- a/pyvergeos/resources/files.py
+++ b/pyvergeos/resources/files.py
@@ -283,7 +283,7 @@ class FileManager(ResourceManager[File]):
 
             raise NotConnectedError("Not connected to VergeOS")
 
-        session = connection._session
+        session = connection.session
         if session is None:
             from pyvergeos.exceptions import NotConnectedError
 
@@ -439,7 +439,7 @@ class FileManager(ResourceManager[File]):
 
             raise NotConnectedError("Not connected to VergeOS")
 
-        session = connection._session
+        session = connection.session
         if session is None:
             from pyvergeos.exceptions import NotConnectedError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests.structures import CaseInsensitiveDict
 
 from pyvergeos import VergeClient
 
@@ -25,7 +26,7 @@ def mock_session(mock_response: MagicMock) -> Generator[MagicMock, None, None]:
     """Create a mock requests session."""
     with patch("pyvergeos.connection.requests.Session") as mock:
         session = MagicMock()
-        session.headers = {}
+        session.headers = CaseInsensitiveDict()
         session.request.return_value = mock_response
         mock.return_value = session
         yield session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def mock_session(mock_response: MagicMock) -> Generator[MagicMock, None, None]:
     """Create a mock requests session."""
     with patch("pyvergeos.connection.requests.Session") as mock:
         session = MagicMock()
+        session.headers = {}
         session.request.return_value = mock_response
         mock.return_value = session
         yield session

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,10 +4,11 @@ from http import HTTPStatus
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from pyvergeos import VergeClient
 from pyvergeos.constants import RETRY_BACKOFF_FACTOR, RETRY_STATUS_CODES, RETRY_TOTAL
-from pyvergeos.exceptions import NotConnectedError
+from pyvergeos.exceptions import AuthenticationError, NotConnectedError, VergeConnectionError
 
 
 class TestVergeClient:
@@ -91,6 +92,188 @@ class TestVergeClient:
 
         with pytest.raises(NotConnectedError):
             client._request("GET", "vms")
+
+
+class TestVergeClientByoSession:
+    """Tests for caller-supplied session wiring."""
+
+    def _session(self, status_code: int = 200) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.text = "{}"
+        response.json.return_value = {
+            "$key": 1,
+            "yb_version": "4.12.0",
+            "os_version": "26.0",
+            "cloud_name": "test-cloud",
+        }
+
+        session = MagicMock(spec=requests.Session)
+        session.headers = {}
+        session.request.return_value = response
+        return session
+
+    def test_constructor_stores_session_config(self) -> None:
+        session = self._session()
+
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            close_session=True,
+            auto_connect=False,
+        )
+
+        assert client._session is session
+        assert client._close_session is True
+
+    def test_connect_forwards_session_to_connection(self) -> None:
+        session = self._session()
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            auto_connect=False,
+        )
+
+        client.connect()
+
+        assert client._connection is not None
+        assert client._connection.session is session
+        client.disconnect()
+
+    def test_reconnect_uses_same_byo_session(self) -> None:
+        session = self._session()
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            auto_connect=False,
+        )
+
+        client.connect()
+        client.disconnect()
+        client.connect()
+
+        assert client._connection is not None
+        assert client._connection.session is session
+        client.disconnect()
+
+    def test_byo_disconnect_does_not_close_session(self) -> None:
+        session = self._session()
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+        )
+
+        client.disconnect()
+
+        session.close.assert_not_called()
+
+    def test_byo_disconnect_restores_absent_headers(self) -> None:
+        session = self._session()
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+        )
+
+        assert "Authorization" in session.headers
+        assert "Content-Type" in session.headers
+        assert "Accept" in session.headers
+
+        client.disconnect()
+
+        assert "Authorization" not in session.headers
+        assert "Content-Type" not in session.headers
+        assert "Accept" not in session.headers
+
+    def test_byo_disconnect_restores_present_headers(self) -> None:
+        session = self._session()
+        session.headers = {
+            "Authorization": "Bearer caller-token",
+            "Content-Type": "text/plain",
+            "Accept": "text/plain",
+        }
+        client = VergeClient(
+            host="test.example.com",
+            token="verge-token",
+            session=session,
+        )
+
+        assert session.headers["Authorization"] == "Bearer verge-token"
+        assert session.headers["Content-Type"] == "application/json"
+        assert session.headers["Accept"] == "application/json"
+
+        client.disconnect()
+
+        assert session.headers["Authorization"] == "Bearer caller-token"
+        assert session.headers["Content-Type"] == "text/plain"
+        assert session.headers["Accept"] == "text/plain"
+
+    def test_failed_connect_cleans_up_byo_headers_and_state(self) -> None:
+        session = self._session(status_code=HTTPStatus.UNAUTHORIZED)
+        session.request.return_value.json.return_value = {"err": "invalid credentials"}
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            auto_connect=False,
+        )
+
+        with pytest.raises(AuthenticationError):
+            client.connect()
+
+        assert client._connection is None
+        assert "Authorization" not in session.headers
+        assert "Content-Type" not in session.headers
+        assert "Accept" not in session.headers
+        session.close.assert_not_called()
+
+    def test_failed_connect_closes_owned_session_and_clears_state(
+        self, mock_session: MagicMock
+    ) -> None:
+        mock_session.request.return_value.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+        mock_session.request.return_value.text = "server error"
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            auto_connect=False,
+        )
+
+        with pytest.raises(VergeConnectionError):
+            client.connect()
+
+        assert client._connection is None
+        mock_session.close.assert_called_once_with()
+
+    def test_default_session_config_is_legacy_owned_path(self, mock_session: MagicMock) -> None:
+        mock_session.request.return_value.json.return_value = {
+            "$key": 1,
+            "yb_version": "4.12.0",
+        }
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            auto_connect=False,
+        )
+
+        assert client._session is None
+        client.connect()
+
+        assert client._connection is not None
+        assert client._connection._pre_connect_headers is None
+        client.disconnect()
+        mock_session.close.assert_called_once_with()
 
 
 class TestVergeClientResourceManagers:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from requests.structures import CaseInsensitiveDict
 
 from pyvergeos import VergeClient
 from pyvergeos.connection import VergeConnection
@@ -120,7 +121,7 @@ class TestVergeClientByoSession:
         }
 
         session = MagicMock(spec=requests.Session)
-        session.headers = {}
+        session.headers = CaseInsensitiveDict()
         session.request.return_value = response
         return session
 
@@ -157,29 +158,49 @@ class TestVergeClientByoSession:
 
     def test_reconnect_uses_same_byo_session(self) -> None:
         session = self._session()
+        session.headers = CaseInsensitiveDict(
+            {
+                "aUtHoRiZaTiOn": "Bearer caller-token",
+                "Content-Type": "text/plain",
+                "Accept": "text/plain",
+            }
+        )
         client = VergeClient(
             host="test.example.com",
-            username="admin",
-            password="secret",
+            token="verge-token",
             session=session,
             auto_connect=False,
         )
 
         client.connect()
+        assert session.headers["Authorization"] == "Bearer verge-token"
         client.disconnect()
-        client.connect()
-
-        assert client._connection is not None
-        assert client._connection.session is session
-        client.disconnect()
-
-    def test_connect_twice_restores_byo_headers_before_reconnecting(self) -> None:
-        session = self._session()
-        session.headers = {
-            "Authorization": "Bearer caller-token",
+        assert dict(session.headers.items()) == {
+            "aUtHoRiZaTiOn": "Bearer caller-token",
             "Content-Type": "text/plain",
             "Accept": "text/plain",
         }
+
+        client.connect()
+        assert session.headers["Authorization"] == "Bearer verge-token"
+        client.disconnect()
+
+        assert dict(session.headers.items()) == {
+            "aUtHoRiZaTiOn": "Bearer caller-token",
+            "Content-Type": "text/plain",
+            "Accept": "text/plain",
+        }
+        session.close.assert_not_called()
+
+    def test_connect_twice_restores_byo_headers_before_reconnecting(self) -> None:
+        session = self._session()
+        session.headers = CaseInsensitiveDict(
+            {
+                "Authorization": "Bearer caller-token",
+                "Content-Type": "text/plain",
+                "Accept": "text/plain",
+            }
+        )
         client = VergeClient(
             host="test.example.com",
             token="verge-token",
@@ -250,11 +271,13 @@ class TestVergeClientByoSession:
 
     def test_byo_disconnect_restores_present_headers(self) -> None:
         session = self._session()
-        session.headers = {
-            "Authorization": "Bearer caller-token",
-            "Content-Type": "text/plain",
-            "Accept": "text/plain",
-        }
+        session.headers = CaseInsensitiveDict(
+            {
+                "Authorization": "Bearer caller-token",
+                "Content-Type": "text/plain",
+                "Accept": "text/plain",
+            }
+        )
         client = VergeClient(
             host="test.example.com",
             token="verge-token",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -162,6 +162,33 @@ class TestVergeClientByoSession:
         assert client._connection.session is session
         client.disconnect()
 
+    def test_connect_twice_restores_byo_headers_before_reconnecting(self) -> None:
+        session = self._session()
+        session.headers = {
+            "Authorization": "Bearer caller-token",
+            "Content-Type": "text/plain",
+            "Accept": "text/plain",
+        }
+        client = VergeClient(
+            host="test.example.com",
+            token="verge-token",
+            session=session,
+            auto_connect=False,
+        )
+
+        client.connect()
+        assert session.headers["Authorization"] == "Bearer verge-token"
+
+        client.connect()
+        assert session.headers["Authorization"] == "Bearer verge-token"
+
+        client.disconnect()
+
+        assert session.headers["Authorization"] == "Bearer caller-token"
+        assert session.headers["Content-Type"] == "text/plain"
+        assert session.headers["Accept"] == "text/plain"
+        session.close.assert_not_called()
+
     def test_byo_disconnect_does_not_close_session(self) -> None:
         session = self._session()
         client = VergeClient(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,12 +1,13 @@
 """Tests for VergeClient."""
 
 from http import HTTPStatus
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
 from pyvergeos import VergeClient
+from pyvergeos.connection import VergeConnection
 from pyvergeos.constants import RETRY_BACKOFF_FACTOR, RETRY_STATUS_CODES, RETRY_TOTAL
 from pyvergeos.exceptions import AuthenticationError, NotConnectedError, VergeConnectionError
 
@@ -58,6 +59,16 @@ class TestVergeClient:
 
         assert not client.is_connected
         # No disconnect needed since never connected
+
+    def test_close_session_false_requires_byo_session(self) -> None:
+        with pytest.raises(ValueError, match="close_session=False"):
+            VergeClient(
+                host="test.example.com",
+                username="admin",
+                password="secret",
+                close_session=False,
+                auto_connect=False,
+            )
 
     def test_context_manager(self, mock_session: MagicMock) -> None:
         mock_session.request.return_value.json.return_value = {
@@ -202,6 +213,22 @@ class TestVergeClientByoSession:
 
         session.close.assert_not_called()
 
+    def test_disconnect_clears_connection_when_close_raises(self) -> None:
+        session = self._session()
+        session.close.side_effect = RuntimeError("close failed")
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            close_session=True,
+        )
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            client.disconnect()
+
+        assert client._connection is None
+
     def test_byo_disconnect_restores_absent_headers(self) -> None:
         session = self._session()
         client = VergeClient(
@@ -264,6 +291,25 @@ class TestVergeClientByoSession:
         assert "Accept" not in session.headers
         session.close.assert_not_called()
 
+    def test_failed_connect_preserves_original_error_when_cleanup_fails(self) -> None:
+        session = self._session(status_code=HTTPStatus.UNAUTHORIZED)
+        session.request.return_value.json.return_value = {"err": "invalid credentials"}
+        client = VergeClient(
+            host="test.example.com",
+            username="admin",
+            password="secret",
+            session=session,
+            auto_connect=False,
+        )
+
+        with (
+            patch.object(VergeConnection, "disconnect", side_effect=RuntimeError("cleanup failed")),
+            pytest.raises(AuthenticationError),
+        ):
+            client.connect()
+
+        assert client._connection is None
+
     def test_failed_connect_closes_owned_session_and_clears_state(
         self, mock_session: MagicMock
     ) -> None:
@@ -298,7 +344,6 @@ class TestVergeClientByoSession:
         client.connect()
 
         assert client._connection is not None
-        assert client._connection._pre_connect_headers is None
         client.disconnect()
         mock_session.close.assert_called_once_with()
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from requests.structures import CaseInsensitiveDict
 
 from pyvergeos.connection import AuthMethod, VergeConnection, build_auth_header
 from pyvergeos.constants import RETRY_BACKOFF_FACTOR, RETRY_STATUS_CODES, RETRY_TOTAL
@@ -140,6 +141,17 @@ class TestVergeConnectionRetryConfig:
         conn = VergeConnection(host="test.local", retry_status_codes=custom_codes)
         assert conn.retry_status_codes == custom_codes
 
+    def test_retry_status_codes_generator_is_normalized(self) -> None:
+        retry_status_codes = (
+            status for status in (HTTPStatus.BAD_GATEWAY, HTTPStatus.GATEWAY_TIMEOUT)
+        )
+
+        conn = VergeConnection(host="test.local", retry_status_codes=retry_status_codes)
+
+        assert conn.retry_status_codes == frozenset(
+            {HTTPStatus.BAD_GATEWAY, HTTPStatus.GATEWAY_TIMEOUT}
+        )
+
     def test_retry_disabled_with_zero_total(self) -> None:
         conn = VergeConnection(host="test.local", retry_total=0)
         assert conn.retry_total == 0
@@ -162,7 +174,7 @@ class TestVergeConnectionByoSession:
 
     def _session(self) -> MagicMock:
         session = MagicMock(spec=requests.Session)
-        session.headers = {}
+        session.headers = CaseInsensitiveDict()
         return session
 
     def test_byo_session_is_public_field_and_not_reconfigured(self) -> None:
@@ -200,6 +212,22 @@ class TestVergeConnectionByoSession:
         with pytest.warns(UserWarning, match=expected):
             VergeConnection(host="test.local", session=session, **kwargs)
 
+    def test_byo_ignored_config_warns_with_joined_config_names(self) -> None:
+        session = self._session()
+
+        with pytest.warns(
+            UserWarning,
+            match="retry_total, retry_backoff_factor, retry_status_codes, verify_ssl",
+        ):
+            VergeConnection(
+                host="test.local",
+                session=session,
+                retry_total=RETRY_TOTAL + 1,
+                retry_backoff_factor=RETRY_BACKOFF_FACTOR + 1,
+                retry_status_codes=frozenset({HTTPStatus.BAD_GATEWAY}),
+                verify_ssl=False,
+            )
+
     def test_byo_disconnect_does_not_close_by_default(self) -> None:
         session = self._session()
         conn = VergeConnection(host="test.local", session=session)
@@ -222,10 +250,12 @@ class TestVergeConnectionByoSession:
 
     def test_apply_auth_headers_snapshots_byo_headers(self) -> None:
         session = self._session()
-        session.headers = {
-            "Authorization": "Bearer caller-token",
-            "Accept": "text/plain",
-        }
+        session.headers = CaseInsensitiveDict(
+            {
+                "Authorization": "Bearer caller-token",
+                "Accept": "text/plain",
+            }
+        )
         conn = VergeConnection(host="test.local", session=session)
 
         conn.apply_auth_headers(
@@ -245,10 +275,11 @@ class TestVergeConnectionByoSession:
         assert session.headers["Authorization"] == "Bearer caller-token"
         assert "Content-Type" not in session.headers
         assert session.headers["Accept"] == "text/plain"
+        assert conn._pre_connect_headers is None
 
     def test_apply_auth_headers_preserves_original_snapshot(self) -> None:
         session = self._session()
-        session.headers = {"Authorization": "Bearer caller-token"}
+        session.headers = CaseInsensitiveDict({"Authorization": "Bearer caller-token"})
         conn = VergeConnection(host="test.local", session=session)
 
         conn.apply_auth_headers({"Authorization": "Bearer verge-token-1"})
@@ -259,19 +290,40 @@ class TestVergeConnectionByoSession:
         conn.disconnect()
 
         assert session.headers["Authorization"] == "Bearer caller-token"
+        assert conn._pre_connect_headers is None
+
+    def test_apply_auth_headers_resets_snapshot_between_byo_cycles(self) -> None:
+        session = self._session()
+        session.headers = CaseInsensitiveDict({"aUtHoRiZaTiOn": "Bearer caller-token"})
+        conn = VergeConnection(host="test.local", session=session)
+
+        conn.apply_auth_headers({"Authorization": "Bearer verge-token-1"})
+        conn.disconnect()
+
+        assert conn._pre_connect_headers is None
+        assert dict(session.headers.items()) == {"aUtHoRiZaTiOn": "Bearer caller-token"}
+
+        session.headers["aUtHoRiZaTiOn"] = "Bearer caller-token-2"
+        conn.apply_auth_headers({"Authorization": "Bearer verge-token-2"})
+        conn.disconnect()
+
+        assert conn._pre_connect_headers is None
+        assert dict(session.headers.items()) == {"aUtHoRiZaTiOn": "Bearer caller-token-2"}
 
     def test_disconnect_restores_byo_headers(self) -> None:
         session = self._session()
-        session.headers = {
-            "Authorization": "Bearer caller-token",
-            "Accept": "text/plain",
-            "Content-Type": "text/plain",
-        }
+        session.headers = CaseInsensitiveDict(
+            {
+                "Authorization": "Bearer caller-token",
+                "Accept": "text/plain",
+                "Content-Type": "text/plain",
+            }
+        )
         conn = VergeConnection(host="test.local", session=session)
         conn._pre_connect_headers = {
-            "Authorization": "Bearer caller-token",
-            "Accept": "text/plain",
-            "Content-Type": None,
+            "Authorization": ("Authorization", "Bearer caller-token"),
+            "Accept": ("Accept", "text/plain"),
+            "Content-Type": ("Content-Type", None),
         }
         session.headers.update(
             {
@@ -286,12 +338,14 @@ class TestVergeConnectionByoSession:
         assert session.headers["Authorization"] == "Bearer caller-token"
         assert session.headers["Accept"] == "text/plain"
         assert "Content-Type" not in session.headers
+        assert conn._pre_connect_headers is None
 
     def test_disconnect_header_restore_missing_key_is_idempotent(self) -> None:
         session = self._session()
         conn = VergeConnection(host="test.local", session=session)
-        conn._pre_connect_headers = {"Authorization": None}
+        conn._pre_connect_headers = {"Authorization": ("Authorization", None)}
 
         conn.disconnect()
 
         assert "Authorization" not in session.headers
+        assert conn._pre_connect_headers is None

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -216,13 +216,49 @@ class TestVergeConnectionByoSession:
 
         session.close.assert_called_once_with()
 
-    def test_owned_disconnect_can_skip_close(self, mock_session: MagicMock) -> None:
-        conn = VergeConnection(host="test.local", close_session=False)
+    def test_owned_close_session_false_requires_byo_session(self) -> None:
+        with pytest.raises(ValueError, match="close_session=False"):
+            VergeConnection(host="test.local", close_session=False)
+
+    def test_apply_auth_headers_snapshots_byo_headers(self) -> None:
+        session = self._session()
+        session.headers = {
+            "Authorization": "Bearer caller-token",
+            "Accept": "text/plain",
+        }
+        conn = VergeConnection(host="test.local", session=session)
+
+        conn.apply_auth_headers(
+            {
+                "Authorization": "Bearer verge-token",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+        assert session.headers["Authorization"] == "Bearer verge-token"
+        assert session.headers["Content-Type"] == "application/json"
+        assert session.headers["Accept"] == "application/json"
 
         conn.disconnect()
 
-        assert conn.session is mock_session
-        mock_session.close.assert_not_called()
+        assert session.headers["Authorization"] == "Bearer caller-token"
+        assert "Content-Type" not in session.headers
+        assert session.headers["Accept"] == "text/plain"
+
+    def test_apply_auth_headers_preserves_original_snapshot(self) -> None:
+        session = self._session()
+        session.headers = {"Authorization": "Bearer caller-token"}
+        conn = VergeConnection(host="test.local", session=session)
+
+        conn.apply_auth_headers({"Authorization": "Bearer verge-token-1"})
+        conn.apply_auth_headers({"Authorization": "Bearer verge-token-2"})
+
+        assert session.headers["Authorization"] == "Bearer verge-token-2"
+
+        conn.disconnect()
+
+        assert session.headers["Authorization"] == "Bearer caller-token"
 
     def test_disconnect_restores_byo_headers(self) -> None:
         session = self._session()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -2,8 +2,10 @@
 
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from pyvergeos.connection import AuthMethod, VergeConnection, build_auth_header
 from pyvergeos.constants import RETRY_BACKOFF_FACTOR, RETRY_STATUS_CODES, RETRY_TOTAL
@@ -73,11 +75,12 @@ class TestVergeConnection:
 
     def test_session_created(self) -> None:
         conn = VergeConnection(host="test.local")
-        assert conn._session is not None
+        assert conn.session is not None
 
     def test_ssl_verification_disabled(self) -> None:
         conn = VergeConnection(host="test.local", verify_ssl=False)
-        assert conn._session.verify is False
+        assert conn.session is not None
+        assert conn.session.verify is False
 
     def test_disconnect_clears_state(self) -> None:
         conn = VergeConnection(host="test.local")
@@ -152,3 +155,107 @@ class TestVergeConnectionRetryConfig:
         assert conn.retry_total == 10
         assert conn.retry_backoff_factor == 0.5
         assert conn.retry_status_codes == custom_codes
+
+
+class TestVergeConnectionByoSession:
+    """Tests for caller-supplied session behavior."""
+
+    def _session(self) -> MagicMock:
+        session = MagicMock(spec=requests.Session)
+        session.headers = {}
+        return session
+
+    def test_byo_session_is_public_field_and_not_reconfigured(self) -> None:
+        session = self._session()
+
+        conn = VergeConnection(host="test.local", session=session)
+
+        assert conn.session is session
+        session.mount.assert_not_called()
+        assert "verify" not in session.__dict__
+
+    def test_byo_verify_ssl_false_warns_without_mutating_session(self) -> None:
+        session = self._session()
+
+        with (
+            patch("pyvergeos.connection.warnings.filterwarnings") as filterwarnings,
+            pytest.warns(UserWarning, match="verify_ssl"),
+        ):
+            VergeConnection(host="test.local", session=session, verify_ssl=False)
+
+        filterwarnings.assert_not_called()
+        assert "verify" not in session.__dict__
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"retry_total": RETRY_TOTAL + 1}, "retry_total"),
+            ({"retry_backoff_factor": RETRY_BACKOFF_FACTOR + 1}, "retry_backoff_factor"),
+            ({"retry_status_codes": frozenset({HTTPStatus.BAD_GATEWAY})}, "retry_status_codes"),
+        ],
+    )
+    def test_byo_ignored_config_warns(self, kwargs: dict[str, object], expected: str) -> None:
+        session = self._session()
+
+        with pytest.warns(UserWarning, match=expected):
+            VergeConnection(host="test.local", session=session, **kwargs)
+
+    def test_byo_disconnect_does_not_close_by_default(self) -> None:
+        session = self._session()
+        conn = VergeConnection(host="test.local", session=session)
+
+        conn.disconnect()
+
+        session.close.assert_not_called()
+
+    def test_byo_disconnect_closes_when_requested(self) -> None:
+        session = self._session()
+        conn = VergeConnection(host="test.local", session=session, close_session=True)
+
+        conn.disconnect()
+
+        session.close.assert_called_once_with()
+
+    def test_owned_disconnect_can_skip_close(self, mock_session: MagicMock) -> None:
+        conn = VergeConnection(host="test.local", close_session=False)
+
+        conn.disconnect()
+
+        assert conn.session is mock_session
+        mock_session.close.assert_not_called()
+
+    def test_disconnect_restores_byo_headers(self) -> None:
+        session = self._session()
+        session.headers = {
+            "Authorization": "Bearer caller-token",
+            "Accept": "text/plain",
+            "Content-Type": "text/plain",
+        }
+        conn = VergeConnection(host="test.local", session=session)
+        conn._pre_connect_headers = {
+            "Authorization": "Bearer caller-token",
+            "Accept": "text/plain",
+            "Content-Type": None,
+        }
+        session.headers.update(
+            {
+                "Authorization": "Basic verge-token",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+
+        conn.disconnect()
+
+        assert session.headers["Authorization"] == "Bearer caller-token"
+        assert session.headers["Accept"] == "text/plain"
+        assert "Content-Type" not in session.headers
+
+    def test_disconnect_header_restore_missing_key_is_idempotent(self) -> None:
+        session = self._session()
+        conn = VergeConnection(host="test.local", session=session)
+        conn._pre_connect_headers = {"Authorization": None}
+
+        conn.disconnect()
+
+        assert "Authorization" not in session.headers

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "pyvergeos"
-version = "1.3.0"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "pyvergeos"
-version = "1.2.2"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Closes #65

## Summary

- allow `VergeClient`/`VergeConnection` to use a caller-supplied `requests.Session`
- preserve caller-owned session lifecycle by leaving supplied sessions open by default
- snapshot and restore SDK-managed auth/JSON headers across connect, reconnect, disconnect, and failed auth paths
- document BYO session behavior and constraints

## Verification

- `uv run pytest tests/unit/test_connection.py tests/unit/test_client.py -v`
- `uv run pytest tests/unit -v`
- `uv run ruff check .`
- `uv run ruff format --check pyvergeos/connection.py tests/unit/test_connection.py`
- `uv run mypy pyvergeos`
- live smoke against `tr1v4.yottabyte.com`: `uv run pytest tests/integration/test_connection.py -v` (`3 passed`)
- targeted live BYO `requests.Session` smoke against `tr1v4.yottabyte.com` covering connect, VM/network list calls, header restore, and caller session left open

Note: I did not run the full live integration suite because many tests create or mutate VergeOS resources.